### PR TITLE
Fixed case issues on $tempTime

### DIFF
--- a/src/layer1.twee
+++ b/src/layer1.twee
@@ -997,7 +997,7 @@ You have successfully taken on the $curse12.name curse. Hopefully you are ok wit
 <<nobr>>
 <<set $corruption -= $playerCurses[$temp].corr>>
 <<set $iconUsed = 1>>
-<<set $temptime=3>>
+<<set $tempTime=3>>
 <<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
 /* 
 <<if $status.duration > 0>>

--- a/src/layer2.twee
+++ b/src/layer2.twee
@@ -1504,7 +1504,7 @@ Use the following option only if you have specifically considered your inventory
 :: Layer2 Ascend2 [layer2]
 <<nobr>><<if $layerExit == 0>>
 	<<set $layerExit = 1>>
-	<<set $temptime=5>>
+	<<set $tempTime=5>>
 	<<include "GeneralTimeSetup">>
 <<endif>>
 
@@ -1518,7 +1518,7 @@ Use the following option only if you have specifically considered your inventory
 		<<if $items[1].count > 9>>
 			<<set $timeL2T1 += 1>>
 		<<endif>>
-		<<set $temptime=1>>
+		<<set $tempTime=1>>
 		<<include "GeneralTimeStats">>
 /*	<<if $forageWater == 0>>
 		<<if $items[3].count > 0>>

--- a/src/layer3.twee
+++ b/src/layer3.twee
@@ -496,7 +496,7 @@ In the deeper parts of the layer, a cold breeze occasionally blows through the c
 
 	<<set $tempTime=6>>
 	<<include "GeneralTimeSetup">>
-	<<set $layerExitTime = $temptime>>
+	<<set $layerExitTime = $tempTime>>
 <<endif>>
 
 <<include "GeneralTimeStats">>


### PR DESCRIPTION
Fixed the layer 1 shrine and layer 2 ascend using lowercase $tempTime, which would cause their travel times to instead be the last action taken.