### PR TITLE
Fixes to GeneralTimeStats - Layer 2 hunting

### DIFF
--- a/src/global.twee
+++ b/src/global.twee
@@ -1497,9 +1497,14 @@ How many dubloons would you like to pay back?
 			<<if $currentLayer==1>>
 				<<set $GenderLog.push($ForageFoodMajor)>>/* layer specific */
 			<<elseif $currentLayer==2>>
-				<<if $mudHunt == 1 && $items[20].count > 0>>
-					<<set $items[20].count -= $tempTime>>
-				<<elseif $mudHunt == 0>>
+				<<if $mudHunt == 1>>
+					<<if $slingshot == 1>>
+					<<elseif ($items[13].count > 0 && $items[20].count > 0>>
+						<<set $items[20].count -= 1>>
+					<<else>>
+						<<set $LibidoLog.push($ForageFoodMajor)>>
+					<<endif>>
+				<<else>>
 					<<set $LibidoLog.push($ForageFoodMajor)>>
 				<<endif>>
 			<<elseif $currentLayer==3>>
@@ -1521,9 +1526,14 @@ How many dubloons would you like to pay back?
 	<<else>>
 		<<for $i = 0; $i < $tempTime; $i++>>
 			<<if $currentLayer==2>>
-				<<if $mudHunt == 1 && $items[20].count > 0>>
-					<<set $items[20].count -= $tempTime>>
-				<<elseif $mudHunt == 0>>
+				<<if $mudHunt == 1>>
+					<<if $slingshot == 1>>
+					<<elseif ($items[13].count > 0 && $items[20].count > 0>>
+						<<set $items[20].count -= 1>>
+					<<else>>
+						<<set $lastFlan=$time+1>>
+					<<endif>>
+				<<else>>
 					<<set $lastFlan=$time+1>>
 				<<endif>>
 			<<elseif $currentLayer==3>>


### PR DESCRIPTION
- Fixes being able to hunt in layer 2 with bullets but no gun
- Fixes not being able to use modified Brave Vector (or player's imagination) to hunt in layer 2
- Fixes exploit if you choose to hunt animals with no ammo, now forced to take the forage penalty
- Fixed more bullets than expected being used if the current action takes longer than 1 day (2 days would use 4 bullets, 3 days would use 9 bullets)