### PR TITLE
Removed redundant for loop in GeneralTimeStats water foraging

### DIFF
--- a/src/global.twee
+++ b/src/global.twee
@@ -1555,45 +1555,41 @@ How many dubloons would you like to pay back?
 	<<else>>
 		<<set $waterL1 += 1>>
 		<<if $abyssKnow == 0>>
-			<<for $i = 0; $i < $tempTime; $i++>>
-				<<if $currentLayer==1>>
-					<<set $GenderLog.push($ForageWaterMajor)>>/* layer specific */
-				<<elseif $currentLayer==2>>
-					<<set $bewitchBabies += 1>>
-				<<elseif $currentLayer==3>>
-					<<set $waterL2 += 1>>
-				<<elseif $currentLayer==4>>
-					<<set $waterL4 += 1>>
-					<<if $abyssKnow == 0>>
-						<<set $algalSize += 1>>
-					<<endif>>
-				<<elseif $currentLayer==5>>	
-					<<set $waterL5 += 1>>
-				<<elseif $currentLayer==6>>
-					<<set $waterL6 += 1>>
-					<<if !($hiredCompanions.some(e => e.name === "Saeko") && $items[17].count > 0)>>
-						<<set $hexflame += 1>>
-					<<endif>>
-				<<endif>>			
-			<</for>>
+			<<if $currentLayer==1>>
+				<<set $GenderLog.push($ForageWaterMajor)>>/* layer specific */
+			<<elseif $currentLayer==2>>
+				<<set $bewitchBabies += 1>>
+			<<elseif $currentLayer==3>>
+				<<set $waterL2 += 1>>
+			<<elseif $currentLayer==4>>
+				<<set $waterL4 += 1>>
+				<<if $abyssKnow == 0>>
+					<<set $algalSize += 1>>
+				<<endif>>
+			<<elseif $currentLayer==5>>	
+				<<set $waterL5 += 1>>
+			<<elseif $currentLayer==6>>
+				<<set $waterL6 += 1>>
+				<<if !($hiredCompanions.some(e => e.name === "Saeko") && $items[17].count > 0)>>
+					<<set $hexflame += 1>>
+				<<endif>>
+			<<endif>>
 		<<else>>
-			<<for $i = 0; $i < $tempTime; $i++>>
-				<<if $layer==3>>
-					<<set $waterL2 += 1>>
-				<<elseif $layer==4>>
-					<<set $waterL4 += 1>>
-					<<if $abyssKnow == 0>>
-						<<set $algalSize += 1>>
-					<<endif>>
-				<<elseif $layer==5>>
-					<<set $waterL5 += 1>>
-				<<elseif $layer==6>>
-					<<set $waterL6 += 1>>
-					<<if !($hiredCompanions.some(e => e.name === "Saeko") && $items[17].count > 0)>>
-						<<set $hexflame += 1>>
-					<<endif>>
-				<<endif>>			
-			<</for>>		
+			<<if $layer==3>>
+				<<set $waterL2 += 1>>
+			<<elseif $layer==4>>
+				<<set $waterL4 += 1>>
+				<<if $abyssKnow == 0>>
+					<<set $algalSize += 1>>
+				<<endif>>
+			<<elseif $layer==5>>
+				<<set $waterL5 += 1>>
+			<<elseif $layer==6>>
+				<<set $waterL6 += 1>>
+				<<if !($hiredCompanions.some(e => e.name === "Saeko") && $items[17].count > 0)>>
+					<<set $hexflame += 1>>
+				<<endif>>
+			<<endif>>
 		<<endif>>
 	<<endif>>
 	<<if $hexflame > 9>>


### PR DESCRIPTION
At the moment, this fixes and single bug with $hexflame only decrementing by 1 each travel instead of decrementing by 1 each day. Removing the redundant loop also fixes future bugs that might arise if someone were to "fix" the inner loop by assigning its own variable to keep track of iterations (currently both used $i, which meant when the inner loop finished it broke the outer loop).

Since I removed the for loop, I also changed the indent on those sections which makes it look like I changed a ton of code. I can assure the only thing important that changed was the removal of the for loop.