### PR TITLE
Fixed Icon of Mercy reporting the wrong curse being removed

### DIFF
--- a/src/layer1.twee
+++ b/src/layer1.twee
@@ -1038,8 +1038,8 @@ You have successfully taken on the $curse12.name curse. Hopefully you are ok wit
 */
 <<set $targetCurse=$playerCurses[$temp]>>
 <</nobr>>
-<<include "CurseRemoval">>
 The curse of $playerCurses[$temp].name has been successfully removed and your corruption has been refunded.
+<<include "CurseRemoval">>
 
 [[Continue exploring the layer|Layer1 Hub]]
 


### PR DESCRIPTION
Swapped two lines so the proper name is read from the array of curses.