### PR TITLE
Fix dizzying heights disappearing after one pick

### DIFF
--- a/src/layer1.twee
+++ b/src/layer1.twee
@@ -259,7 +259,7 @@ You find yourself amidst the slightly-off natural splendor of the first layer. W
 	<<endif>>
 <<endif>>
 
-<<set _temp1 =$HeightLog.filter(e => e.name === "Dizzying Heights")>>
+<<set _temp1 =$HeightLog.filter(e => e.name === "Dizzying Heights").length>>
 <<if _temp1 < 5 || ($StoredCurse.name == "Dizzying Heights" && _temp1 < 4 && $ManagedMisfortuneActive==false)>>
 	<<set _table += "<tr><td>[[Take on Dizzying Heights]]</td>">>
 	<<if $ownedRelics.some(e => e.name === "Managed Misfortune") && $StoredCurse.name != "Dizzying Heights">>


### PR DESCRIPTION
Previously _temp1 was being set to an array object that contains only Dizzying Heights curses, this change gets the length of that new temporary array so it can do (array.length < 5) without always throwing up false from trying to compare an array to a number.