### PR TITLE
Fixes for size related curses

### DIFF
--- a/src/global.twee
+++ b/src/global.twee
@@ -407,27 +407,27 @@ You need sex constantly - having sex will only sate your hunger for a matter of 
 <br>
 <<if $app.penisCor>=1>>
 	<<if $app.penisCor == 1>>
-	You have a tiny penis of <<print Math.round($app.penisCor)*2.5>> cm, which is honestly barely larger than a clitoris.
+	You have a tiny penis of <<PenisLengthText>>, which is honestly barely larger than a clitoris.
 	<<elseif $app.penisCor <= 2.5>>
-	You have a very small penis of <<print Math.round($app.penisCor)*2.5>> cm. You need some very tight pants to show something that even remotely resembles a bulge in your crotch.
+	You have a very small penis of <<PenisLengthText>>. You need some very tight pants to show something that even remotely resembles a bulge in your crotch.
 	<<elseif $app.penisCor <= 3.5>>
-	You have a small penis of <<print Math.round($app.penisCor)*2.5>> cm. You are a bit self conscious about it, but it works perfectly well.
+	You have a small penis of <<PenisLengthText>>. You are a bit self conscious about it, but it works perfectly well.
 	<<elseif $app.penisCor <= 4.5>>
-	You have a below average penis of <<print Math.round($app.penisCor)*2.5>> cm. Yeah, you know it's not that big, but you try not to get too hung up on it.
+	You have a below average penis of <<PenisLengthText>>. Yeah, you know it's not that big, but you try not to get too hung up on it.
 	<<elseif $app.penisCor <= 5.5>>
-	You have a pretty average penis of <<print Math.round($app.penisCor)*2.5>> cm. Nothing to be ashamed of, but nothing to write home about either.
+	You have a pretty average penis of <<PenisLengthText>>. Nothing to be ashamed of, but nothing to write home about either.
 	<<elseif $app.penisCor <= 6.5>>
-	You have a totally average penis of <<print Math.round($app.penisCor)*2.5>> cm, very typical for a man in your demographics.
+	You have a totally average penis of <<PenisLengthText>>, very typical for a man in your demographics.
 	<<elseif $app.penisCor <= 7.5>>
-	You have a slightly above average penis of <<print Math.round($app.penisCor)*2.5>> cm, not anything out of the ordinary, but some people may particularly enjoy it.
+	You have a slightly above average penis of <<PenisLengthText>>, not anything out of the ordinary, but some people may particularly enjoy it.
 	<<elseif $app.penisCor <= 8.5>>
-	You have a large penis of <<print Math.round($app.penisCor)*2.5>> cm, people who like larger sizes are likely to be impressed.
+	You have a large penis of <<PenisLengthText>>, people who like larger sizes are likely to be impressed.
 	<<elseif $app.penisCor <= 9.5>>
-	You have a very large penis of <<print Math.round($app.penisCor)*2.5>> cm, size queens dream of meeting someone like you, but tighter orifices can be a bit of an issue occasionally.
+	You have a very large penis of <<PenisLengthText>>, size queens dream of meeting someone like you, but tighter orifices can be a bit of an issue occasionally.
 	<<elseif $app.penisCor > 9.5 && $app.penisCor < 100>>
-	You have an enormous penis of <<print Math.round($app.penisCor)*2.5>> cm. Are you even going to able to have sex with this monster schlong?
+	You have an enormous penis of <<PenisLengthText>>. Are you even going to able to have sex with this monster schlong?
 	<<elseif $app.penisCor >= 100>>
-	You have a truly gargantuan penis that hangs at a size of <<print (Math.round($app.penisCor)*0.025).toFixed(1)>> meters long. Sex with normal sized people would need to be very different than it used to be.
+	You have a truly gargantuan penis that hangs at a size of <<PenisLengthText true>> long. Sex with normal sized people would need to be very different than it used to be.
 	<</if>>
 <</if>>
 <br><br>

--- a/src/widgets.twee
+++ b/src/widgets.twee
@@ -33,7 +33,7 @@
 	<</if>>
 
 	<<if $HeightLog.some(e=> e.name === "Minish-ish")>>
-		<<set $height_change=$app.modheight/10-$app.height>>
+		<<set $height_change=$app.height/10-$app.height>>
 		<<if $hiredCompanions.length < 1>>
 			<<set $SizeHandicap=1>>
 		<</if>>
@@ -311,6 +311,11 @@
 <<Update_MC_Speech>>
 <</widget>>
 
+:: Appearance widgets [widget nobr]
+<<widget "PenisLengthText">>
+	<<print (Math.round($app.penisCor)*(!!_args[0] ? 0.0254 : 2.54)).toFixed(1) + (!!_args[0] ? " meters" : " cm")>>\
+<</widget>>
+
 :: Age widget [widget nobr]
 <<widget "AgeCorrected">>
 <<set $app.appAge = $app.age>>
@@ -435,10 +440,18 @@
 
 :: Perceived widgets [widget nobr]
 <<widget "appGender">>
+	<<set _penisCorTemp = $app.penisCor>>
+	<<if $playerCurses.some(e => e.name === "Colossal-able")>>
+		<<set _penisCorTemp /= 70>>
+	<</if>>
+
+	<<if $playerCurses.some(e => e.name === "Minish-ish")>>
+		<<set _penisCorTemp *= 10>>
+	<</if>>
 	<<if $app.fit>7>>
-		<<set $app.appGender = 2*($app.gender-1) -0.25*($app.penisCor-4) +($app.breastsCor-3)+0.5*$colwear+0.25*$scent-1>>
+		<<set $app.appGender = 2*($app.gender-1) -0.25*(_penisCorTemp-4) +($app.breastsCor-3)+0.5*$colwear+0.25*$scent-1>>
 	<<else>>
-		<<set $app.appGender = 2*($app.gender-1) -0.25*($app.penisCor-4) +($app.breastsCor-3)+0.5*$colwear+0.25*$scent>>
+		<<set $app.appGender = 2*($app.gender-1) -0.25*(_penisCorTemp-4) +($app.breastsCor-3)+0.5*$colwear+0.25*$scent>>
 	<</if>>
 <</widget>>
 


### PR DESCRIPTION
- Fixed gender calculation not taking Minish-ish and Colossal-able into account, causing futas to turn male or female depending on the actual cock size.
- Corrected inch to cm math from 2.5cm to 2.54cm and moved the code to display it into a reusable widget.
- Fixed Minish-ish calculation changing the height to a negative value.