### PR TITLE
Appearance tweaks

### DIFF
--- a/src/global.twee
+++ b/src/global.twee
@@ -319,9 +319,9 @@ Thanks again for playing!
 
 Your hair color is $app.hair, while your eyes are colored $app.eyeColor.
 You have $app.skinColor colored $app.skinType skin.
-You are <<print Math.round($app.heightCor)>> cm tall.
+You are <<BodyHeightText>> tall.
 You have $app.ears ears.
-You are $app.age years old<<if $app.age != $app.appAge>>, but you appear to be <<print Math.round($app.appAge)>> years old<</if>>.
+You are $app.age years old<<if $app.age != Math.round($app.appAge)>>, but you appear to be <<print Math.round($app.appAge)>> years old<</if>>.
 
 <<nobr>>
 <<if $dollevent2== true>>
@@ -1454,7 +1454,7 @@ How many dubloons would you like to pay back?
 		When you were cursed with knife-ears, you knew it would alter your appearance and the way other perceived you. But what you hadn't realized is just how sensitive the tips of your ears would become! Sometimes when you lay down your head on your pillow at night, if the angle is right, it feels almost sensual and you feel an urge to rub up against the pillow more. While it isn't too hard to control yourself, these new, pleasurable sensations are strange to deal with.
 	<</if>>
 	<<if $tempCurse.name == "Dizzying Heights">>
-		You wince as you stub your toe, yet again. You're not quite used to your legs being this length, or really the new size of your whole body. With the Dizzying Heights curse and what scavenging you've done, you're now <<print Math.round($app.heightCor)>> cm tall. You didn't think that would be such a big deal, but you'd gotten used to your body being a certain size, and a lot of the motions that you practiced many times before are just producing awkward results now! The whole world feels like it has changed in size, even though you know it's the same, it's only you that's changed.
+		You wince as you stub your toe, yet again. You're not quite used to your legs being this length, or really the new size of your whole body. With the Dizzying Heights curse and what scavenging you've done, you're now <<BodyHeightText>> tall. You didn't think that would be such a big deal, but you'd gotten used to your body being a certain size, and a lot of the motions that you practiced many times before are just producing awkward results now! The whole world feels like it has changed in size, even though you know it's the same, it's only you that's changed.
 	<</if>>
 	<<if $tempCurse.name == "Increased Sensitivity">>
 		A part of you knew that being cursed with Increased Sensitivity would be a major change in erotic situations and it might not be the most convenient thing in everyday life. However, the tantalizing excitement drew you in, and now you're living with the consequences. You hadn't fully understood how the brush of cloth against your nipples and between your legs would draw shivers of desire out of you. You hadn't expected that you'd be splattering your juices simply by brushing against something at the right angle and position, but here you are, hot and panting simply because you brushed against a boulder the wrong way as you were moving past it.

--- a/src/widgets.twee
+++ b/src/widgets.twee
@@ -316,6 +316,11 @@
 	<<print (Math.round($app.penisCor)*(!!_args[0] ? 0.0254 : 2.54)).toFixed(1) + (!!_args[0] ? " meters" : " cm")>>\
 <</widget>>
 
+<<widget "BodyHeightText">>
+	<<set _meters = ($app.heightCor > 100)>>
+	<<print (Math.round($app.heightCor)*(_meters ? 0.01 : 1)).toFixed(_meters ? 2 : 1) + (_meters ? " meters" : " cm")>>\
+<</widget>>
+
 :: Age widget [widget nobr]
 <<widget "AgeCorrected">>
 <<set $app.appAge = $app.age>>


### PR DESCRIPTION
- Fix for "You are 25 years old, but you appear to be 25 years old.".
- If you're above 100 cm height, your body height now displays as 123.45 meters instead of 12345 cm. Added the widget `<<BodyHeightText>>` for that.