### PR TITLE
Configure twee-config for macro parameter validation

### DIFF
--- a/src/companionConversations.twee
+++ b/src/companionConversations.twee
@@ -2732,7 +2732,7 @@ You blush, embarrassed.
 Saeko shoots you a withering glare before storming off, her footsteps echoing with frustration.
 
 <<if $hiredCompanions.some(e => e.name === "Lily")>>\
-	<<say companionLily>>What just happened? I saw Saeko stomping away in a huff.<</say>>
+	<<say $companionLily>>What just happened? I saw Saeko stomping away in a huff.<</say>>
 	<<say $mc>> Saeko created a schedule to help me with my, uh, nighttime accidents. But she wanted to monitor it constantly, and I didn't want to burden her with that. She got upset because she put a lot of effort into it, and I didn't want to use it.<</say>>
 	Lily furrows her brow, deep in thought.
 

--- a/t3lt.twee-config.yml
+++ b/t3lt.twee-config.yml
@@ -79,7 +79,7 @@ sugarcube-2:
     HornGrowthDesc:
       name: HornGrowthDesc
       parameters:
-        - "var &+ number"
+        - "var|string &+ number"
     Inhuman:
       name: Inhuman
       parameters:
@@ -103,7 +103,7 @@ sugarcube-2:
     Numerical:
       name: Numerical
       parameters:
-        - "var &+ (string |+ string)"
+        - "var|number &+ (string |+ string)"
     ObjectivePronoun:
       name: ObjectivePronoun
       parameters:
@@ -131,7 +131,7 @@ sugarcube-2:
     PluralS:
       name: PluralS
       parameters:
-        - "number"
+        - "var|number"
     PossesivePronoun:
       name: PossesivePronoun
       parameters:

--- a/t3lt.twee-config.yml
+++ b/t3lt.twee-config.yml
@@ -1,7 +1,183 @@
 sugarcube-2:
   macros:
+    AffectionChange:
+      name: AffectionChange
+      parameters:
+        - "string &+ number"
+    AgeCorrected:
+      name: AgeCorrected
+      parameters:
+        - ""
+    AppearanceCorrect:
+      name: AppearanceCorrect
+      parameters:
+        - ""
+    appGender:
+      name: appGender
+      parameters:
+        - ""
+    BodyHeightText:
+      name: BodyHeightText
+      parameters:
+        - ""
+    CarryAdjust:
+      name: CarryAdjust
+      parameters:
+        - ""
+    CheckParty:
+      name: CheckParty
+      parameters:
+        - ""
+    checkTime:
+      name: checkTime
+      parameters:
+        - ""
+    CloneSelf:
+      name: CloneSelf
+      parameters:
+        - ""
+    ConversationChoices:
+      name: ConversationChoices
+      parameters:
+        - "link |+ ...link"
+    createGolem:
+      name: createGolem
+      parameters:
+        - ""
+    CurseGrid:
+      name: CurseGrid
+      parameters:
+        - "string"
+    dollTF:
+      name: dollTF
+      parameters:
+        - ""
+    Equipment:
+      name: Equipment
+      parameters:
+        - ""
+    FlaskFirst:
+      name: FlaskFirst
+      parameters:
+        - ""
+    GenderCorrected:
+      name: GenderCorrected
+      parameters:
+        - ""
+    GenderPronoun:
+      name: GenderPronoun
+      parameters:
+        - ""
+    Handicap:
+      name: Handicap
+      parameters:
+        - ""
+    HeightCorrected:
+      name: HeightCorrected
+      parameters:
+        - ""
+    HornGrowthDesc:
+      name: HornGrowthDesc
+      parameters:
+        - "var &+ number"
+    Inhuman:
+      name: Inhuman
+      parameters:
+        - ""
+    Lewdness:
+      name: Lewdness
+      parameters:
+        - ""
+    LibidoCorrected:
+      name: LibidoCorrected
+      parameters:
+        - ""
+    MonsterPregCheckParty:
+      name: MonsterPregCheckParty
+      parameters:
+        - ""
+    mrms:
+      name: mrms
+      parameters:
+        - ""
+    Numerical:
+      name: Numerical
+      parameters:
+        - "var &+ (string |+ string)"
+    ObjectivePronoun:
+      name: ObjectivePronoun
+      parameters:
+        - ""
+    PenisLengthText:
+      name: PenisLengthText
+      parameters:
+        - "|+ bool"
+    PerceivedGender:
+      name: PerceivedGender
+      parameters:
+        - ""
+    PerceivedGender2:
+      name: PerceivedGender2
+      parameters:
+        - ""
+    PerceivedRace:
+      name: PerceivedRace
+      parameters:
+        - ""
+    PerceivedStature:
+      name: PerceivedStature
+      parameters:
+        - ""
+    PluralS:
+      name: PluralS
+      parameters:
+        - "number"
+    PossesivePronoun:
+      name: PossesivePronoun
+      parameters:
+        - ""
+    PregCheck:
+      name: PregCheck
+      parameters:
+        - ""
+    Pronoun:
+      name: Pronoun
+      parameters:
+        - ""
+    randomSexSelect:
+      name: randomSexSelect
+      parameters:
+        - ""
+    RelicGrid:
+      name: RelicGrid
+      parameters:
+        - "string"
     say:
       name: say
       container: true
-    ConversationChoices:
-      name: ConversationChoices
+      parameters:
+        - "var"
+    SemenDemonCalc:
+      name: SemenDemonCalc
+      parameters:
+        - "var|number"
+    statUpdateCompanions:
+      name: statUpdateCompanions
+      parameters:
+        - ""
+    Threat1Criterion:
+      name: Threat1Criterion
+      parameters:
+        - ""
+    Update_MC_Speech:
+      name: Update_MC_Speech
+      parameters:
+        - ""
+    Update_Misc_Stat:
+      name: Update_Misc_Stat
+      parameters:
+        - ""
+    volume:
+      name: volume
+      parameters:
+        - ""


### PR DESCRIPTION
Hi, I was checking out the code in VSCode with the [Twee 3 Language Tools](https://marketplace.visualstudio.com/items?itemName=cyrusfirheir.twee3-language-tools) extension and found that it was complaining about missing widget/macro definitions.

After looking into it, I thought it might be helpful to make use of the extension's [parameter validation](https://github.com/cyrusfirheir/twee3-language-tools/blob/HEAD/docs/parameters.md) functionality. Most macros don't use `_args` (none use `_contents`), but I did find a few cases where I think the parameters are worth documenting if nothing else.

I did stumble across one mistake: In one instance, the `<<say>>` was used with the text `companionLily` instead of variable `$companionLily`. As far as I can tell this macro must always take a variable.