### PR TITLE
Refactor and tweak Skewed & Steady Shrine logic

### DIFF
--- a/src/layer3.twee
+++ b/src/layer3.twee
@@ -195,21 +195,21 @@ Would you like to use the Gossamery Scales to gain corruption based on your dubl
 <<else>>
 You have already used the scales on your journey. You may not use them again.
 <</if>>
-<<if ($hiredCompanions.length > 0) && ($skewedForced < 4)>>
-	Would you like to use the Skewed Shrine to give a Curse to one of your willing companions at the cost of <<print ($skewedUsed * 5)>> dubloons?<br>
-	<<link "Yes, travel to the Skewed Shrine to transfer a Curse" "Layer3 Skewed1a">>
-		<<set $tempTime = 3>>
-		<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-	<</link>><br><br>
-	Would you like to use the Skewed Shrine to force a Curse on one of your unwilling companions at the cost of <<print ($skewedUsed * 5)>> dubloons?<br>
-	<<link "Yes, travel to the Skewed Shrine to force a Curse" "Layer3 Skewed 2a">>
-		<<set $tempTime = 3>>
-		<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-	<</link>><br><br>
-	<<elseif $skewedForced > 4>>
-	None of your companions trust you at this shrine. None will get close enough for you to use the shrine with them. They watch you with eyes full of fear and anger, as if they could bolt at any moment and leave you alone in the Abyss.<br><br>
-	<<else>>
+<<if !$hiredCompanions.length>>
 	You must have companions if you would like to use the Skewed Shrine.<br><br>
+<<elseif $skewedForced < 4>>
+	Would you like to use the Skewed Shrine to give a Curse to one of your willing companions at the cost of <<print ($skewedUsed * 5)>> dubloons?<br>
+	<<link "Yes, use the Skewed Shrine to transfer a Curse" "Layer3 Skewed1a">>
+		<<set $tempTime = 3>>
+		<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
+	<</link>><br><br>
+	Would you like to use the Skewed Shrine to force a Curse upon one of your unwilling companions at the cost of <<print ($skewedUsed * 5)>> dubloons?<br>
+	<<link "Yes, use the Skewed Shrine to force a Curse" "Layer3 Skewed 2a">>
+		<<set $tempTime = 3>>
+		<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
+	<</link>><br><br>
+<<else>>
+	None of your companions trust you at this shrine anymore. None will get close enough for you to use the shrine with them. They watch you with eyes full of fear and anger, as if they could bolt at any moment and leave you alone in the Abyss.<br><br>
 <</if>>
 <</nobr>>
 [[Continue exploring the third layer|Layer3 Hub]]
@@ -392,61 +392,43 @@ Which Curse would you like to transfer to your willing companion? It can't be to
 	You do not have enough dubloons for an offering.
 <<else>>
 	<<for _companion range $hiredCompanions>>
-		<<capture _companion>>
-			<<for _j = 0; _j < $playerCurses.length; _j++>>
-				<<if _j==0>>
-					<<print "_companion.name doesn't mind taking:">><br>
-				<</if>>
-				<<set _curse = $playerCurses[_j]>>
-				<<if _companion.name == $companionTwin.name>>
-					<<set _tempname = "Twin">>
-					<<set _flag =  false>>
-				<<elseif _companion.name == "Golem">>
-					<<set _tempname = _companion.name >>
-					<<set _flag =  false>>
-					You can't transfer a Curse to your Golem.<br>
-				<<else>>
-					<<set _tempname = _companion.name >>
-					<<set _flag =  setup.willingCurses[_tempname ].includes(_curse.name)>>
-				<</if>>
+		<<for _index, _curse range $playerCurses>>
+			<<set _flag = false>>
+			<<set _tempName = _companion.name>>
 
-				<<if _flag>>
-					<<capture _j>>
-						<<print "$playerCurses[_j].name">>
-						<<link "Choose" "Layer3 Skewed1a">>
-							<<set _companion.curses.push($playerCurses[_j])>>
-							
-							<<if _companion == $companionTwin >>
-								<<set _tempName = "Twin">>
-							<<else>>
-								<<set _tempName = _companion.name>>
-							<</if>>
+			<<switch _tempName>>
+				<<case $companionTwin.name>>
+					<<if _index < 1>>Your twin already shares all of your Curses.<br><</if>>
+				<<case "Golem">>
+					<<if _index < 1>>You can't transfer Curses to your Golem.<br><</if>>
+				<<default>>
+					<<if _index < 1>>_companion.name doesn't mind taking:<br><</if>>
+					<<set _flag = setup.willingCurses[_tempName].includes(_curse.name)>>
+					<<if _flag>>
+						/* Check whether companion already has this curse (e.g. from the layer 4 shrine). */
+						<<set _flag = !_companion.curses.some(companionCurse => companionCurse.name == _curse.name)>>
+					<</if>>
+			<</switch>>
 
-							<<if $playerCurses[_j].type == "Age">>
-								<<set _string = "$AgeLog" + _tempName>>
-							<<elseif $playerCurses[_j].type == "Gender">>
-								<<set _string = "$GenderLog" + _tempName>>
-							<<elseif $playerCurses[_j].type == "Height">>
-								<<set _string = "$HeightLog" + _tempName>>
-							<<elseif $playerCurses[_j].type == "Handicap">>
-								<<set _string = "$HandicapLog" + _tempName>>
-							<<elseif $playerCurses[_j].type == "Libido">>
-								<<set _string = "$LibidoLog" + _tempName>>
-							<</if>>
-							<<if $playerCurses[_j].type != "">>
-								<<print "<<set " + _string + ".push($playerCurses[_j])>>">>
-							<</if>>
+			<<if _flag>>
+				<<capture _companion, _curse, _tempName>>
+					&nbsp; _curse.name
+					<<link "Choose" "Layer3 Skewed1a">>
+						<<set _companion.curses.push(_curse)>>
 
-							<<set $targetCurse = $playerCurses[_j]>>
-							<<include "CurseRemoval">>
-							<<set $dubloons -= ($skewedUsed * 5)>>
-							<<set $skewedUsed += 1>>
-							<<statUpdateCompanions>>
-						<</link>><br>
-					<</capture>>
-				<</if>>
-			<</for>>
-		<</capture>>
+						<<set _logName = _curse.type + "Log" + _tempName>>
+						<<set _log = State.variables[_logName]>>
+						<<if _log>><<set _log.push(_curse)>><</if>>
+
+						<<set $targetCurse = _curse>>
+						<<include "CurseRemoval">>
+						<<set $dubloons -= ($skewedUsed * 5)>>
+						<<set $skewedUsed += 1>>
+						<<statUpdateCompanions>>
+					<</link>><br>
+				<</capture>>
+			<</if>>
+		<</for>>
 	<</for>>
 <</if>>
 <</nobr>>
@@ -464,15 +446,15 @@ The knot of doubt that forms in the pit of your stomach is easily ignored as you
 
 With the Skewed Shrine's power at your fingertips, you must now decide: do you impose your Curse upon your unwilling companion, prioritizing your own well-being at their expense, or do you release them and face the Abyss on your own terms? The decision seems straightforward to you, a necessary evil to achieve success.
 
-Which Curse would you like to force on your unwilling companion?
+Which Curse would you like to force upon your unwilling companion?
 
 <<nobr>>
 <<if $dubloons < ($skewedUsed * 5)>>
 	You do not have enough dubloons for an offering.
 <<else>>
-	<<for _i = 0; _i < $playerCurses.length; _i++>>
-		<<capture _i>>
-			<<print "[[$playerCurses[_i].name|Layer3 Skewed2b][$temp to _i]]">><br>
+	<<for _curse range $playerCurses>>
+		<<capture _curse>>
+			[[_curse.name|Layer3 Skewed2b][$temp to _curse]]<br>
 		<</capture>>
 	<</for>>
 <</if>>
@@ -900,46 +882,47 @@ As predicted, the water is pure and you can drink it without side effects!
 :: Layer3 Skewed2b [layer3]
 [img[setup.ImagePath+'Wonders/slantedshrine.png']]
 
-Which companion would you like to force the Curse of $playerCurses[$temp].name on?
+Which companion would you like to force the Curse of $temp.name upon?
 
 The magic of the shrine wisps through the air menacingly as your victim struggles helplessly.
 
 <<nobr>>
-<<for _i = 0; _i < $hiredCompanions.length; _i++>>
-	<<capture _i>>
-	<<print $hiredCompanions[_i].name>><<print " ">>
-	<<if $hiredCompanions[_i].name == $companionTwin.name >>
-		<<set _tempName = "Twin">>
-	<<else>>
-		<<set _tempName = $hiredCompanions[_i].name>>
-	<</if>>
-	<<set _string1 = "Transfer to " + $hiredCompanions[_i].name>>
-	<<if $hiredCompanions[_i].name == $companionGolem.name >>
-		You can't transfer a Curse to your Golem.<br>
-	<<else>>
-		<<link _string1 "Layer3 Skewed Apply">>
-		<<set $hiredCompanions[_i].curses.push($playerCurses[$temp])>>
-		<<print "<<set $companion"+ _tempName +".curses.push($playerCurses[$temp])>>">>
-		<<set $temp2=_i>>
+<<set _curse = $temp>>
+<<for _companion range $hiredCompanions>>
+	<<set _flag = false>>
+	<<set _tempName = _companion.name>>
 
-		<<if $playerCurses[$temp].type == "Age">>
-			<<set _string = "$AgeLog" + _tempName>>
-		<<elseif $playerCurses[$temp].type == "Gender">>
-			<<set _string = "$GenderLog" + _tempName>>
-		<<elseif $playerCurses[$temp].type == "Height">>
-			<<set _string = "$HeightLog" + _tempName>>
-		<<elseif $playerCurses[$temp].type == "Handicap">>
-			<<set _string = "$HandicapLog" + _tempName>>
-		<<elseif $playerCurses[$temp].type == "Libido">>
-			<<set _string = "$LibidoLog" + _tempName>>
-		<</if>>
-		<<if $playerCurses[$temp].type != "">>
-			<<print "<<set " + _string + ".push($playerCurses[$temp])>>">>
-		<</if>>
-		<<statUpdateCompanions>>
-		<</link>><br>
+	<<switch _tempName>>
+		<<case $companionTwin.name>>
+			Your twin already shares all of your Curses.<br>
+		<<case "Golem">>
+			You can't transfer Curses to your Golem.<br>
+		<<default>>
+			/* Check whether companion already has this curse (e.g. from the layer 4 shrine). */
+			<<set _flag = !_companion.curses.some(companionCurse => companionCurse.name == _curse.name)>>
+			<<if !_flag>>_companion.name already has this Curse!<br><</if>>
+	<</switch>>
+
+	<<if _flag>>
+		<<capture _companion, _tempName>>
+			<<set _choiceText = "Transfer to " + _tempName>>
+			<<link _choiceText "Layer3 Skewed Apply">>
+				<<set _companion.curses.push(_curse)>>
+
+				<<set _logName = _curse.type + "Log" + _tempName>>
+				<<set _log = State.variables[_logName]>>
+				<<if _log>><<set _log.push(_curse)>><</if>>
+
+				<<set $targetCurse = _curse>>
+				<<include "CurseRemoval">>
+				<<set $dubloons -= ($skewedUsed * 5)>>
+				<<set $skewedUsed += 1>>
+				<<statUpdateCompanions>>
+
+				<<set $temp2 = _companion>>
+			<</link>><br>
+		<</capture>>
 	<</if>>
-	<</capture>>
 <</for>>
 <</nobr>>
 
@@ -948,12 +931,8 @@ The magic of the shrine wisps through the air menacingly as your victim struggle
 [img[setup.ImagePath+'Wonders/slantedshrine.png']]
 
 <<nobr>>
-<<set $targetCurse = $playerCurses[$temp]>>
-<<include "CurseRemoval" >>
-<<set $dubloons -= ($skewedUsed * 5)>>
-<<set $skewedUsed += 1>>
 <<set $skewedForced += 1>>
-<<set _companionName = $hiredCompanions[$temp2].name>>
+<<set _companionName = $temp2.name>>
 <<set _affectionPenalty = 4 - $hsswear>>
 <<include "Companion Mistreatment Reaction">>
 <</nobr>>

--- a/src/layer4.twee
+++ b/src/layer4.twee
@@ -229,21 +229,21 @@ The Brave Vector Relic you can find here is a perfect example of something you m
 [img[setup.ImagePath+'Clipped-Fin/Abyss Diver Page 5-wonders.png']]
 
 <<nobr>>
-<<if ($hiredCompanions.length > 0) && ($steadyForced < 4)>>
+<<if !$hiredCompanions.length>>
+	You must have companions if you would like to use the Steady Shrine.<br><br>
+<<elseif $steadyForced < 4>>
 	Would you like to use the Steady Shrine to copy a Curse to one of your willing companions at the cost of <<print ($skewedUsed * 5)>> dubloons?<br>
 	<<link "Yes, use the Steady Shrine to copy a Curse" "Layer4 Steady1a">>
 		<<set $tempTime = 3>>
 		<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
 	<</link>><br><br>
-	Would you like to use the Steady Shrine to force a Curse on one of your unwilling companions at the cost of <<print ($skewedUsed * 5)>> dubloons?<br>
-	<<link "Yes, use the Steady Shrine to force a Curse" "Layer4 Steady 2a">>
+	Would you like to use the Steady Shrine to forcibly copy a Curse onto one of your unwilling companions at the cost of <<print ($skewedUsed * 5)>> dubloons?<br>
+	<<link "Yes, use the Steady Shrine to forcibly copy a Curse" "Layer4 Steady 2a">>
 		<<set $tempTime = 3>>
 		<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
 	<</link>><br><br>
-<<elseif $steadyForced > 4>>
-	None of your companions trust you at this shrine anymore. None will get close enough for you to use the shrine with them. They watch you with eyes full of fear and anger, as if they could bolt at any moment and leave you alone in the Abyss.<br><br>
 <<else>>
-	You must have companions if you would like to use the Steady Shrine.<br><br>
+	None of your companions trust you at this shrine anymore. None will get close enough for you to use the shrine with them. They watch you with eyes full of fear and anger, as if they could bolt at any moment and leave you alone in the Abyss.<br><br>
 <</if>>
 
 <<if ($purityUsed == 0)>>
@@ -778,60 +778,43 @@ Which Curse would you like to transfer to your willing companion? It can't be to
 	You do not have enough dubloons for an offering.
 <<else>>
 	<<for _companion range $hiredCompanions>>
-		<<capture _companion>>
-			<<for $j = 0; $j < $playerCurses.length; $j++>>
-				<<if $j==0>>
-					<<print "_companion.name doesn't mind taking:">><br>
-				<</if>>
-				<<set _curse = $playerCurses[$j]>>
-				<<if _companion.name == $companionTwin.name>>
-					<<set _tempname = "Twin">>
-					<<set _flag =  true>>
-				<<elseif _companion.name == "Golem">>
-					<<set _tempname = _companion.name >>
-					<<set _flag =  false>>
-					You can't copy a Curse to your Golem.<br>
-				<<else>>
-					<<set _tempname = _companion.name >>
-					<<set _flag =  setup.willingCurses[_tempname ].includes(_curse.name)>>
-				<</if>>
-				<<if _flag && !_companion.curses.some(e=> e.name === _curse.name )>>
-					<<capture _curse>>
-						<<print "_curse.name">>
-						<<link "Choose" "Layer4 Steady1a">>
-							<<set _companion.curses.push(_curse)>>
-							
-							<<if _companion == $companionTwin >>
-								<<set _tempName = "Twin">>
-							<<else>>
-								<<set _tempName = _companion.name>>
-							<</if>>
+		<<for _index, _curse range $playerCurses>>
+			<<set _flag = false>>
+			<<set _tempName = _companion.name>>
 
-							<<if _curse.type == "Age">>
-								<<set _string = "$AgeLog" + _tempName>>
-							<<elseif _curse.type == "Gender">>
-								<<set _string = "$GenderLog" + _tempName>>
-							<<elseif _curse.type == "Height">>
-								<<set _string = "$HeightLog" + _tempName>>
-							<<elseif _curse.type == "Handicap">>
-								<<set _string = "$HandicapLog" + _tempName>>
-							<<elseif _curse.type == "Libido">>
-								<<set _string = "$LibidoLog" + _tempName>>
-							<</if>>
-							<<if _curse.type != "">>
-								<<print "<<set " + _string + ".push(_curse)>>">>
-							<</if>>
+			<<switch _tempName>>
+				<<case $companionTwin.name>>
+					<<if _index < 1>>Your twin already shares all of your Curses.<br><</if>>
+				<<case "Golem">>
+					<<if _index < 1>>You can't copy Curses to your Golem.<br><</if>>
+				<<default>>
+					<<if _index < 1>>_companion.name doesn't mind taking:<br><</if>>
+					<<set _flag = setup.willingCurses[_tempName].includes(_curse.name)>>
+					<<if _flag>>
+						/* Check whether companion already has this curse (e.g. from this shrine). */
+						<<set _flag = !_companion.curses.some(companionCurse => companionCurse.name == _curse.name)>>
+					<</if>>
+			<</switch>>
 
-							<<set $corruption += Math.round(_curse.corr / 2 ) >>
-							/* The CYOA states that the cost counter is shared between shrines. */
-							<<set $dubloons -= ($skewedUsed * 5)>>
-							<<set $skewedUsed += 1>>
-							<<statUpdateCompanions>>
-						<</link>><br>
-					<</capture>>
-				<</if>>
-			<</for>>
-		<</capture>>
+			<<if _flag>>
+				<<capture _companion, _curse, _tempName>>
+					&nbsp; _curse.name
+					<<link "Choose" "Layer4 Steady1a">>
+						<<set _companion.curses.push(_curse)>>
+
+						<<set _logName = _curse.type + "Log2" + _tempName>>
+						<<set _log = State.variables[_logName]>>
+						<<if _log>><<set _log.push(_curse)>><</if>>
+
+						<<set $corruption += Math.round(_curse.corr / 2)>>
+						/* The CYOA states that the cost counter is shared between shrines. */
+						<<set $dubloons -= ($skewedUsed * 5)>>
+						<<set $skewedUsed += 1>>
+						<<statUpdateCompanions>>
+					<</link>><br>
+				<</capture>>
+			<</if>>
+		<</for>>
 	<</for>>
 <</if>>
 <</nobr>>
@@ -853,15 +836,15 @@ The knot of doubt that forms in the pit of your stomach is easily ignored as you
 
 With the Steady Shrine's power at your fingertips, you must now decide: do you impose your Curse upon your unwilling companion, prioritizing your own well-being at their expense, or do you release them and face the Abyss on your own terms? The decision seems straightforward to you, a necessary evil to achieve success.
 
-Which Curse would you like to force on your unwilling companion?
+Which Curse would you like to forcibly copy onto your unwilling companion?
 
 <<nobr>>
 <<if $dubloons < ($skewedUsed * 5)>>
 	You do not have enough dubloons for an offering.
 <<else>>
-	<<for $i = 0; $i < $playerCurses.length; $i++>>
-		<<capture $i>>
-			<<print "[[$playerCurses[$i].name|Layer4 Steady2b][$temp to $i]]">><br>
+	<<for _curse range $playerCurses>>
+		<<capture _curse>>
+			[[_curse.name|Layer4 Steady2b][$temp to _curse]]<br>
 		<</capture>>
 	<</for>>
 <</if>>
@@ -904,46 +887,47 @@ If you can't or don't want to cut down the tree, you can burn it down and bathe 
 :: Layer4 Steady2b [layer4]
 [img[setup.ImagePath+'Wonders/steadyshrine.png']]
 
-Which companion would you like to force the Curse of $playerCurses[$temp].name on?
+Which companion would you like to forcibly copy the Curse of $temp.name onto?
 
 The magic of the shrine wisps through the air menacingly as your victim struggles helplessly.
-<<nobr>>
-<<for _i = 0; _i < $hiredCompanions.length; _i++>>
-	<<capture _i>>
-	<<if !$hiredCompanions[_i].curses.some(e=> e.name === $playerCurses[$temp].name ) >>
-		<<if $hiredCompanions[_i].name == $companionTwin.name >>
-			<<set _tempName = "Twin">>
-		<<else>>
-			<<set _tempName = $hiredCompanions[_i].name>>
-		<</if>>
-		<<set _string1 = "Transfer to " + $hiredCompanions[_i].name>>
-		<<if $hiredCompanions[_i].name == $companionGolem.name>>
-				You can't copy a Curse to your Golem.<br>
-		<<else>>
-			<<link _string1 "Layer4 Steady Apply">>
-				<<set $hiredCompanions[_i].curses.push($playerCurses[$temp])>>
-				<<print "<<set $companion"+ _tempName +".curses.push($playerCurses[$temp])>>">>
-				<<set $temp2=_i>>
 
-				<<if $playerCurses[$temp].type == "Age">>
-					<<set _string = "$AgeLog" + _tempName>>
-				<<elseif $playerCurses[$temp].type == "Gender">>
-					<<set _string = "$GenderLog" + _tempName>>
-				<<elseif $playerCurses[$temp].type == "Height">>
-					<<set _string = "$HeightLog" + _tempName>>
-				<<elseif $playerCurses[$temp].type == "Handicap">>
-					<<set _string = "$HandicapLog" + _tempName>>
-				<<elseif $playerCurses[$temp].type == "Libido">>
-					<<set _string = "$LibidoLog" + _tempName>>
-				<</if>>
-				<<if $playerCurses[$temp].type != "">>
-					<<print "<<set " + _string + ".push($playerCurses[$temp])>>">>
-				<</if>>
+<<nobr>>
+<<set _curse = $temp>>
+<<for _companion range $hiredCompanions>>
+	<<set _flag = false>>
+	<<set _tempName = _companion.name>>
+
+	<<switch _tempName>>
+		<<case $companionTwin.name>>
+			Your twin already shares all of your Curses.<br>
+		<<case "Golem">>
+			You can't copy Curses to your Golem.<br>
+		<<default>>
+			/* Check whether companion already has this curse (e.g. from this shrine). */
+			<<set _flag = !_companion.curses.some(companionCurse => companionCurse.name == _curse.name)>>
+			<<if !_flag>>_companion.name already has this Curse!<br><</if>>
+	<</switch>>
+
+	<<if _flag>>
+		<<capture _companion, _tempName>>
+			<<set _choiceText = "Transfer to " + _tempName>>
+			<<link _choiceText "Layer4 Steady Apply">>
+				<<set _companion.curses.push(_curse)>>
+
+				<<set _logName = _curse.type + "Log" + _tempName>>
+				<<set _log = State.variables[_logName]>>
+				<<if _log>><<set _log.push(_curse)>><</if>>
+
+				<<set $corruption += Math.round(_curse.corr / 2)>>
+				/* The CYOA states that the cost counter is shared between shrines. */
+				<<set $dubloons -= ($skewedUsed * 5)>>
+				<<set $skewedUsed += 1>>
 				<<statUpdateCompanions>>
+
+				<<set $temp2 = _companion>>
 			<</link>><br>
-		<</if>>
+		<</capture>>
 	<</if>>
-	<</capture>>
 <</for>>
 <</nobr>>
 
@@ -952,11 +936,8 @@ The magic of the shrine wisps through the air menacingly as your victim struggle
 [img[setup.ImagePath+'Wonders/steadyshrine.png']]
 
 <<nobr>>
-<<set $corruption += Math.round($playerCurses[$temp].corr / 2)>>
-<<set $dubloons -= ($skewedUsed * 5)>>
-<<set $skewedUsed += 1>>
 <<set $skewedForced += 1>>
-<<set _companionName = $hiredCompanions[$temp2].name>>
+<<set _companionName = $temp2.name>>
 <<set _affectionPenalty = 3 - $hsswear>>
 <<include "Companion Mistreatment Reaction">>
 <</nobr>>


### PR DESCRIPTION
In the same vein as https://github.com/FloricSpacer/AbyssDiver/pull/38, I went through the logic for the curse transfer/copy shrines and refactored the logic. This one is a bit more involved as it includes some visual tweaks as well.

Bugfixes:
* The logic for going to each shrine had a hole in it where it would display the text for "no companions" if `$skewedForced == 4`. I reordered the branches to make the logic more obvious (and fix the bug).
* The skewed shrine did not check whether companions already possessed a curse (presumably because its logic predates the steady shrine).
* You could transfer curses to your twin, even though they share all your curses (and this is enforced by calls to the `<<statUpdateCompanions>>` macro). There was also logic to _copy_ curses to your twin, but this was prevented by the check for already owned curses.
* When forcing a curse onto a companion, it would be added both to `$companionName.curses` and `$hiredCompanions[index].curses`, but that's probably harmless because they're (usually?) different objects (and the `<<statUpdateCompanions>>` macro sets the former to the latter).

Logic tweaks:
* Use range-based for loops (we can still get the index for the check that needs it).
* Only capture variables when they need to be used inside a `<<link>>` (or the setter of a `[[link]]`).
* Pass object references around instead of indices.
* Don't use `<<print>>` where naked variable markup suffices.
* Get a reference to the log variable to update in the same way as the CurseRemoval passage (in this case we can use it for writing as well since we're pushing to the underlying array).
* Moved more of the logic for the consequences of a forced transfer/copy into the `<<link>>` to make the differences from a willing transfer/copy more obvious.

Display tweaks:
* For the willing transfer/copy, curse names are indented by 2 spaces for readability.
* Added text for the twin to explain why they can't receive curses.
* For the golem, only say that it can't receive curses once (instead of for each curse).
* For both the golem and the twin, omit the "doesn't mind taking" text.
* When forcing a curse onto a companion, just show "Transfer to [Name]" (instead of leading with the name as plain text).

Misc. text tweaks:
* Skewed shrine: `force on` -> `force upon`
* Steady shrine: `force on` -> `forcibly copy onto` (as a reminder of which shrine you're at)

I tested all 4 variants (skewed & steady, willing & forced) with all companions (including golem & twin) and didn't spot any further issues. An easy way to test with the new range-based loops is to replace `$playerCurses` with `$curses` (obviously it can't remove a curse you don't have, but since https://github.com/FloricSpacer/AbyssDiver/pull/38 the CurseRemoval passage is okay with that).

By the way, one thing I noticed: The affection penalty for forcibly copying a curse onto a companion is smaller (`3 - $hsswear`) than the penalty for forcibly transferring a curse to them (`4 - $hsswear`). Is that on purpose?