### PR TITLE
Turn CurseRemoval into a widget and capture its local variables

### DIFF
--- a/src/global.twee
+++ b/src/global.twee
@@ -1619,8 +1619,7 @@ Manage food and water items:<br>
 		<<else>>
 			You are affected by the Curse $StoredCurse[_i].name stored in the marbles.
 			<<link "Deactivate the stored Curse" "Use Items and Relics">>
-				<<set $targetCurse = $StoredCurse[_i]>>
-				<<include "CurseRemoval">>
+				<<RemoveCurse $StoredCurse[_i]>>
 				<<set _j = $ManagedMisfortuneActive.indexOf(c => c.name===$StoredCurse[_i].name)>>
 				<<set $ManagedMisfortuneActive.deleteAt(_j)>>
 			<</link>>	
@@ -1866,14 +1865,18 @@ How many dubloons would you like to pay back?
 [[Confirm|Commerce Balloon][$dubloons -= parseInt($temp), $debt -= parseInt($temp)]]
 <<back>>
 
-:: CurseRemoval [nobr]
+:: Curse removal widget [widget nobr]
+<<widget "RemoveCurse">>
+<<capture _i, _j, _logName, _logVar, _targetCurse>>
+
+<<set _targetCurse = _args[0]>>
 <<for _i = 0; _i < $playerCurses.length; ++_i>>
-	<<if $playerCurses[_i].name == $targetCurse.name>>
-		<<set _logName = $targetCurse.type + "Log">>
-		<<set _log = State.variables[_logName]>>
-		<<if _log>>
-			<<for _j = _log.length - 1; _j >= 0; --_j>>
-				<<if _log[_j].name == $targetCurse.name>><<break>><</if>>
+	<<if $playerCurses[_i].name == _targetCurse.name>>
+		<<set _logName = _targetCurse.type + "Log">>
+		<<set _logVar = State.variables[_logName]>>
+		<<if _logVar>>
+			<<for _j = _logVar.length - 1; _j >= 0; --_j>>
+				<<if _logVar[_j].name == _targetCurse.name>><<break>><</if>>
 			<</for>>
 			<<if _j >= 0>>
 				<<set State.variables[_logName].deleteAt(_j)>>
@@ -1883,6 +1886,9 @@ How many dubloons would you like to pay back?
 		<<break>>
 	<</if>>
 <</for>>
+
+<</capture>>
+<</widget>>
 
 :: GeneralTimeSetup[nobr]
 <<nobr>>

--- a/src/layer1.twee
+++ b/src/layer1.twee
@@ -989,9 +989,8 @@ But gradually, a newfound certainty washes over you - the realization that your 
 <<set $tempTime=3>>
 <<include "GeneralTimeSetup">>
 <<include "GeneralTimeStats">>
-<<set $targetCurse=$playerCurses[$temp]>>
 The Curse, $playerCurses[$temp].name, has been successfully removed and your corruption has been refunded.<br>
-<<include "CurseRemoval">>
+<<RemoveCurse $playerCurses[$temp]>>
 <</nobr>>
 [[Continue exploring the layer|Layer1 Hub]]
 

--- a/src/layer3.twee
+++ b/src/layer3.twee
@@ -420,8 +420,7 @@ Which Curse would you like to transfer to your willing companion? It can't be to
 						<<set _log = State.variables[_logName]>>
 						<<if _log>><<set _log.push(_curse)>><</if>>
 
-						<<set $targetCurse = _curse>>
-						<<include "CurseRemoval">>
+						<<RemoveCurse _curse>>
 						<<set $dubloons -= ($skewedUsed * 5)>>
 						<<set $skewedUsed += 1>>
 						<<statUpdateCompanions>>
@@ -913,8 +912,7 @@ The magic of the shrine wisps through the air menacingly as your victim struggle
 				<<set _log = State.variables[_logName]>>
 				<<if _log>><<set _log.push(_curse)>><</if>>
 
-				<<set $targetCurse = _curse>>
-				<<include "CurseRemoval">>
+				<<RemoveCurse _curse>>
 				<<set $dubloons -= ($skewedUsed * 5)>>
 				<<set $skewedUsed += 1>>
 				<<statUpdateCompanions>>

--- a/src/layer5.twee
+++ b/src/layer5.twee
@@ -1357,7 +1357,6 @@ Please enter your new exoskeleton color:
 	You have a single chance to bend fate using the mystical luck of the Devil's Own. Cherry's fate is strong, so you only get 1 chance to use this effect on your entire adventure. Would you like to reroll Cherry's Chaotic Luck?
 
 	<<link "Reroll with Devil's Own" "Layer5 Cherry Curse">>
-		<<set $targetCurse = $curses[$temp1]>>
 		<<set $corruption -= $playerCurses[$playerCurses.length - 1].corr>>
 		<<if $curses[$temp1].type == "Gender" >>
 			<<set _temp = $GenderLog.length>>
@@ -1365,9 +1364,8 @@ Please enter your new exoskeleton color:
 				<<set $GenderLog.deleteAt(_temp-1)>>
 			<</if>>
 		<</if>>
-		<<include "CurseRemoval">>
+		<<RemoveCurse $curses[$temp1]>>
 		
-		<<set $targetCurse = $curses[$temp2]>>
 		<<set $corruption -= $playerCurses[$playerCurses.length - 1].corr>>
 		<<if $curses[$temp2].type == "Gender" >>
 			<<set _temp = $GenderLog.length>>
@@ -1375,7 +1373,7 @@ Please enter your new exoskeleton color:
 				<<set $GenderLog.deleteAt(_temp-1)>>
 			<</if>>
 		<</if>>
-		<<include "CurseRemoval">>
+		<<RemoveCurse $curses[$temp2]>>
 
 		<<set _temp = $ownedRelics.findIndex(e=> e.name==="Devil's Own")>>
 		<<set $soldRelics.push($ownedRelics[_temp])>>
@@ -1452,7 +1450,6 @@ Please enter your new exoskeleton color:
 		<<set $ownedRelics.deleteAt($ownedRelics.length-1)>>
 		<<set $corruption += Math.floor(Math.max(($relics[$temp1].corr / 2) - $corRed, 0))>>
 		
-		<<set $targetCurse = $curses[$temp2]>>
 		<<set $corruption -= $playerCurses[$playerCurses.length - 1].corr>>
 		<<if $curses[$temp2].type == "Gender" >>
 			<<set _temp = $GenderLog.length>>
@@ -1460,7 +1457,7 @@ Please enter your new exoskeleton color:
 				<<set $GenderLog.deleteAt(_temp-1)>>
 			<</if>>
 		<</if>>
-		<<include "CurseRemoval">>
+		<<RemoveCurse $curses[$temp2]>>
 		<<set _temp = $ownedRelics.findIndex(e=> e.name==="Devil's Own")>>
 		<<set $soldRelics.push($ownedRelics[_temp])>>
 		<<set $ownedRelics.deleteAt(_temp)>>

--- a/src/layer6.twee
+++ b/src/layer6.twee
@@ -1086,7 +1086,6 @@ The Curses you have obtained with Cherry's Chaotic Luck are $curses[$temp1].name
 	You have a single chance to bend fate using the mystical luck of the Devil's Own. Cherry's fate is strong, so you only get 1 chance to use this effect on your entire adventure. Would you like to reroll Cherry's Chaotic Luck?
 
 	<<link "Reroll with Devil's Own" "Layer6 Cherry Curse">>
-		<<set $targetCurse = $curses[$temp1]>>
 		<<set $corruption -= $playerCurses[$playerCurses.length - 1].corr>>
 		<<if $curses[$temp1].type == "Gender" >>
 			<<set _temp = $GenderLog.length>>
@@ -1094,9 +1093,8 @@ The Curses you have obtained with Cherry's Chaotic Luck are $curses[$temp1].name
 				<<set $GenderLog.deleteAt(_temp-1)>>
 			<</if>>
 		<</if>>
-		<<include "CurseRemoval">>
+		<<RemoveCurse $curses[$temp1]>>
 		
-		<<set $targetCurse = $curses[$temp2]>>
 		<<set $corruption -= $playerCurses[$playerCurses.length - 1].corr>>
 		<<if $curses[$temp2].type == "Gender" >>
 			<<set _temp = $GenderLog.length>>
@@ -1104,7 +1102,7 @@ The Curses you have obtained with Cherry's Chaotic Luck are $curses[$temp1].name
 				<<set $GenderLog.deleteAt(_temp-1)>>
 			<</if>>
 		<</if>>
-		<<include "CurseRemoval">>
+		<<RemoveCurse $curses[$temp2]>>
 		<<set _temp = $ownedRelics.findIndex(e=> e.name==="Devil's Own")>>
 		<<set $soldRelics.push($ownedRelics[_temp])>>
 		<<set $ownedRelics.deleteAt(_temp)>>
@@ -1151,7 +1149,6 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 		<<set $ownedRelics.deleteAt($ownedRelics.length-1)>>
 		<<set $corruption += Math.floor(Math.max(($relics[$temp1].corr / 2) - $corRed, 0))>>
 		
-		<<set $targetCurse = $curses[$temp2]>>
 		<<set $corruption -= $playerCurses[$playerCurses.length - 1].corr>>
 		<<if $curses[$temp2].type == "Gender" >>
 			<<set _temp = $GenderLog.length>>
@@ -1159,7 +1156,7 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 				<<set $GenderLog.deleteAt(_temp-1)>>
 			<</if>>
 		<</if>>
-		<<include "CurseRemoval">>
+		<<RemoveCurse $curses[$temp2]>>
 		<<set _temp = $ownedRelics.findIndex(e=> e.name==="Devil's Own")>>
 		<<set $soldRelics.push($ownedRelics[_temp])>>
 		<<set $ownedRelics.deleteAt(_temp)>>

--- a/src/layer7.twee
+++ b/src/layer7.twee
@@ -1335,7 +1335,6 @@ The Curses you have obtained with Cherry's Chaotic Luck are $curses[$temp1].name
 	You have a single chance to bend fate using the mystical luck of the Devil's Own. Cherry's fate is strong, so you only get 1 chance to use this effect on your entire adventure. Would you like to reroll Cherry's Chaotic Luck?
 
 	<<link "Reroll with Devil's Own" "Layer7 Cherry Curse">>
-		<<set $targetCurse = $curses[$temp1]>>
 		<<set $corruption -= $playerCurses[$playerCurses.length - 1].corr>>
 		<<if $curses[$temp1].type == "Gender" >>
 			<<set _temp = $GenderLog.length>>
@@ -1343,9 +1342,8 @@ The Curses you have obtained with Cherry's Chaotic Luck are $curses[$temp1].name
 				<<set $GenderLog.deleteAt(_temp-1)>>
 			<</if>>
 		<</if>>
-		<<include "CurseRemoval">>
+		<<RemoveCurse $curses[$temp1]>>
 		
-		<<set $targetCurse = $curses[$temp2]>>
 		<<set $corruption -= $playerCurses[$playerCurses.length - 1].corr>>
 		<<if $curses[$temp2].type == "Gender" >>
 			<<set _temp = $GenderLog.length>>
@@ -1353,7 +1351,7 @@ The Curses you have obtained with Cherry's Chaotic Luck are $curses[$temp1].name
 				<<set $GenderLog.deleteAt(_temp-1)>>
 			<</if>>
 		<</if>>
-		<<include "CurseRemoval">>
+		<<RemoveCurse $curses[$temp2]>>
 
 		<<set _temp = $ownedRelics.findIndex(e=> e.name==="Devil's Own")>>
 		<<set $soldRelics.push($ownedRelics[_temp])>>
@@ -1413,7 +1411,6 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 		<<set $ownedRelics.deleteAt($ownedRelics.length-1)>>
 		<<set $corruption += Math.floor(Math.max(($relics[$temp1].corr / 2) - $corRed, 0))>>
 		
-		<<set $targetCurse = $curses[$temp2]>>
 		<<set $corruption -= $playerCurses[$playerCurses.length - 1].corr>>
 		<<if $curses[$temp2].type == "Gender" >>
 			<<set _temp = $GenderLog.length>>
@@ -1421,7 +1418,7 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 				<<set $GenderLog.deleteAt(_temp-1)>>
 			<</if>>
 		<</if>>
-		<<include "CurseRemoval">>
+		<<RemoveCurse $curses[$temp2]>>
 		<<set _temp = $ownedRelics.findIndex(e=> e.name==="Devil's Own")>>
 		<<set $soldRelics.push($ownedRelics[_temp])>>
 		<<set $ownedRelics.deleteAt(_temp)>>

--- a/src/layer8.twee
+++ b/src/layer8.twee
@@ -959,21 +959,18 @@ You give a wry smile, looking down at your new arms. There's a certain allure to
 <<nobr>>
 	<<set $playerCurses.push($curse108)>><<set $corruption += $curse108.corr>><<set $GenderLog.push($curse108)>>
 	<<if $playerCurses.some(e => e.name === "Double Pepperoni")>>
-		<<set $targetCurse = $curse39>>
-		<<include "CurseRemoval">>
-		<<set $corruption -= $targetCurse.corr>>
+		<<RemoveCurse $curse39.name>>
+		<<set $corruption -= $curse39.corr>>
 		<br>You feel the Double Pepperoni Curse leaving your body.<br>
 	<</if>>
 	<<if $playerCurses.some(e => e.name === "Softie")>>
-		<<set $targetCurse = $curse51>>
-		<<include "CurseRemoval">>
-		<<set $corruption -= $targetCurse.corr>>
+		<<RemoveCurse $curse51.name>>
+		<<set $corruption -= $curse51.corr>>
 		<br>You feel the Softie Curse leaving your body.<br>
 	<</if>>
 	<<if $playerCurses.some(e => e.name === "Hard Mode")>>
-		<<set $targetCurse = $curse52>>
-		<<include "CurseRemoval">>
-		<<set $corruption -= $targetCurse.corr>>
+		<<RemoveCurse $curse52.name>>
+		<<set $corruption -= $curse52.corr>>
 		<br>You feel the Hard Mode Curse leaving your body.<br>
 	<</if>>
 <</nobr>>\
@@ -1243,7 +1240,6 @@ The Curses you have obtained with Cherry's Chaotic Luck are $curses[$temp1].name
 	You have a single chance to bend fate using the mystical luck of the Devil's Own. Cherry's fate is strong, so you only get 1 chance to use this effect on your entire adventure. Would you like to reroll Cherry's Chaotic Luck?
 
 	<<link "Reroll with Devil's Own" "Layer8 Cherry Curse">>
-		<<set $targetCurse = $curses[$temp1]>>
 		<<set $corruption -= $playerCurses[$playerCurses.length - 1].corr>>
 		<<if $curses[$temp1].type == "Gender" >>
 			<<set _temp = $GenderLog.length>>
@@ -1251,9 +1247,8 @@ The Curses you have obtained with Cherry's Chaotic Luck are $curses[$temp1].name
 				<<set $GenderLog.deleteAt(_temp-1)>>
 			<</if>>
 		<</if>>
-		<<include "CurseRemoval">>
+		<<RemoveCurse $curses[$temp1]>>
 		
-		<<set $targetCurse = $curses[$temp2]>>
 		<<set $corruption -= $playerCurses[$playerCurses.length - 1].corr>>
 		<<if $curses[$temp2].type == "Gender" >>
 			<<set _temp = $GenderLog.length>>
@@ -1261,7 +1256,7 @@ The Curses you have obtained with Cherry's Chaotic Luck are $curses[$temp1].name
 				<<set $GenderLog.deleteAt(_temp-1)>>
 			<</if>>
 		<</if>>
-		<<include "CurseRemoval">>
+		<<RemoveCurse $curses[$temp2]>>
 
 		<<set _temp = $ownedRelics.findIndex(e=> e.name === "Devil's Own")>>
 		<<set $soldRelics.push($ownedRelics[_temp])>>
@@ -1341,7 +1336,6 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 		<<set $ownedRelics.deleteAt($ownedRelics.length-1)>>
 		<<set $corruption += Math.floor(Math.max(($relics[$temp1].corr / 2) - $corRed, 0))>>
 		
-		<<set $targetCurse = $curses[$temp2]>>
 		<<set $corruption -= $playerCurses[$playerCurses.length - 1].corr>>
 		<<if $curses[$temp2].type == "Gender" >>
 			<<set _temp = $GenderLog.length>>
@@ -1349,7 +1343,7 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 				<<set $GenderLog.deleteAt(_temp-1)>>
 			<</if>>
 		<</if>>
-		<<include "CurseRemoval">>
+		<<RemoveCurse $curses[$temp2]>>
 		<<set _temp = $ownedRelics.findIndex(e=> e.name === "Devil's Own")>>
 		<<set $soldRelics.push($ownedRelics[_temp])>>
 		<<set $ownedRelics.deleteAt(_temp)>>

--- a/src/widgets.twee
+++ b/src/widgets.twee
@@ -3154,33 +3154,33 @@
 <<widget "Equipment">>
 
 <<if !$ownedRelics.some(e => e.name === "Heart-stealing Stole")>>
-	<<set $hsswear=0>>
+	<<set $hsswear = 0>>
 <</if>>
 
 <<if !$ownedRelics.some(e => e.name === "Solace Lace")>>
-	<<set $slwear=0>>
+	<<set $slwear = 0>>
 <</if>>
 
 <<if !$ownedRelics.some(e => e.name === "Event Horizon")>>
-	<<set $EventHorizonWear=false>>
+	<<set $EventHorizonWear = false>>
 <</if>>
 
 <<if !$ownedRelics.some(e => e.name === "Chain of Lorelei")>>
-	<<set $colwear=0>>
+	<<set $colwear = 0>>
 <</if>>
 
 <<if !$ownedRelics.some(e => e.name === "Blind Divine")>>
-	<<set $BDwear=false>>
+	<<set $BDwear = false>>
 <</if>>
 
 <<if $ownedRelics.some(e => e.name === "Heavy is the Head")>>
-	<<if $HeavyHeadwear && $IQdrop<900>>
-		<<set $IQdrop+=999>>
+	<<if $HeavyHeadwear && $IQdrop < 900>>
+		<<set $IQdrop += 999>>
 	<</if>>
 <<else>>
-	<<set $HeavyHeadwear=false>>
-	<<if $IQdrop>900>>
-		<<set $IQdrop-=999>>
+	<<set $HeavyHeadwear = false>>
+	<<if $IQdrop > 900>>
+		<<set $IQdrop -= 999>>
 	<</if>>
 <</if>>
 
@@ -3189,43 +3189,45 @@
 <</if>>
 
 <<if !$ownedRelics.some(e => e.name === "Daedalus Mechanism")>>
-	<<set $DaedalusEquip = false>> <<set $DaedalusFly=false>>
+	<<set $DaedalusEquip = false>>
+	<<set $DaedalusFly = false>>
 <</if>>
 
 <<if !$ownedRelics.some(e => e.name === "Aeonglass with Endless Time")>>
-	<<set $EndlessAeonglass=false>>
+	<<set $EndlessAeonglass = false>>
 <</if>>
 
-<<set $ManagedMisfortuneMax = $ownedRelics.filter(e => e.name === "Managed Misfortune").length*2>>
-<<if $ManagedMisfortuneMax < $StoredCurse.length >>
-<<for _i=$StoredCurse.length-1; _i>=$ManagedMisfortuneMax; _i-->>
-	<<if $ManagedMisfortuneActive.some(e => e.name ===$StoredCurse[_i].name)>>
-		<<set $targetCurse = $StoredCurse[_i]>>
+<<set $ManagedMisfortuneMax = 2 * $ownedRelics.filter(e => e.name === "Managed Misfortune").length>>
+<<for $StoredCurse.length > $ManagedMisfortuneMax>>
+	<<set _curse = $StoredCurse.pop()>>
+	<<set _activeIndex = $ManagedMisfortuneActive.findIndex(e => e.name === _curse.name)>>
+	<<if _activeIndex !== -1>>
+		<<set $targetCurse = _curse>>
 		<<include "CurseRemoval">>
-		<<set _j = $ManagedMisfortuneActive.indexOf(c => c.name===$StoredCurse[_i].name)>>
-		<<set $ManagedMisfortuneActive.deleteAt(_j)>>
+		<<set $ManagedMisfortuneActive.deleteAt(_activeIndex)>>
 	<</if>>
-	<<set $StoredCurse.deleteAt(_i)>>
 <</for>>
-<</if>>
 
 <<if !$ownedRelics.some(e => e.name === "Lightning Rook")>>
-	<<set $LightningWear=false>>
+	<<set $LightningWear = false>>
 <</if>>
 
-<<if !$ownedRelics.some(e => e.name === "Lambent Specter") && $hiredCompanions.some(e => e.name === "Golem")>>
-	<<for _i = 0; _i < $hiredCompanions.length; _i++>>
-		<<if $hiredCompanions[_i].name == 'Golem'>>
-			<<set $hiredCompanions.deleteAt(_i)>>
-		<</if>>
+<<if !$ownedRelics.some(e => e.name === "Lambent Specter")>>
+	<<set _i = $hiredCompanions.findIndex(e => e.name === "Golem")>>
+	<<for _i !== -1>>
+		<<set $hiredCompanions.deleteAt(_i)>>
+		<<set _i = $hiredCompanions.findIndex(e => e.name === "Golem")>>
 	<</for>>
 <</if>>
 
-<<if ( $items[5].count > 0 || $items[17].count>0 || $items[21].count > 0 || $hiredCompanions.some(c => c.name === "Saeko") ) && !$abyssKnowCheatoff>>
+<<if $abyssKnowCheatoff>>
+	<<set $abyssKnow = 0>>
+<<elseif $items[5].count > 0 || $items[17].count > 0 || $items[21].count > 0 || $hiredCompanions.some(c => c.name === "Saeko")>>
 	<<set $abyssKnow = 1>>
 <<else>>
 	<<set $abyssKnow = 0>>
 <</if>>
+
 <</widget>>
 
 :: Affection widget [widget nobr]

--- a/src/widgets.twee
+++ b/src/widgets.twee
@@ -3202,8 +3202,7 @@
 	<<set _curse = $StoredCurse.pop()>>
 	<<set _activeIndex = $ManagedMisfortuneActive.findIndex(e => e.name === _curse.name)>>
 	<<if _activeIndex !== -1>>
-		<<set $targetCurse = _curse>>
-		<<include "CurseRemoval">>
+		<<RemoveCurse _curse>>
 		<<set $ManagedMisfortuneActive.deleteAt(_activeIndex)>>
 	<</if>>
 <</for>>

--- a/t3lt.twee-config.yml
+++ b/t3lt.twee-config.yml
@@ -152,6 +152,10 @@ sugarcube-2:
       name: RelicGrid
       parameters:
         - "string"
+    RemoveCurse:
+      name: RemoveCurse
+      parameters:
+        - "var"
     say:
       name: say
       container: true


### PR DESCRIPTION
This should go on top of <https://github.com/FloricSpacer/AbyssDiver/pull/40> (I think I can change the branch it compares to). Two changes:
* Turns passage `CurseRemoval` into widget `RemoveCurse`, letting you pass the curse as an argument.
* Makes the temporary variables used inside the widget unique (with a `removeCurse` prefix) so they don't trample existing variables (I think another way would be to `<<capture>>` them, but that feels awkward when they might not even be defined).

Edit: Changed to use the `<<capture>>` macro instead to avoid introducing long variable names everywhere.