### PR TITLE
Work around syntax highlighting issues with ConversationChoices macro

### DIFF
--- a/src/companionConversations.twee
+++ b/src/companionConversations.twee
@@ -49,10 +49,9 @@
 :: Maru Convo0
 <<say $companionMaru>>Hi I'm Maru<</say>>
 
-<<ConversationChoices
-	[[Greet him warmly with a hug|Maru Convo0 Hug]]
-	[[Greet him with a firm handshake|Maru Convo0 Shake]]
-	[[Greet him with a small wave from a distance|Maru Convo0 Wave]]
+<<Choices	[[Greet him warmly with a hug|Maru Convo0 Hug]]
+			[[Greet him with a firm handshake|Maru Convo0 Shake]]
+			[[Greet him with a small wave from a distance|Maru Convo0 Wave]]
 >>
 
 
@@ -64,9 +63,8 @@ You give Maru a tight hug, his body feels warm between your arms.
 At first he seems shocked, but after only a few moments he loosens up and hugs you back, blushing profoundly.
 
 <<say $companionMaru>>Well uh... Thank you. I hope I can be of use to you. I may not be as skilled as some people, but I swear it was worth it to hire me!<</say>>
-<<ConversationChoices
-	[[An extra person means extra carrying capacity, so don't worry about it!|Maru Convo0 Carry1]]
-	[[Don't worry about it. Everybody has their strong points. What are you good at?|Maru Convo0 Skill]]
+<<Choices	[[An extra person means extra carrying capacity, so don't worry about it!|Maru Convo0 Carry1]]
+			[[Don't worry about it. Everybody has their strong points. What are you good at?|Maru Convo0 Skill]]
 >>
 
 
@@ -94,9 +92,8 @@ You give a him firm handshake.
 He looks a little rattled by the firm handshake, but tries to respond energetically.
 
 <<say $companionMaru>>Oh, well, uh... Happy to be part of the team boss!<</say>>
-<<ConversationChoices
-	[["Me too! I have a lot of stuff I'll need you to take care of once we get going on our expedition"|Maru Convo0 Expectations]]
-	[["Me too! Lets make this an exciting adventure together!"|Maru Convo0 Exciting]]
+<<Choices	[["Me too! I have a lot of stuff I'll need you to take care of once we get going on our expedition"|Maru Convo0 Expectations]]
+			[["Me too! Lets make this an exciting adventure together!"|Maru Convo0 Exciting]]
 >>
 
 
@@ -121,9 +118,8 @@ You stand a bit akwardly and wave hello over at him.
 Maru giggles at your response.
 
 <<say $companionMaru>>I know that already, silly! So just tell me what you need me for, and I'll see if I can help out.<</say>>
-<<ConversationChoices
-	[["Uh... I don't know exactly. I guess we'll figure it out over time"|Maru Convo0 Improv]]
-	[["Hmm... Maybe you can carry some of our equipment?"|Maru Convo0 Carry2]]
+<<Choices	[["Uh... I don't know exactly. I guess we'll figure it out over time"|Maru Convo0 Improv]]
+			[["Hmm... Maybe you can carry some of our equipment?"|Maru Convo0 Carry2]]
 >>
 
 
@@ -146,10 +142,9 @@ Maru cheerfully brings you a meal he made, checking to see if it is as satisfyin
 <<say $mc>> You know, we're traveling together in one of the most dangerous places in the world, yet I<<if $IQdrop >10>>, like,<</if>> know almost<<if $IQdrop >20>>, like,<</if>> nothing about you. Do you want to tell me anything about yourself?<</say>>
 <<say $companionMaru>> Well, I'm not the most interesting person in the world. Was there anything you wanted to ask?<</say>>
 
-<<ConversationChoices
-	[[Could you tell me something about your childhood?|Maru Convo1 Childhood]]
-	[[Why do you wear such feminine clothes if you're a guy? It's really weird|Maru Convo1 Clothes]]
-	[[What's in this meal? It's really tasty!|Maru Convo1 Tasty]]
+<<Choices	[[Could you tell me something about your childhood?|Maru Convo1 Childhood]]
+			[[Why do you wear such feminine clothes if you're a guy? It's really weird|Maru Convo1 Clothes]]
+			[[What's in this meal? It's really tasty!|Maru Convo1 Tasty]]
 >>
 
 :: Maru Convo1 Childhood
@@ -304,9 +299,8 @@ Maru's face turns a deep shade of red as he hears your question.
 <<say $companionMaru>>Anyway, I hope this helps.<</say>>
 Maru extends the bulky garment towards you.
 
-<<ConversationChoices
-[[Thanks, but I'll try to manage without it.|Maru Wetting Denied]]
-[[Thanks, this is very thoughtful. I hope it will help me.|Maru Wetting Accepted ]]
+<<Choices	[[Thanks, but I'll try to manage without it.|Maru Wetting Denied]]
+			[[Thanks, this is very thoughtful. I hope it will help me.|Maru Wetting Accepted]]
 >>
 
 :: Maru Wetting Denied
@@ -425,10 +419,9 @@ Grateful, you thank Maru once more and decide to carry on with your journey, now
 <<say $companionLily>>Heeeey! I'm Lily, You must be $mc.name, right? Ready for our daring adventure into the belly of the beast, hero? Just stick with me and it'll all work out, don't worry!<</say>>
 She points her thumb at her chest and stands proudly, as if to show that she is prepared for anything you might find in the Abyss.
 
-<<ConversationChoices
-	[[Greet her warmly with a hug|Lily Convo0 Hug]]
-	[[Greet her with a firm handshake|Lily Convo0 Handshake]]
-	[[Greet her with a small wave from a distance|Lily Convo0 Wave]]
+<<Choices	[[Greet her warmly with a hug|Lily Convo0 Hug]]
+			[[Greet her with a firm handshake|Lily Convo0 Handshake]]
+			[[Greet her with a small wave from a distance|Lily Convo0 Wave]]
 >>
 
 :: Lily Convo0 Hug
@@ -441,10 +434,9 @@ She releases her grip on you and smiles widely.
 <<say $companionLily>>I didn't expect such a warm welcome, but hey I'm not complaining! Especially from such a cute <<PerceivedGender $app>>.<</say>>
 She winks at you and grins as she finishes her comment. You weren't sure if you were going for the cute vibe, but at the very least you want to be taken seriously as an adventurer. On the other hand, you suppose it's good that your new teammate likes you.
 
-<<ConversationChoices
-	[[Oh thanks! Well, if you insist, then I'll stay close and be sure to let you take care of me|Lily Convo0 Care]]
-	[[Look who's talking! I'll make sure to protect that cute face of yours and keep you safe too!|Lily Convo0 Safe]]
-	[[If she's already this into you, maybe you can take this to the next level and lean in for a kiss?|Lily Convo0 Kiss]]
+<<Choices	[[Oh thanks! Well, if you insist, then I'll stay close and be sure to let you take care of me|Lily Convo0 Care]]
+			[[Look who's talking! I'll make sure to protect that cute face of yours and keep you safe too!|Lily Convo0 Safe]]
+			[[If she's already this into you, maybe you can take this to the next level and lean in for a kiss?|Lily Convo0 Kiss]]
 >>
 
 :: Lily Convo0 Care
@@ -498,9 +490,8 @@ She shrugs and chuckles lightly.
 
 <<say $companionLily>>Just don't start asking me about my hobbies next.<</say>>
 
-<<ConversationChoices
-	[[Why not? I do actually want to get to know you better, and asking about you is the best way to do that!|Lily Convo0 Hobbies]]
-	[[Don't worry, I won't!|Lily Convo0 Nothing]]
+<<Choices	[[Why not? I do actually want to get to know you better, and asking about you is the best way to do that!|Lily Convo0 Hobbies]]
+			[[Don't worry, I won't!|Lily Convo0 Nothing]]
 >>
 
 :: Lily Convo0 Hobbies
@@ -539,9 +530,8 @@ Lily looks you over with a raised eyebrow after which a smile quickly forms on h
 <<say $companionLily>>Haha, don't be scared! I won't bite unless you want me to.<</say>>
 She winks at you and smiles even wider at her own implied joke.
 
-<<ConversationChoices
-	[[Please, bite me|Lily Convo0 Bite]]
-	[[I, uh, think I'd rather have you not do that|Lily Convo0 NoBite]]
+<<Choices	[[Please, bite me|Lily Convo0 Bite]]
+			[[I, uh, think I'd rather have you not do that|Lily Convo0 NoBite]]
 >>
 
 :: Lily Convo0 Bite 
@@ -568,10 +558,9 @@ You talk for quite some time afterwards. She is actually quite attentive and int
 :: Lily Convo1
 While normally you've gotten to know Lily as a bright light in any conversation, today she has been unusually quiet and her mood seems to be much more somber than usual.
 
-<<ConversationChoices
-	[[Try to cheer her up with a joke.|Lily Convo1 Joke]]
-	[[Don't say anything and hope she starts talking herself. |Party overview][$companionLily.affec-=(2-$hsswear),$LilyConvo1=false]]
-	[[Sit her down and ask her what's wrong.|Lily Convo1 Sit]]
+<<Choices	[[Try to cheer her up with a joke.|Lily Convo1 Joke]]
+			[[Don't say anything and hope she starts talking herself.|Party overview][$companionLily.affec-=(2-$hsswear),$LilyConvo1=false]]
+			[[Sit her down and ask her what's wrong.|Lily Convo1 Sit]]
 >>
 
 :: Lily Convo1 Joke
@@ -612,15 +601,13 @@ While normally you've gotten to know Lily as a bright light in any conversation,
 	Lily giggles and a grin spreads across her face.
 <</if>>\
 <<if $lilyJoke==false>>\
-	<<ConversationChoices
-		[[Well, if you liked them there's a whole lot more where those came from!|Lily Convo1 Jokes]]
-		[[I'm glad you're back to your normal upbeat self|Lily Convo1 Upbeat]]
-		[[So, uh, can I ask what's been bothering you?|Lily Convo1 Bothering]]
+	<<Choices	[[Well, if you liked them there's a whole lot more where those came from!|Lily Convo1 Jokes]]
+				[[I'm glad you're back to your normal upbeat self|Lily Convo1 Upbeat]]
+				[[So, uh, can I ask what's been bothering you?|Lily Convo1 Bothering]]
 	>>
 <<else>>\
-	<<ConversationChoices
-		[[I'm glad you're back to your normal upbeat self|Lily Convo1 Upbeat]]
-		[[So, uh, can I ask what's been bothering you?|Lily Convo1 Bothering]]
+	<<Choices	[[I'm glad you're back to your normal upbeat self|Lily Convo1 Upbeat]]
+				[[So, uh, can I ask what's been bothering you?|Lily Convo1 Bothering]]
 	>>
 <</if>>
 
@@ -693,10 +680,9 @@ Lily looks up as she seems to consider her thoughts.
 <<say $companionLily>>I think I just have a lot on my mind right now.<</say>>
 <<say $mc>>You know you can<<if $IQdrop >10>>, like,<</if>> talk to me Lily...<</say>>
 
-<<ConversationChoices
-	[[...because I need you at your best. You know I rely on you, Lily. |Lily Convo1 Rely]]
-	[[...because a smile fits a pretty lady like you much better than a frown. |Lily Convo1 Smile]]
-	[[...because you being happy makes me happy too. |Lily Convo1 Happy]]
+<<Choices	[[...because I need you at your best. You know I rely on you, Lily.|Lily Convo1 Rely]]
+			[[...because a smile fits a pretty lady like you much better than a frown.|Lily Convo1 Smile]]
+			[[...because you being happy makes me happy too.|Lily Convo1 Happy]]
 >>
 
 :: Lily Convo1 Rely
@@ -812,10 +798,9 @@ Lily scratches her head and gazes upward.
 You both chuckle at the ridiculous mental image.
 
 <<say $companionLily>>But more seriously, I want to have friends and maybe even a family of my own at some point. I love the idea of having someone special in my life to share all my experiences with.<</say>>
-<<ConversationChoices
-	[[I didn't know you had such a strong desire to settle down. I always thought you were very travel-oriented.|Lily Convo2 Settle]]
-	[[What's the problem with having a family?|Lily Convo2 Family]]
-	[[A family sounds a bit dull, to be honest. I'd rather stick to the adventures of the road!|Lily Convo2 Adventures]]
+<<Choices	[[I didn't know you had such a strong desire to settle down. I always thought you were very travel-oriented.|Lily Convo2 Settle]]
+			[[What's the problem with having a family?|Lily Convo2 Family]]
+			[[A family sounds a bit dull, to be honest. I'd rather stick to the adventures of the road!|Lily Convo2 Adventures]]
 >>
 
 :: Lily Convo2 Settle
@@ -945,9 +930,8 @@ She puffs out her chest a bit and gestures widely over her whole body.
 <<say $companionLily>>Anyway, not to say that this whole journey is not a good workout on its own, buuut... When I saw the World Stone, I started wondering if it could be even better. This could be a golden opportunity to get in better shape than ever before!<</say>>
 <<say $mc>>Oh, I see! So you<<if $IQdrop >5>>, like,<</if>> want to use it to train?<</say>>
 <<say $companionLily>>Exactly, <<mrms>> smartypants. Soooo... Can I borrow it for a while? I don't want you to get rid of the best workout tool I've ever found!<</say>>
-<<ConversationChoices
-	[[I don't know Lily, I was actually planning on selling it|Lily ConvoPr Sell]]
-	[[Of course Lily, as long as you're careful with it. I'll let you use it and won't sell it|Lily ConvoPr Keep]]
+<<Choices	[[I don't know Lily, I was actually planning on selling it|Lily ConvoPr Sell]]
+			[[Of course Lily, as long as you're careful with it. I'll let you use it and won't sell it|Lily ConvoPr Keep]]
 >>
 
 :: Lily ConvoPr Sell
@@ -996,14 +980,12 @@ You look down, slightly ashamed at the obvious contempt she is showing you.
 	<<say $companionLily>>You could let mommy take care of you. How about it?<</say>>
 
 	<<if $app.subdom <= 0>>\
-		<<ConversationChoices
-			[[I think its better we stop here Lily, I don't feel comfortable with this whole situation|Lily ConvoLac NoDom]]
-			[[Okay, mommy|Lily ConvoPr Mommy]]
+		<<Choices	[[I think its better we stop here Lily, I don't feel comfortable with this whole situation|Lily ConvoLac NoDom]]
+					[[Okay, mommy|Lily ConvoPr Mommy]]
 		>>
 	<<else>>\
-		<<ConversationChoices
-			[[I don't know Lily, I don't feel comfortable with this whole situation|Lily ConvoLac NoSub]]
-			[[Okay, mommy|Lily ConvoLac Mommy]]
+		<<Choices	[[I don't know Lily, I don't feel comfortable with this whole situation|Lily ConvoLac NoSub]]
+					[[Okay, mommy|Lily ConvoLac Mommy]]
 		>>	
 	<</if>>
 <<elseif $app.appGender >= 6 && $app.subdom > -1>>\
@@ -1025,9 +1007,8 @@ You look down, slightly ashamed at the obvious contempt she is showing you.
 
 	<<say $companionLily>>You just let little old me take care of that sexy body of yours. How about it? Who's your mommy?<</say>>
 
-	<<ConversationChoices
-		[[I don't know Lily, I don't feel comfortable with this whole situation|Lily ConvoLac NoSub]]
-		[[You're my mommy?|Lily ConvoLac Mommy]]
+	<<Choices	[[I don't know Lily, I don't feel comfortable with this whole situation|Lily ConvoLac NoSub]]
+				[[You're my mommy?|Lily ConvoLac Mommy]]
 	>>
 <<else>>\
 	<<set $companionLily.affec-=(2-$hsswear)>>\
@@ -1142,10 +1123,9 @@ She lets out a small giggle as she strokes your $app.hair hair softly as you con
 :: Khemia Convo0
 <<appGender>>\
 <<say $companionKhemia>>Yo, I'm Khemia, nice to meet you.<</say>>
-<<ConversationChoices
-	[[Greet him warmly with a hug|Khemia Convo0 Hug]]
-	[[Greet him with a firm handshake|Khemia Convo0 Handshake]]
-	[[Greet him with a small wave from a distance|Khemia Convo0 Wave]]
+<<Choices	[[Greet him warmly with a hug|Khemia Convo0 Hug]]
+			[[Greet him with a firm handshake|Khemia Convo0 Handshake]]
+			[[Greet him with a small wave from a distance|Khemia Convo0 Wave]]
 >>
 
 :: Khemia Convo0 Hug
@@ -1165,9 +1145,8 @@ You give Khemia a big hug, and while he seems hesitant for a moment, he reciproc
 	He gives you a wide grin and embraces your hug.
 <</if>>\
 
-<<ConversationChoices
-	[[Okay, maybe we can tone down the whole physical contact thing a little bit|Khemia Convo0 NoPhysical]]
-	[[Haha, sure, I'll try. But no promises!|Khemia Convo0 NoPromise]]
+<<Choices	[[Okay, maybe we can tone down the whole physical contact thing a little bit|Khemia Convo0 NoPhysical]]
+			[[Haha, sure, I'll try. But no promises!|Khemia Convo0 NoPromise]]
 >>
 
 :: Khemia Convo0 NoPhysical
@@ -1212,9 +1191,8 @@ You give a him a firm handshake, which he answers with his own impressively firm
 <<say $companionKhemia>>52 dives and counting <<mrms>>. <</say>>
 He has a clear smug expression as he mentions his extensive experience in the Abyss.
 
-<<ConversationChoices
-	[[Wow, you must have some incredible stories to tell!|Khemia Convo0 Stories]]
-	[[Great! Then I'm sure you'll prove useful to the team|Khemia Convo0 Team]]
+<<Choices	[[Wow, you must have some incredible stories to tell!|Khemia Convo0 Stories]]
+			[[Great! Then I'm sure you'll prove useful to the team|Khemia Convo0 Team]]
 >>
 
 :: Khemia Convo0 Stories
@@ -1246,8 +1224,7 @@ You stand a bit awkwardly near Khemia and wave a small greeting to him.
 Khemia strides over to you and pats your back so hard you almost fall over.
 
 <<say $companionKhemia>>I can tell this is your first time this close to the Abyss, but don't worry, Khemia has got your back now. I can guarantee you that this expedition will be a breeze with me on board.<</say>>
-<<ConversationChoices
-			[[Well, to be honest, with my leadership it was always going to be a breeze!|Khemia Convo0 Breeze]]
+<<Choices	[[Well, to be honest, with my leadership it was always going to be a breeze!|Khemia Convo0 Breeze]]
 			[[I'm so glad you said that. I'll be putting my trust and the fate of this expedition in your capable hands|Khemia Convo0 Fate]]
 >>
 
@@ -1304,16 +1281,14 @@ He's breathing heavily, but there's no trembling in his motions as he stands and
 <<nobr>>
 <<set _cutCheck = setup.haveCuttingTool() ? 1 : 0>>
 <<if _cutCheck==1>>
-	<<ConversationChoices
-		[[Your skills are impressive. I'm glad to have you along, and that we've got a sword for you to use.| Khemia Convo1 Impressive]]
-		[[Yeah... Would you mind practicing against me?| Khemia Convo1 Practice]] 
-		[[Pff, You're just dancing around a bit. I'd bet I could disarm you if I really try.| Khemia Convo1 Dancing]] 
+	<<Choices	[[Your skills are impressive. I'm glad to have you along, and that we've got a sword for you to use.| Khemia Convo1 Impressive]]
+				[[Yeah... Would you mind practicing against me?| Khemia Convo1 Practice]] 
+				[[Pff, You're just dancing around a bit. I'd bet I could disarm you if I really try.| Khemia Convo1 Dancing]] 
 	>>
 <<else>>
-	<<ConversationChoices
-		[[Your skills are impressive. I'm glad to have you along.| Khemia Convo1 Impressive2]] 
-		[[Yeah... Would you mind practicing against me?| Khemia Convo1 Practice]] 
-		[[Pff, You're just dancing around a bit. I'd bet I could disarm you if I really try.| Khemia Convo1 Dancing]] 
+	<<Choices	[[Your skills are impressive. I'm glad to have you along.| Khemia Convo1 Impressive2]] 
+				[[Yeah... Would you mind practicing against me?| Khemia Convo1 Practice]] 
+				[[Pff, You're just dancing around a bit. I'd bet I could disarm you if I really try.| Khemia Convo1 Dancing]] 
 	>>
 <</if>>
 <</nobr>>
@@ -1378,9 +1353,8 @@ Khemia looks around until he finds a stick he feels is suitable and throws it to
 You catch the stick and stand at the place he points to about four meters from him and lock eyes.
 
 <<say $companionKhemia>>Ready or not, here I come!<</say>>
-<<ConversationChoices
-	[[Take up a cautious stance, and try to defend against his incoming charge| Khemia Convo1 PracticeD]] 
-	[[Charge him, stick held high and hit him before he gets a chance to hit you| Khemia Convo1 PracticeO]] 
+<<Choices	[[Take up a cautious stance, and try to defend against his incoming charge| Khemia Convo1 PracticeD]] 
+			[[Charge him, stick held high and hit him before he gets a chance to hit you| Khemia Convo1 PracticeO]] 
 >>
 
 :: Khemia Convo1 Dancing
@@ -1390,9 +1364,8 @@ Khemia scowls, not even attempting to hide the disdain on his face.
 <<say $companionKhemia>>Talk is cheap. Would a master like yourself be willing to demonstrate your skills and take me down in a sparring match? Assuming you can, of course.<</say>>
 His face returns to a smile, but it seems less friendly now, more predatory.
 
-<<ConversationChoices
-	[[Pick up a stick of your own and join him| Khemia Convo1 Challenge]]
-	[[I think not. We have more important things to be doing than playing silly games.| Khemia Convo1 Silly]]
+<<Choices	[[Pick up a stick of your own and join him| Khemia Convo1 Challenge]]
+			[[I think not. We have more important things to be doing than playing silly games.| Khemia Convo1 Silly]]
 >>
 
 :: Khemia Convo1 PracticeD
@@ -1468,9 +1441,8 @@ What is there to do but attack? You lunge forward, trying to land a hit, but Khe
 You pick up a stick of your own, and lock eyes with Khemia, standing four meters apart.
 A spark of anger burns within his gaze, perhaps you shouldn't have insulted his pride, or perhaps it's time you taught him his place.
 
-<<ConversationChoices
-	[[Take up a cautious stance, and try to defend against his incoming charge| Khemia Convo1 ChallengeD]] 
-	[[Charge him, stick held high and beat him to the punch| Khemia Convo1 ChallengeO]] 
+<<Choices	[[Take up a cautious stance, and try to defend against his incoming charge| Khemia Convo1 ChallengeD]] 
+			[[Charge him, stick held high and beat him to the punch| Khemia Convo1 ChallengeO]] 
 >>
 
 :: Khemia Convo1 ChallengeD
@@ -1739,10 +1711,9 @@ He flashes a wide grin, but the ensuing silence seems to dampen his enthusiasm.
 
 :: Cherry Convo0
 <<say $companionCherry>>Um, hi... I'm Cherry.<</say>>
-<<ConversationChoices
-	[[Greet her warmly with a hug|Cherry Convo0 Hug]]
-	[[Greet her with a firm handshake|Cherry Convo0 Handshake]]
-	[[Greet her with a small wave from a distance|Cherry Convo0 Wave]]
+<<Choices	[[Greet her warmly with a hug|Cherry Convo0 Hug]]
+			[[Greet her with a firm handshake|Cherry Convo0 Handshake]]
+			[[Greet her with a small wave from a distance|Cherry Convo0 Wave]]
 >>
 
 :: Cherry Convo0 Hug
@@ -1754,9 +1725,8 @@ She shuffles around awkwardly before responding.
 
 <<say $companionCherry>>It's fine. I'm just not really used to it. <</say>>
 
-<<ConversationChoices
-	[[I hope you are just as excited about this trip as I am!|Cherry Convo0 Excited]]
-	[[So, could you tell me a little bit more about yourself before we start the journey?|Cherry Convo0 Yourself]]
+<<Choices	[[I hope you are just as excited about this trip as I am!|Cherry Convo0 Excited]]
+			[[So, could you tell me a little bit more about yourself before we start the journey?|Cherry Convo0 Yourself]]
 >>
 
 :: Cherry Convo0 Excited
@@ -1783,9 +1753,8 @@ When you look at her there is no sign of emotion, her expression seems totally b
 
 <<say $companionCherry>>Okay. Thanks, I guess.<</say>>
 
-<<ConversationChoices
-	[[I hope we are going to get along well with each other!|Cherry Convo0 Along]]
-	[[So, is there anything in particular I should know about you before we get to exploring?|Cherry Convo0 Know]]
+<<Choices	[[I hope we are going to get along well with each other!|Cherry Convo0 Along]]
+			[[So, is there anything in particular I should know about you before we get to exploring?|Cherry Convo0 Know]]
 >>
 
 :: Cherry Convo0 Along
@@ -1815,13 +1784,10 @@ For a second you seem to spot a small smile creep up on Cherry, but in an instan
 
 <<say $companionCherry>>Yeah, I believe that was kind of why you hired me, right?<</say>>
 <<if $IQdrop >20>>
-	<<ConversationChoices
-			[[Wow, how did you know?|Cherry Convo0 Awkward Bimbo]]
-	>>
+	<<Choices [[Wow, how did you know?|Cherry Convo0 Awkward Bimbo]]>>
 <<else>>
-	<<ConversationChoices
-			[[Haha, yeah. I guess I'm just a bit awkward with new people|Cherry Convo0 Awkward]]
-			[[I was just trying to make conversation, because you were so silent. You don't need to state the obvious|Cherry Convo0 Silent]]
+	<<Choices	[[Haha, yeah. I guess I'm just a bit awkward with new people|Cherry Convo0 Awkward]]
+				[[I was just trying to make conversation, because you were so silent. You don't need to state the obvious|Cherry Convo0 Silent]]
 	>>
 <</if>>
 :: Cherry Convo0 Awkward Bimbo
@@ -1852,10 +1818,9 @@ She turns around and walks off. What happened? Did you annoy her or something? S
 :: Cherry Convo1
 You're taking a brief rest, and you see Cherry staring at you, except her eyes aren't quite focused on you, they seem to be focused a thousand kilometers behind you. Her expression is held in a sad frown, tinged with pain.
 
-<<ConversationChoices
-	[[Leave her to her memories; the only way to deal with pain is to face it. It's not your place to interfere.|Cherry Convo1 Memories][$alt=1]] 
-	[[Sit down beside her, and wait for her to say something.|Cherry Convo1 Sit]] 
-	[[Make a joke to cheer her up|Cherry Convo1 Joke]] 
+<<Choices	[[Leave her to her memories; the only way to deal with pain is to face it. It's not your place to interfere.|Cherry Convo1 Memories][$alt=1]] 
+			[[Sit down beside her, and wait for her to say something.|Cherry Convo1 Sit]] 
+			[[Make a joke to cheer her up|Cherry Convo1 Joke]] 
 >>
 
 :: Cherry Convo1 Memories
@@ -1885,10 +1850,9 @@ A few moments of pause drag out, and you give her space to continue.
 
 <<say $companionCherry>>She was always making friends, dancing, laughing. Sometimes I miss her.<</say>>
 
-<<ConversationChoices
-	[[What happened?|Cherry Convo1 Happened]] 
-	[[I know what it's like to lose people, but we're still here. All we can do is honor their memories, and live on|Cherry Convo1 Lose][$alt=1]]
-	[[Ah, okay. It's good you got that off your chest, but we should keep moving|Cherry Convo1 Memories][$alt=2]] 
+<<Choices	[[What happened?|Cherry Convo1 Happened]] 
+			[[I know what it's like to lose people, but we're still here. All we can do is honor their memories, and live on|Cherry Convo1 Lose][$alt=1]]
+			[[Ah, okay. It's good you got that off your chest, but we should keep moving|Cherry Convo1 Memories][$alt=2]] 
 >>
 
 :: Cherry Convo1 Joke
@@ -1916,10 +1880,9 @@ A few more wet trails join the first rolling down her face.
 
 <<say $companionCherry>>I don't want others to suffer from my burden. She should have lived. She should still be laughing and dancing.<</say>>
 
-<<ConversationChoices
-	[[It's not your fault that the world is the way it is. We all have our burdens. We can get through things together|Cherry Convo1 Together]]
-	[[I'm sorry. Losing people is hard. Living with the grief never gets easy|Cherry Convo1 Lose][$alt=2]]
-	[[Walk away from the crying woman and just continue with the journey, this is too much for you|Cherr Convo1 Run]] 
+<<Choices	[[It's not your fault that the world is the way it is. We all have our burdens. We can get through things together|Cherry Convo1 Together]]
+			[[I'm sorry. Losing people is hard. Living with the grief never gets easy|Cherry Convo1 Lose][$alt=2]]
+			[[Walk away from the crying woman and just continue with the journey, this is too much for you|Cherr Convo1 Run]] 
 >>
 
 :: Cherry Convo1 Run
@@ -2011,14 +1974,12 @@ Cherry's face gradually flushes a deep scarlet, and she hesitates before respond
 
 <<say $companionCherry>>No reason, I'll just go and tend to my own stuff now.<</say>>
 <<if $app.subdom <= 0 >>
-	<<ConversationChoices
-		[[Cherry, did you want the milk?|Cherry ConvoLac Dom]]
-		[[Okay? That was strange|Cherry ConvoLac End]]
+	<<Choices	[[Cherry, did you want the milk?|Cherry ConvoLac Dom]]
+				[[Okay? That was strange|Cherry ConvoLac End]]
 	>>
 <<else>>
-	<<ConversationChoices
-		[[It's okay, you can tell me if you're interested in my milk|Cherry ConvoLac Sub]]
-		[[Okay? Strange|Cherry ConvoLac End]]
+	<<Choices	[[It's okay, you can tell me if you're interested in my milk|Cherry ConvoLac Sub]]
+				[[Okay? Strange|Cherry ConvoLac End]]
 	>>
 <</if>>
 
@@ -2098,9 +2059,8 @@ Her gaze falls to the ground, almost shyly.
 <<say $mc>>Aw, thank you. Was that all?<</say>>
 <<say $companionCherry>>Actually...<</say>>
 <<say $companionCherry>>Can I pet... I mean, touch it?<</say>>
-<<ConversationChoices
-	[[Sure, no problem|Cherry Fluffy Yes]]
-	[[I'd rather you didn't|Cherry Fluffy No]]
+<<Choices	[[Sure, no problem|Cherry Fluffy Yes]]
+			[[I'd rather you didn't|Cherry Fluffy No]]
 >>
 
 :: Cherry Fluffy Yes
@@ -2177,10 +2137,9 @@ Her eyes reveal a hint of disappointment, but she quickly scurries away.
 :: Cloud Convo0
 <<say $companionCloud>>'Sup, name's Cloud. I'm glad I'm able to go on an expedition with someone like you.<</say>>
 
-<<ConversationChoices
-	[[Greet him warmly with a hug|Cloud Convo0 Hug]]
-	[[Greet him with a firm handshake|Cloud Convo0 Handshake]]
-	[[Greet him with a small wave from a distance|Cloud Convo0 Wave]]
+<<Choices	[[Greet him warmly with a hug|Cloud Convo0 Hug]]
+			[[Greet him with a firm handshake|Cloud Convo0 Handshake]]
+			[[Greet him with a small wave from a distance|Cloud Convo0 Wave]]
 >>
 
 :: Cloud Convo0 Hug
@@ -2191,9 +2150,8 @@ Cloud grins widely as he replies.
 
 <<say $companionCloud>>You're pretty smooth, already buttering me up. I thought I was supposed to work for you.<</say>>
 
-<<ConversationChoices
-	[[Yeah, but having a good relationship with everyone on an expedition like this is important, right?|Cloud Convo0 Relationship]]
-	[[Well, I've heard you have some powerful connections, so being a little extra nice couldn't hurt|Cloud Convo0 Connections]]
+<<Choices	[[Yeah, but having a good relationship with everyone on an expedition like this is important, right?|Cloud Convo0 Relationship]]
+			[[Well, I've heard you have some powerful connections, so being a little extra nice couldn't hurt|Cloud Convo0 Connections]]
 >>
 
 :: Cloud Convo0 Relationship
@@ -2229,9 +2187,8 @@ You give him a firm handshake, and he responds in kind while flashing you a wide
 <<say $mc>>Welcome to the team! I'm $mc.name.<</say>>
 <<say $companionCloud>>I'm happy to be of service to a great adventurer like yourself, how can I help?<</say>>
 
-<<ConversationChoices
-	[[I've heard you're an excellent marksman, so I'd appreciate it if you can keep me safe and keep the expedition on track!|Cloud Convo0 Safe]]
-	[[I've heard you're an excellent marksman, so I was wondering if you've ever killed someone?|Cloud Convo0 Killed]]
+<<Choices	[[I've heard you're an excellent marksman, so I'd appreciate it if you can keep me safe and keep the expedition on track!|Cloud Convo0 Safe]]
+			[[I've heard you're an excellent marksman, so I was wondering if you've ever killed someone?|Cloud Convo0 Killed]]
 >>
 
 :: Cloud Convo0 Safe
@@ -2268,10 +2225,9 @@ You stand around a bit awkwardly and wave hello to him from a distance.
 He looks at you, slightly perplexed, and scratches the back of his head.
 
 <<say $companionCloud>>So I'm guessing you've never led an expedition like this before, am I right?<</say>>
-<<ConversationChoices
-	[[Oh no, is it that obvious? It's true I've never done this before, but I'll do my best to become a capable expedition leader as soon as I can!|Cloud Convo0 Admit]]
-	[[*Lie* Nah, I have loads of experience, the Abyss is going to be a piece of cake, just one more place to conquer|Cloud Convo0 Lie]]
-	[[*Truth* Nah, I have loads of experience. I've lead expeditions before and call it a vision or something, but I have an idea of what to expect down there, in the Abyss|Cloud Convo0 Truth]]
+<<Choices	[[Oh no, is it that obvious? It's true I've never done this before, but I'll do my best to become a capable expedition leader as soon as I can!|Cloud Convo0 Admit]]
+			[[*Lie* Nah, I have loads of experience, the Abyss is going to be a piece of cake, just one more place to conquer|Cloud Convo0 Lie]]
+			[[*Truth* Nah, I have loads of experience. I've lead expeditions before and call it a vision or something, but I have an idea of what to expect down there, in the Abyss|Cloud Convo0 Truth]]
 >>
 
 :: Cloud Convo0 Admit
@@ -2319,10 +2275,9 @@ He then pushes the body onto its back and points at the other wounds.
 <<say $companionCloud>> And these are stab wounds, but every single one missed a vital organ. Based on the amount of blood here, my guess is that he bled out in the end after managing to get away at first.<</say>>
 <<say $mc>> That sounds pretty gruesome, why would they do that to him? <</say>>
 <<say $companionCloud>> Indeed, it must have been. Check his bag. If my guess is right, we might be able to find something useful. <</say>>
-<<ConversationChoices
-	[[Just follow his instructions|Cloud Convo1 Instructions]]
-	[[You sure seem to know a lot about bandits. Have you had any experience with them?|Cloud Convo1 Experience]]
-	[[Why should we take anything from him? It's immoral, even if he is already dead|Cloud Convo1 Immoral]]
+<<Choices	[[Just follow his instructions|Cloud Convo1 Instructions]]
+			[[You sure seem to know a lot about bandits. Have you had any experience with them?|Cloud Convo1 Experience]]
+			[[Why should we take anything from him? It's immoral, even if he is already dead|Cloud Convo1 Immoral]]
 >>
 
 :: Cloud Convo1 Instructions
@@ -2432,9 +2387,8 @@ Cloud ponders for a moment, his eyes sparkling as an idea forms.
 	Cloud effortlessly removes your clothing, leaving you feeling exposed and vulnerable. Instinctively, you attempt to shield your breasts from his gaze. When you glance back, you find him wearing a broad, charming grin.
 
 	<<say $companionCloud>>Trust me, let me work my magic. You'll feel much better afterwards.<</say>>
-	<<ConversationChoices
-		[[I don't really like where this is going, Cloud|Cloud ConvoLac No]]
-		[[Okay, I trust you|Cloud ConvoLac Yes]]
+	<<Choices	[[I don't really like where this is going, Cloud|Cloud ConvoLac No]]
+				[[Okay, I trust you|Cloud ConvoLac Yes]]
 	>>
 <<else>>
 	<<set $companionCloud.affec-=(3-$hsswear)>>
@@ -2550,10 +2504,9 @@ He relinquishes his hold on your breasts, delivers a playful slap to your buttoc
 :: Saeko Convo0
 <<say $companionSaeko>>Oh, hello. I'm Saeko. You're the expedition leader, correct?<</say>>
 
-<<ConversationChoices
-	[[Greet her warmly with a hug|Saeko Convo0 Hug]]
-	[[Greet her with a firm handshake|Saeko Convo0 Handshake]]
-	[[Greet her with a small wave from a distance|Saeko Convo0 Wave]]
+<<Choices	[[Greet her warmly with a hug|Saeko Convo0 Hug]]
+			[[Greet her with a firm handshake|Saeko Convo0 Handshake]]
+			[[Greet her with a small wave from a distance|Saeko Convo0 Wave]]
 >>
 
 :: Saeko Convo0 Hug
@@ -2566,9 +2519,8 @@ She speaks matter of factly, as if she were simply stating the sky was blue.
 
 <<say $companionSaeko>>But I'm also glad to join you on this expedition. I think there will be some great opportunities down there and I'd like to see how well I can apply my theoretical knowledge.<</say>>
 
-<<ConversationChoices
-	[[Yeah, I'm excited to discover all the magical wonders the Abyss has in store for us!|Saeko Convo0 Magical]]
-	[[Yeah, I'm thrilled to delve into all the mysteries the Abyss holds!|Saeko Convo0 MysteryTour]]
+<<Choices	[[Yeah, I'm excited to discover all the magical wonders the Abyss has in store for us!|Saeko Convo0 Magical]]
+			[[Yeah, I'm thrilled to delve into all the mysteries the Abyss holds!|Saeko Convo0 MysteryTour]]
 >>
 
 :: Saeko Convo0 Magical
@@ -2610,9 +2562,8 @@ Even though you meant it as a joke, you see no sign of her dropping her professi
 
 <<say $companionSaeko>>Glad to meet you as well. I hope we can have a fruitful collaboration in this expedition!<</say>>
 
-<<ConversationChoices
-	[[Very good, what is your ambition for this field expedition?|Saeko Convo0 Ambition]]
-	[[Uh, sorry, I was just joking...|Saeko Convo0 Joking]]
+<<Choices	[[Very good, what is your ambition for this field expedition?|Saeko Convo0 Ambition]]
+			[[Uh, sorry, I was just joking...|Saeko Convo0 Joking]]
 >>
 
 :: Saeko Convo0 Ambition
@@ -2652,9 +2603,8 @@ She looks at you with a rather blank expression, as if she was merely drifting t
 
 <<say $companionSaeko>>Yes, I think that is rather obvious. I'm ready to go when you are. I hope you know what you're doing. <</say>>
 
-<<ConversationChoices
-		[[Uh, of course! So um, what do you think you can contribute to the expedition? |Saeko Convo0 Contribute]]
-		[[Of course! I'll grab the tent, you take the rest of the equipment. Let's go!|Saeko Convo0 Equipment ]]
+<<Choices	[[Uh, of course! So um, what do you think you can contribute to the expedition?|Saeko Convo0 Contribute]]
+			[[Of course! I'll grab the tent, you take the rest of the equipment. Let's go!|Saeko Convo0 Equipment]]
 >>
 
 :: Saeko Convo0 Contribute
@@ -2767,11 +2717,10 @@ Her attempt at a smile is so unnatural that it borders on unsettling.
 If you accept her tests, the soreness and minor cuts she inflicts on you will increase your next 1 travel time by 1 day.
 
 <<if $subdom > 0 >>
-	[[Sure, if it's only minor tests |Saeko Plant Accept]]
+	[[Sure, if it's only minor tests|Saeko Plant Accept]]
 <<else>>
-	<<ConversationChoices
-		[[Sure, if it's only minor tests |Saeko Plant Accept]]
-		[[I think I'll pass on being a lab rat |Saeko Plant Reject]]
+	<<Choices	[[Sure, if it's only minor tests|Saeko Plant Accept]]
+				[[I think I'll pass on being a lab rat|Saeko Plant Reject]]
 >>
 <</if>>
 
@@ -2838,9 +2787,8 @@ You blush, embarrassed.
 <<say $mc>>Can I have it? <</say>>
 <<say $companionSaeko>> There's no need. I'll be the one enforcing it. Otherwise, I have no confidence that the schedule will be implemented correctly. Even a slight deviation could render the whole thing useless. <</say>>
 
-<<ConversationChoices
-[[That sounds a bit too intense. I think I'll manage without it.|Saeko Wetting Denied]]
-[[Okay, sure. If you think it'll prevent any more accidents like that.|Saeko Wetting Accepted]]
+<<Choices	[[That sounds a bit too intense. I think I'll manage without it.|Saeko Wetting Denied]]
+			[[Okay, sure. If you think it'll prevent any more accidents like that.|Saeko Wetting Accepted]]
 >>
 
 :: Saeko Wetting Denied
@@ -2900,10 +2848,9 @@ Saeko meticulously guides you through a comprehensive timetable, detailing every
 <<Update_MC_Speech>>\
 You see your twin sitting down staring into the distance, seemingly lost in thought. You sit down next to <<if $companionTwin.sex=='male'>>him <<else>>her <</if>> also in silence. You have an idea what's on <<if $companionTwin.sex=='male'>>his <<else>>her <</if>>mind because you have also been thinking about it. The moment you want to say something $companionTwin.name speaks up.
 <<say $companionTwin>>You know when I obtained the twin Curse first I was sort of happy, I've sort of always wondered what it would be like to have a twin. But very quickly afterwards I honestly got scared that you might replace me or something. Is that weird?<</say>>
-<<ConversationChoices
-	[[I'm still kind of scared that you will replace me at some point...|Twin Convo1 Scared]]
-	[[Honestly, I've never have had that feeling, so no worries.|Twin Convo1 Lie]]
-	[[Yeah I had the same thing at first, but lately I'm more often happy that we found eachother in the end|Twin Convo1 Happy]]
+<<Choices	[[I'm still kind of scared that you will replace me at some point...|Twin Convo1 Scared]]
+			[[Honestly, I've never have had that feeling, so no worries.|Twin Convo1 Lie]]
+			[[Yeah I had the same thing at first, but lately I'm more often happy that we found eachother in the end|Twin Convo1 Happy]]
 >>
 
 :: Twin Convo1 Scared
@@ -2961,9 +2908,7 @@ A familiar surge of arousal washes over you, and as you scan the room for a pote
 
 [[Maybe, maybe not. But you're not getting it on with your twin, real or not|Party overview]]
 <<if !(($companionTwin.curses.some(e => e.name === "Absolute Pregnancy") && $playerCurses.some(e => e.name === "Absolute Birth Control")) || ($companionTwin.curses.some(e => e.name === "Absolute Birth Control") && $playerCurses.some(e => e.name === "Absolute Pregnancy")))>>\
-<<ConversationChoices
-[[A proposition never hurt anyone|Twin Sex]]
->>
+<<Choices [[A proposition never hurt anyone|Twin Sex]]>>
 <</if>>
 
 :: Twin Sex
@@ -3513,14 +3458,11 @@ Instantly, you grasp the implications of her words. A flurry of thoughts race th
 <<if $pregTwinMC == true>>\
 	<<say $mc>> And you're sure it's mine?<</say>>
 	<<say $companionTwin>> Yes, I'm damn sure it's yours. What the hell are you even implying?<</say>>
-	<<ConversationChoices
-		[[Well, this is going to be a problem.|Twin Pregnant Negative]]
-		[[Oh my god, this is the best news I've heard all day!|Twin Pregnant Positive]]
+	<<Choices	[[Well, this is going to be a problem.|Twin Pregnant Negative]]
+				[[Oh my god, this is the best news I've heard all day!|Twin Pregnant Positive]]
 	>>
 <<else>>
-	<<ConversationChoices
-		[[Let's not panic. It's not ideal, but we'll figure it out, don't worry.|Twin Pregnant Neutral]]
-	>>
+	<<Choices [[Let's not panic. It's not ideal, but we'll figure it out, don't worry.|Twin Pregnant Neutral]]>>
 <</if>>
 
 :: Twin Pregnant Negative
@@ -4189,11 +4131,10 @@ You start to pry out the Omoikane Circuit from your phone, causing it to immedia
 :: AI ConvoL1
 <<Update_MC_Speech>>\
 <<say $companionAI>>How can I help you today?<</say>>
-<<ConversationChoices
-	[[Can you give me some more information on threats in this layer?|AI ConvoL1 Threats]]
-	[[Can you give me some more information on the Relics in this layer?|AI ConvoL1 Relics]]
-	[[Can you give me some more information on the Curses in this layer?|AI ConvoL1 Curses]]
-	[[Can you give me some more information on the wonder in this layer?|AI ConvoL1 Wonder]]
+<<Choices	[[Can you give me some more information on threats in this layer?|AI ConvoL1 Threats]]
+			[[Can you give me some more information on the Relics in this layer?|AI ConvoL1 Relics]]
+			[[Can you give me some more information on the Curses in this layer?|AI ConvoL1 Curses]]
+			[[Can you give me some more information on the wonder in this layer?|AI ConvoL1 Wonder]]
 >>
 
 
@@ -4267,11 +4208,10 @@ You start to pry out the Omoikane Circuit from your phone, causing it to immedia
 :: AI ConvoL2
 <<Update_MC_Speech>>\
 <<say $companionAI>>How can I help you today?<</say>>
-<<ConversationChoices
-	[[Can you give me some more information on threats in this layer?|AI ConvoL2 Threats]]
-	[[Can you give me some more information on the Relics in this layer?|AI ConvoL2 Relics]]
-	[[Can you give me some more information on the Curses in this layer?|AI ConvoL2 Curses]]
-	[[Can you give me some more information on the wonder in this layer?|AI ConvoL2 Wonder]]
+<<Choices	[[Can you give me some more information on threats in this layer?|AI ConvoL2 Threats]]
+			[[Can you give me some more information on the Relics in this layer?|AI ConvoL2 Relics]]
+			[[Can you give me some more information on the Curses in this layer?|AI ConvoL2 Curses]]
+			[[Can you give me some more information on the wonder in this layer?|AI ConvoL2 Wonder]]
 >>
 
 :: AI ConvoL2 Threats
@@ -4474,11 +4414,10 @@ But unfortunately, this is no longer your story, it's hers.
 :: AI ConvoL3
 <<Update_MC_Speech>>\
 <<say $companionAI>>How can I help you today?<</say>>
-<<ConversationChoices
-	[[Can you give me some more information on threats in this layer?|AI ConvoL3 Threats]]
-	[[Can you give me some more information on the Relics in this layer?|AI ConvoL3 Relics]]
-	[[Can you give me some more information on the Curses in this layer?|AI ConvoL3 Curses]]
-	[[Can you give me some more information on the wonder in this layer?|AI ConvoL3 Wonder]]
+<<Choices	[[Can you give me some more information on threats in this layer?|AI ConvoL3 Threats]]
+			[[Can you give me some more information on the Relics in this layer?|AI ConvoL3 Relics]]
+			[[Can you give me some more information on the Curses in this layer?|AI ConvoL3 Curses]]
+			[[Can you give me some more information on the wonder in this layer?|AI ConvoL3 Wonder]]
 >>
 
 :: AI ConvoL3 Threats

--- a/src/companionSetup.twee
+++ b/src/companionSetup.twee
@@ -969,8 +969,8 @@ Overall the world would probably see <<if _companion.sex=="male">>him<<else>>her
 <<include "CompanionDescription">>
 [[Return|$menuReturn]]
 
-:: ConversationChoices [widget nobr]
-<<widget "ConversationChoices">>
+:: Choices [widget nobr]
+<<widget "Choices">>
 	<div class="conversation-choices">
 		<<for _link range _args>>
 			<<capture _link>>

--- a/src/surface.twee
+++ b/src/surface.twee
@@ -1086,9 +1086,7 @@ While your mind never changed, and you always yearned to once again have control
 
 <<say $creepydoll>> AAAAAAAAAAAAAAAAHHHHHHHHHHHHHHHHHHHHH<</say>>
 A sudden sensation of intense pain surges through your body, making you double over. It feels as if your body has been engulfed by flames that sear each and every nerve in your skin, while a thousand needles are pushed deeper into you, all at once. Almost immediately, it becomes too much for you and you pass out.
-<<ConversationChoices
-	[[Darkness...|Doll event continued]]
->>
+<<Choices [[Darkness...|Doll event continued]]>>
 
 :: Doll event continued[surface]
 You wake up in a corner of the Relic Workshop with the doll clutched tightly in your arms, pressed against your chest. It gives a pleasantly warm feeling, comforting you after your terrifying experience before you passed out. Somehow, as you hug the doll, you feel calm and satisfied for at least a moment. When you look down and check your skin, everything seems alright, no scars or burns anywhere. Luckily it seems that your body has not actually been torn apart, instead it was either a psychic attack of some sort or a vision of a possible future. Whatever the case, perhaps its better to not proceed with the plan to cut open the doll.
@@ -1136,9 +1134,8 @@ As you run, you trip over something that somehow didn't seem to fully be there. 
 <<say $creepydoll>> Because it makes us look like cute twins!<</say>>
 <<say $mc>> I... I don't want this. Or at least, I think I don't?<</say>>
 <<say $creepydoll>> Oh somebody is grumpy, so why don't you take a nap, and then we'll decide later?<</say>>
-<<ConversationChoices
-	[[Don't risk the dolls ire and take the nap|DollWarning nap]]
-	[[Insist you want to leave NOW!|DollWarning leave]]
+<<Choices	[[Don't risk the dolls ire and take the nap|DollWarning nap]]
+			[[Insist you want to leave NOW!|DollWarning leave]]
 >>
 
 

--- a/t3lt.twee-config.yml
+++ b/t3lt.twee-config.yml
@@ -32,14 +32,14 @@ sugarcube-2:
       name: checkTime
       parameters:
         - ""
+    Choices:
+      name: Choices
+      parameters:
+        - "link |+ ...link"
     CloneSelf:
       name: CloneSelf
       parameters:
         - ""
-    ConversationChoices:
-      name: ConversationChoices
-      parameters:
-        - "link |+ ...link"
     createGolem:
       name: createGolem
       parameters:


### PR DESCRIPTION
Having a newline between the macro name and the first choice seems to break the syntax highlighting provided by the Twee 3 Language Tools extension. This ends up making `companionConversations.twee` pretty unreadable. I've filed a bug on the extension repo (not sure I should link to it here - who knows how they feel about adult games), but I don't know how long it'll take to fix so here's a workaround.

This change:
* Replaces the newline and any following tabs of identation before the first choice with a single tab.
* Indents subsequent choices the same way.
* Renames `ConversationChoices` to simply `Choices` to reduce the required amount of indentation for subsequent choices. A bit ambiguous, but I doubt it'll be an issue in practice.

For the few instances with only a single choice, I moved everything onto the same line. I also fixed up a few instances of trailing whitespace inside the links.