### PR TITLE
Fix age correction widget and fountain of youth

### DIFF
--- a/src/companionSetup.twee
+++ b/src/companionSetup.twee
@@ -750,7 +750,7 @@ The rest of the world just sees you as a pair of twins who did everything togeth
 <<nobr>>
 <<if _companion.name=="Golem">>The golem, which is controlled by your summoned specter,<<else>>_companion.name<</if>> is a _companion.sex <<PerceivedRace _companion>>.
 <<if _companion.sex=="male">>He<<else>>She<</if>> is <<set _meters = (_companion.heightCor > 100)>><<print (Math.round(_companion.heightCor)*(_meters ? 0.01 : 1)).toFixed(_meters ? 2 : 1) + (_meters ? " meters" : " cm")>> tall 
-and  _companion.age years old<<if _companion.age != Math.round(_companion.appAge)>>, but <<if _companion.sex=="male">>he<<else>>she<</if>> appears to be <<print Math.round(_companion.appAge)>> years old<<else>>.<</if>>
+and _companion.realAge years old<<if _companion.realAge != _companion.appAge>>, but <<if _companion.sex=="male">>he<<else>>she<</if>> appears to be _companion.appAge years old<</if>>.
 
 <br><br>
 <<if _companion.sex=="male">>His<<else>>Her<</if>> hair color is _companion.hair.<br>

--- a/src/global.twee
+++ b/src/global.twee
@@ -397,7 +397,7 @@ You have $app.skinColor colored $app.skinType skin.<<if $app.skinType.includes("
 <br>
 You are <<BodyHeightText>> tall.<br>
 You have $app.ears ears.<br>
-You are $app.age years old<<if $app.age != Math.round($app.appAge)>>, but you appear to be <<print Math.round($app.appAge)>> years old<</if>><<if $eternalYouth < 9999>> and you will never appear to be any older due to your biological immortality granted by the Fountain of Youth<</if>>.
+You are $app.realAge years old<<if $app.realAge != $app.appAge>>, but you appear to be $app.appAge years old<</if>><<if $eternalYouth < 9999>> and you will never appear to be any older due to your biological immortality granted by the Fountain of Youth<</if>>.
 <br><br>
 <<if $DaedalusEquip==true>> You appear to have two $relic73.variation wings sprouting from your back. However, in reality, this is the Daedalus Mechanism.<br><br><</if>>
 <<if $swapComp > -1>>

--- a/src/layer8.twee
+++ b/src/layer8.twee
@@ -198,7 +198,7 @@ Do you want to visit Boundless Space to swap break the spatial limits of a Relic
 :: Layer8 Youth [layer8]
 
 [img[setup.ImagePath+'Wonders/fountainofyouth.png']]
-<<set $eternalYouth == $time>>\
+<<set $eternalYouth = $time>>\
 The dizzying path through the abstract architectural maze of the eighth layer has led you to an unusually serene pocket. Entering the colorless expanse, you're immediately drawn towards the marble construct at its heart. As you approach, the Fountain of Youth looms larger, the regal marble lion atop it frozen in a moment of silent fury, spewing forth a stream of water that twinkles with an otherworldly glow.
 
 As you approach the fountain, the air seems to grow cooler, and a faintly sweet aroma teases your senses—an inexplicable scent that evokes memories of the first dew-kissed morning of spring, the intoxicating freshness of a rain-washed world. A tingling curiosity spurs you to reach out, to dip your fingers into the ever-flowing water. The sensation is like immersing your hand into liquid silk—cool, smooth, and inviting.

--- a/src/script.js
+++ b/src/script.js
@@ -3,10 +3,10 @@ Config.navigation.override = function (destPassage) {
 	if (StoryVar.brokerUsed == 1 && StoryVar.corruption < 0) {
 		return "BrokerEnd";
 	}
-	if (StoryVar.ownedRelics.some(e => e.name === "Creepy Doll") && StoryVar.app.appAge < 10 && StoryVar.dollevent2==false){
+	if (StoryVar.ownedRelics.some(e => e.name === "Creepy Doll") && isFinite(StoryVar.app.appAge) && StoryVar.app.appAge < 10 && StoryVar.dollevent2==false){
 		return "DollWarning";
 	}
-	if (StoryVar.ownedRelics.some(e => e.name === "Creepy Doll") && StoryVar.app.appAge < 4 && StoryVar.dollevent2==true){
+	if (StoryVar.ownedRelics.some(e => e.name === "Creepy Doll") && isFinite(StoryVar.app.appAge) && StoryVar.app.appAge < 4 && StoryVar.dollevent2==true){
 		return "DollEnd";
 	}
 	if (StoryVar.app.age < 18) {
@@ -67,7 +67,7 @@ Config.navigation.override = function (destPassage) {
 		StoryVar.lastBirthTwin = StoryVar.time
 		return "Labor Scene Companion";
 	}
-	if (StoryVar.app.appAge < 3 && StoryVar.app.age > 17) {
+	if (isFinite(StoryVar.app.appAge) && StoryVar.app.appAge < 3 && StoryVar.app.age > 17) {
 		return "AgeEnd";
 	}
 	if (StoryVar.companionMaru.affec < -9 && !StoryVar.companionMaru.swap && StoryVar.hiredCompanions.some(e => e.name === "Maru")) {

--- a/src/widgets.twee
+++ b/src/widgets.twee
@@ -646,89 +646,87 @@
 
 :: Age widget [widget nobr]
 <<widget "AgeCorrected">>
-
-<<for _i=0; _i<=$hiredCompanions.length; _i++>>
-	<<if _i==$hiredCompanions.length>>
-		<<set _handle = $app>>
-		<<set _AgeLog = $AgeLog>>
-	<<else>>
-		<<if $hiredCompanions[_i].name == $companionTwin.name >>
-			<<set _tempName = "Twin">>
-		<<else>>
-			<<set _tempName = $hiredCompanions[_i].name>>
-		<</if>>
-		<<print "<<set _handle  = $companion"+ _tempName +" >>">>
-		<<print "<<set _AgeLog  = $AgeLog"+ _tempName +" >>">>
-	<</if>>
-
-	<<set _handle.appAge = _handle.age>>
-	<<set _thresholdDay = 0>>
-	<<for _ageEvent range _AgeLog>>
- 
-		<<if _ageEvent.name == "Age Reduction A" >>
-			<<if _handle.appAge <= 22>>
-				<<set _handle.appAge -= 2>>
-			<<else>>
-				<<set _handle.Age += _ageEvent.variation/365.24>>
-				<<if _i== $hiredCompanions.length>><<set _thresholdDay = _ageEvent.variation>><</if>>/*temp fix to only correct mc age */
-				<<set _handle.appAge = 20>>
-			<</if>>
-		<</if>>
-
-		<<if _ageEvent.name == "Age Reduction B" >>
-			<<if _handle.appAge <= 23>>
-				<<set _handle.appAge -= 3>>
-			<<else>>
-				<<set _handle.Age += _ageEvent.variation/365.24>>
-				<<if _i== $hiredCompanions.length>><<set _thresholdDay = _ageEvent.variation>><</if>>/*temp fix to only correct mc age */
-				<<set _handle.appAge = 20>>
-			<</if>>
-		<</if>>
-
-
-		<<if _ageEvent.name == "Age Reduction C" >>
-			<<if _handle.appAge <= 24>>
-				<<set _handle.appAge -= 4>>
-			<<else>>
-				<<set _handle.Age += _ageEvent.variation/365.24>>
-				<<if _i== $hiredCompanions.length>><<set _thresholdDay = _ageEvent.variation>><</if>>/*temp fix to only correct mc age */
-				<<set _handle.appAge = 20>>
-			<</if>>
-		<</if>>
-
-		<<if _ageEvent.name == "1 Day Food Forage Minor Impact" >>
-			<<set _handle.appAge -= 0.08>>
-		<</if>>
-
-		<<if _ageEvent.name == "1 Day Food Forage Major Impact" >>
-			<<set _handle.appAge -= 1>>
-		<</if>>
-
-		<<if _ageEvent.name == "Doll Transformation">>
-			<<if _handle.appAge>19>>
-				<<set _handle.Age += _ageEvent.variation/365.24>>
-				<<set _thresholdDay = _ageEvent.variation>>
-				<<set _handle.appAge = 17>>
-			<<else>>
-				<<set _handle.appAge -= 2>>
-			<</if>>
-		<</if>>
-
+<<capture _handle, _AgeLog>>
+	<<for _handle range $hiredCompanions>>
+		<<set _tempName = _handle.name != $companionTwin.name ? _handle.name : "Twin">>
+		<<set _AgeLog = State.variables["AgeLog" + (_handle.name != $companionTwin.name ? _handle.name : "Twin")]>>
+		<<include "CorrectAge">>
+		/* Update the companion variables to match the $hiredCompanions elements. */
+		<<set State.variables["companion" + _tempName] = _handle>>
 	<</for>>
-	<<if $eternalYouth < $time>>
-		<<set _handle.Age +=($eternalYouth-_thresholdDay)/365.24>>
-		<<set _handle.appAge +=($eternalYouth-_thresholdDay)/365.24>>
-	<<else>>
-		<<set _handle.Age +=($time-_thresholdDay)/365.24>>
-		<<set _handle.appAge +=($time-_thresholdDay)/365.24>>
-	<</if>>
-
-	<<if _handle.appAge < settings.appAgeControl>>
-		<<set _handle.appAge = settings.appAgeControl>>
-	<</if>>
-<</for>>
-
+	<<set _handle = $app>>
+	<<set _AgeLog = $AgeLog>>
+	<<include "CorrectAge">>
+<</capture>>
 <</widget>>
+
+:: CorrectAge [nobr]
+<<capture _oldTime, _eventAge, _ageEvent, _newTime>>
+	<<set _oldTime = 0>>
+	<<set _eventAge = _handle.age>>
+	<<for _ageEvent range _AgeLog>>
+		/* If this is an age event with a recorded time, add the elapsed time to the subject's age. */
+		<<if _ageEvent.variation>>
+			<<set _newTime = _ageEvent.variation>>
+			/* If we're adjusting the MC and MC has eternal youth, only age them until they drank from the fountain. */
+			<<if _handle === $app && _newTime > $eternalYouth>>
+				<<set _newTime = $eternalYouth>>
+			<</if>>
+			<<if _oldTime < _newTime>>
+				<<set _eventAge += (_newTime - _oldTime) / 365.2425>>
+			<</if>>
+			<<set _oldTime = _ageEvent.variation>>
+		<</if>>
+		/* Now apply the effect of the age event. */
+		<<switch _ageEvent.name>>
+			<<case "Age Reduction A">>
+				<<if _eventAge > 22>>
+					<<set _eventAge = 20>>
+				<<else>>
+					<<set _eventAge -= 2>>
+				<</if>>
+			<<case "Age Reduction B">>
+				<<if _eventAge > 23>>
+					<<set _eventAge = 20>>
+				<<else>>
+					<<set _eventAge -= 3>>
+				<</if>>
+			<<case "Age Reduction C">>
+				<<if _eventAge > 24>>
+					<<set _eventAge = 20>>
+				<<else>>
+					<<set _eventAge -= 4>>
+				<</if>>
+			<<case "Doll Transformation">>
+				<<if _eventAge > 19>>
+					<<set _eventAge = 17>>
+				<<else>>
+					<<set _eventAge -= 2>>
+				<</if>>
+			<<case "1 Day Food Forage Minor Impact">>
+				<<set _eventAge -= 0.08>>
+			<<case "1 Day Food Forage Major Impact">>
+				<<set _eventAge -= 1>>
+		<</switch>>
+	<</for>>
+
+	/* Add any additional elapsed time to the subject's age. */
+	<<set _newTime = $time>>
+	/* If we're adjusting the MC and MC has eternal youth, only age them until they drank from the fountain. */
+	<<if _handle === $app && _newTime > $eternalYouth>>
+		<<set _newTime = $eternalYouth>>
+	<</if>>
+	<<if _oldTime < _newTime>>
+		<<set _eventAge += (_newTime - _oldTime) / 365.2425>>
+	<</if>>
+
+	/* Update the subject's apparent age. */
+	<<set _handle.appAge = Math.round(_eventAge)>>
+
+	/* Also set the subject's real age depending on the elapsed time. */
+	<<set _handle.realAge = Math.round(_handle.age + _newTime / 365.2425)>>
+<</capture>>
+
 
 :: Libido widget [widget nobr]
 <<widget "LibidoCorrected">>


### PR DESCRIPTION
The age correction widget had a bunch of issues. Of particular note:
* It was adjusting property `Age`, which is not used anywhere (it was probably trying to adjust `age`, but that's wrong too).
* It was adding all the time from the start of the game until the moment each curse is acquired (instead of using the intervals between curse acquisitions).
* It wasn't updating the `$companion` variables, so once object identity is lost (after loading a save, presumably) the calculated value didn't actually affect uses like `$companionMaru.appAge` like in the `CompanionDescription` passage.

This change:
* Fixes the above issues.
* Splits the inner logic of the widget out into a passage so we don't need to special-case the MC (other than for the fountain of youth).
* Adds new property `realAge`, since `age` can't really be adjusted on the fly, and uses it in the 2 places that care (personal description and companion description).
* Moves the rounding logic into the passage itself (since we never want the unrounded value). Maybe we can add a widget for "and n months" at some point, but for now this is simpler.
* Fixes the activation of the fountain of youth by changing `==` to `=` (I'm pretty sure it didn't work before, unless there's some SugarCube exception that interprets `==` in `<<set>>` as assignment).

There are still a few weird things:
* Transferring an age reduction curse to a companion doesn't update the time, so won't take their aging up to that point into account (only matters if you get the curse, wait a long time and then transfer it).
* Similarly with copying, both curses share the same timestamp.
* Age Regression curses still work after you use the fountain of youth (I figured that this was intended, but the text doesn't make it clear), although you now correctly stop aging after drinking from it for the purpose of each curse's age check.