### PR TITLE
Maintain object identity between companion variables

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -93,6 +93,27 @@ Config.navigation.override = function (destPassage) {
 
 Config.history.maxStates = 20;
 
+$(document).on(':passagestart', () => {
+	// Get a reference to the active story variables store.
+	const vars = variables();
+	// Get name of twin so we don't have to look it up each time.
+	const twinName = vars.companionTwin.name;
+	// Restore object identity between $companions array and $companionName variables.
+	const companions = vars.companions;
+	for (const [i, companion] of companions.entries()) {
+		const name = companion.name != twinName ? companion.name : "Twin";
+		companions[i] = vars[`companion${name}`];
+	}
+	// Restore object identity between $hiredCompanions array and $companionName variables.
+	const hiredCompanions = vars.hiredCompanions;
+	for (const [i, hiredCompanion] of hiredCompanions.entries()) {
+		const name = hiredCompanion.name != twinName ? hiredCompanion.name : "Twin";
+		hiredCompanions[i] = vars[`companion${name}`];
+	}
+	// Restore object identity between $app.curses and $playerCurses.
+	vars.app.curses = vars.playerCurses;	
+});
+
 predisplay["Menu Return"] = function (taskName) {
 	if (! tags().contains("noreturn")) {
 		State.variables.menuReturn = passage();

--- a/src/widgets.twee
+++ b/src/widgets.twee
@@ -651,8 +651,6 @@
 		<<set _tempName = _handle.name != $companionTwin.name ? _handle.name : "Twin">>
 		<<set _AgeLog = State.variables["AgeLog" + (_handle.name != $companionTwin.name ? _handle.name : "Twin")]>>
 		<<include "CorrectAge">>
-		/* Update the companion variables to match the $hiredCompanions elements. */
-		<<set State.variables["companion" + _tempName] = _handle>>
 	<</for>>
 	<<set _handle = $app>>
 	<<set _AgeLog = $AgeLog>>
@@ -2456,7 +2454,6 @@
 
 :: Carry adjustment widget [widget nobr]
 <<widget "CarryAdjust">>
-<<set $app.curses = $playerCurses>>/*temporary fix to prevent having to replace all instances */
 <<Equipment>>
 <<statUpdateCompanions>>
 <<Handicap>>


### PR DESCRIPTION
This adds an event listener on the `:passagestart` event that restores/maintains object identity between the `$companion` array, the `$companionName` variables and the `$hiredCompanions` array. With this, updating one place should always update them all (in theory it also makes a lot of what `<<statUpdateCompanions>>` does unnecessary, but I didn't mess with that yet).

I removed the code that tried to synchronize the variables in `<<AgeCorrected>>` - my apologies for the problems it caused. I also moved the `$app.curses = $playerCurses` assignment from `<<CarryAdjust>>` over to the event listener since it should work for everything.

@Ilyza91 This could certainly use some more testing than what I've done so far. I'll try to test more thoroughly but could you check if this fixes the Inanis Ego NaN?