### PR TITLE
Fix a typo in the log variable logic for Steady Shrine

### DIFF
--- a/src/layer4.twee
+++ b/src/layer4.twee
@@ -802,7 +802,7 @@ Which Curse would you like to transfer to your willing companion? It can't be to
 					<<link "Choose" "Layer4 Steady1a">>
 						<<set _companion.curses.push(_curse)>>
 
-						<<set _logName = _curse.type + "Log2" + _tempName>>
+						<<set _logName = _curse.type + "Log" + _tempName>>
 						<<set _log = State.variables[_logName]>>
 						<<if _log>><<set _log.push(_curse)>><</if>>
 


### PR DESCRIPTION
Fixes the companion curse log update logic for Steady Shrine. Not sure how this slipped in, I definitely tested it but this is how it was committed...