### PR TITLE
Add CollectRelic macro and fix displayed relic costs a bit

### DIFF
--- a/src/layer1.twee
+++ b/src/layer1.twee
@@ -489,8 +489,7 @@ Choose the Curse you wish to remove:
 
 
 :: Pick up the Star Compass [layer1]
-<<set $ownedRelics.push($relic1)>><<set $corruption -= ($relic1.corr - $corRed)>>\
-[img[setup.ImagePath + $relic1.pic]]
+<<CollectRelic $relic1>>
 
 The journey to this Relic takes you over undulating hills covered in grasses which sway gently in the wind. Night falls, but you press onwards, knowing that you're almost at your destination. It's peaceful out here, and the stars are out, giving you just enough light to keep moving.
 
@@ -505,14 +504,7 @@ This may not be very useful in most circumstances, but perhaps at some point in 
 
 
 :: Pick up the Rømer Stones [layer1]
-<<nobr>>
-
-<<set $ownedRelics.push($relic2)>>
-<<set $corruption -= ($relic2.corr - $corRed)>>
-<<set $tempTime = $relic2.time>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-<</nobr>>\
-[img[setup.ImagePath + $relic2.pic]]
+<<CollectRelic $relic2>>
 
 The Relic you're looking for is in the deeper parts of the layer. The rain from countless clouds runs down in tributaries, and eventually into rivers. Down this far there are many ponds and lakes that slowly flow into rivers and then deeper into the next layer of the Abyss. Some denser vegetation and lots of fungi slow your progress, but they make the journey quite beautiful.
 
@@ -529,8 +521,7 @@ While they aren't useful on their own, perhaps you can take these stones back to
 
 
 :: Pick up the Creepy Doll [layer1]
-<<set $ownedRelics.push($relic3)>><<set $corruption -= ($relic3.corr - $corRed)>>\
-[img[setup.ImagePath + $relic3.pic]]
+<<CollectRelic $relic3>>
 
 <<if $app.appAge > 13>><<if $hiredCompanions.some(e => e.name === "Maru")>>
 As you and Maru search for an interesting doll you've heard about, you come across the decaying jusk of a house. It looks as if someone once lived here, but it has been long since abandoned to be degraded by the forces of the Abyss.
@@ -589,8 +580,7 @@ Recognizing the doll's mysterious properties and potential value, you overcome y
 
 
 :: Pick up the Giddy Reaper [layer1]
-<<set $ownedRelics.push($relic4)>><<set $corruption -= ($relic4.corr - $corRed)>>\
-[img[setup.ImagePath + $relic4.pic]]
+<<CollectRelic $relic4>>
 
 The gradual slopes and sweeping grasslands of this layer of the Abyss are occassionally broken up by small streams and clumps of more robust vegetation. Your quest for this latest Relic sends you across the landscape until you reach a particularly verdant thicket. No paths exist through it, but many shrieks and squaks from birds inhabiting the many branches of the short trees here greet you as you find a space between trees and slowly make your way inside.
 
@@ -609,13 +599,7 @@ On the way back, you decide to test your prize, and you swipe it through some of
 
 
 :: Pick up the Silk Twister [layer1]
-<<nobr>>
-<<set $ownedRelics.push($relic5)>>
-<<set $corruption -= ($relic5.corr - $corRed)>>
-<<set $tempTime = $relic5.time>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-<</nobr>>\
-[img[setup.ImagePath + $relic5.pic]]
+<<CollectRelic $relic5>>
 
 You set out after a Relic that's a bit higher up in a nearby canyon. The vegetation along your path isn't too thick, but you soon find yourself traveling along a small river. Miasma laden mist clings to the surface of the water, thrown up by small rapids. There are some large trees along the watercourse, and above it are flocks of birds that are either native to this layer of the Abyss, or that have flown down here. Your path takes you up a tributary into the river, and you move through dappled light from a low canopy.
 
@@ -632,8 +616,7 @@ The creature has no interest in preying upon things that do not fly, an odd pecu
 
 
 :: Pick up the Vertebra Key [layer1]
-<<set $ownedRelics.push($relic6)>><<set $corruption -= ($relic6.corr - $corRed)>>\
-[img[setup.ImagePath + $relic6.pic]]
+<<CollectRelic $relic6>>
 
 The Relic you're pursuing takes you off the beaten path. You leave the plains and rivers behind, climbing down a rocky ravine. You struggle as you climb down narrow ledges, large boulders, and dusty rocks. Everything is dry here, compared to the verdant sanctuary that is the rest of the layer.
 
@@ -656,8 +639,7 @@ Something clicks in your brain, and you have a sudden instinct. This is your cel
 
 
 :: Pick up the Chain of Lorelei [layer1]
-<<set $ownedRelics.push($relic7)>><<set $corruption -= ($relic7.corr - $corRed)>>\
-[img[setup.ImagePath + $relic7.pic]]
+<<CollectRelic $relic7>>
 
 Long-term erosion is evident throughout this layer of the Abyss. Yet in every landscape, some things resist erosion better than others. To the southeast there is a butte that rises well above the surrounding landscape. You journey towards it. Far to the north you can see a crimson kite dragon briefly arc above the horizon before gliding back down below it.
 
@@ -680,8 +662,7 @@ You can wear this choker to change your voice, which may influence how some peop
 
 
 :: Pick up the Hive Tassel [layer1]
-<<set $ownedRelics.push($relic8)>><<set $corruption -= Math.max(($relic8.corr - $corRed), 0)>>\
-[img[setup.ImagePath + $relic8.pic]]
+<<CollectRelic $relic8>>
 
 As you wander through a grove of trees in search of the mysterious tassel that's somehow connected to the bees, you notice something new. A constant buzzing surrounds you all at once, as if you were swallowed by a swarm of bees. And in fact, when you glance at the trees, you can see that their bark is now impossible to make out, instead covered in layers of yellow and black insects moving over each other.
 
@@ -698,13 +679,7 @@ As you investigate the new sound, you spot a tree with a few branches vibrating 
 
 
 :: Pick up the Smitten Mitt [layer1]
-<<nobr>>
-<<set $ownedRelics.push($relic9)>>
-<<set $corruption -= ($relic9.corr - $corRed)>>
-<<set $tempTime = $relic9.time>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-<</nobr>>\
-[img[setup.ImagePath + $relic9.pic]]
+<<CollectRelic $relic9>>
 
 There are many beautiful things in this layer of the Abyss, but also lots of places that are slightly monotonous. Your Relic expedition sets you out through vast grasslands. In places the grasses are sparse and intermixed with other types of vegetation. In other places they rise high, thick, and dominant.
 

--- a/src/layer2.twee
+++ b/src/layer2.twee
@@ -1136,8 +1136,7 @@ Despite the anxiety and uncertainty that grips you, you press on, trying to focu
 
 
 :: Pick up the Firmament Pigment [layer2]
-<<set $ownedRelics.push($relic10)>><<set $corruption -= ($relic10.corr - $corRed)>>\
-[img[setup.ImagePath + $relic10.pic]]
+<<CollectRelic $relic10>>
 
 After many hours of trudging through the second layer of the Abyss, you feel a change in the atmosphere. A notable quietness falls upon the dense thicket, only broken by the pitter-patter of water droplets falling from the canopy above. You pause, taking a moment to wipe the dampness from your forehead. As you straighten, your gaze falls on a vine-wrapped entrance to a cavern, nestled snugly in the base of an enormous tree. The cavern, made visible by a stray beam of light breaking through the thick foliage, promises a departure from the oppressive density of the jungle.
 
@@ -1156,13 +1155,7 @@ Suddenly, the whole cavern is bathed in starlight, as if you've brought the heav
 
 
 :: Pick up the Pearly Gates [layer2]
-<<nobr>>
-<<set $ownedRelics.push($relic11)>>
-<<set $corruption -= ($relic11.corr - $corRed)>>
-<<set $tempTime = $relic11.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic11.pic]]
-<</nobr>>
+<<CollectRelic $relic11>>
 
 The thorny path ahead of you is shadowed, sunlight filtering down through the thick overhead foliage in small, scattered patches. It seems as though the jungle pulsates with a rhythm of its own, a chorus of croaks, chirps, and distant growls setting a primeval symphony. The path narrows even further and the undergrowth gives way to a large, formidable tree, its bark weathered and gnarled with time. Puzzlingly, a natural archway is formed by the tree's roots, reminiscent of a gateway into another world.
 
@@ -1181,13 +1174,7 @@ Pulling away from the now silent tree gateway, you embark back on your journey, 
 
 
 :: Pick up the World Stone [layer2]
-<<nobr>>
-<<set $ownedRelics.push($relic12)>>
-<<set $corruption -= ($relic12.corr - $corRed)>>
-<<set $tempTime = $relic12.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic12.pic]]
-<</nobr>>
+<<CollectRelic $relic12>>
 
 You traverse deeper into the dense labyrinth of the second layer of the Abyss. Your heart pounds, the rhythmic beat echoed by the symphony of raindrops cascading from the thicket above.
 
@@ -1210,13 +1197,7 @@ You can try working out with this Relic. It can both improve your muscle tone an
 
 
 :: Pick up the Forest's Gift [layer2]
-<<nobr>>
-<<set $ownedRelics.push($relic13)>>
-<<set $corruption -= ($relic13.corr - $corRed)>>
-<<set $tempTime = $relic13.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic13.pic]]
-<</nobr>>
+<<CollectRelic $relic13>>
 
 You descend deeper into the wild, verdant undergrowth of the second layer of the Abyss. Thick bramble of gnarled trunks and tangled vines are slick with the constant drizzle from above. Large eyes blink at you from within the darkness of the foliage, the Abyss's curious critters observing your progress with cautious intrigue.
 
@@ -1239,13 +1220,7 @@ The beast seems to pause, its eyes softening ever so slightly. Slowly, it steps 
 
 
 :: Pick up the Harmless Harmony [layer2]
-<<nobr>>
-<<set $ownedRelics.push($relic14)>>
-<<set $corruption -= ($relic14.corr - $corRed)>>
-<<set $tempTime = $relic14.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic14.pic]]
-<</nobr>>
+<<CollectRelic $relic14>>
 
 As you cautiously tread through the eerie, dense foliage, the ambient sounds of this enchanted forest echo around you, an orchestra of nature humming a haunting symphony. This second layer of the Abyss, though treacherous, is full of life. The rhythmic dripping of dew from the flora overhead enhances the ambiance, merging with the symphony of the Abyss to create an unusual melody.
 
@@ -1268,14 +1243,7 @@ With the Relic in your possession, you turn back to the dense path you've just c
 
 
 :: Pick up the Umbra Trident [layer2]
-<<nobr>>
-<<set $ownedRelics.push($relic15)>>
-<<set $corruption -= ($relic15.corr - $corRed)>>
-<<set $tempTime = $relic15.time-$SibylBuff>>
-<<set $dark = true>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic15.pic]]
-<</nobr>>
+<<CollectRelic $relic15>>
 
 Your eyes catch something peculiar ahead; a pocket of unnatural darkness amidst the verdant chaos, a stark contrast to the vibrant hues of the thicket. An unassuming, shadowy cavern lays tucked away, concealed within a gnarled tree's enormous roots.
 
@@ -1300,13 +1268,7 @@ The Umbra Trident - a golden fork, deceptively simple, and yet, brimming with un
 
 
 :: Pick up the Event Horizon [layer2]
-<<nobr>>
-<<set $ownedRelics.push($relic16)>>
-<<set $corruption -= ($relic16.corr - $corRed)>>
-<<set $tempTime = $relic16.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic16.pic]]
-<</nobr>>
+<<CollectRelic $relic16>>
 
 All around you is the incessant dripping of water from the verdant canopy above, the droplets refracting the faint light that filters down from the upper layer. The gentle drizzle slowly intensifies, culminating in a downpour akin to a monsoon shower.
 
@@ -1327,13 +1289,7 @@ As you withdraw your hand, the vapor subsides, and the orchids return to their r
 
 
 :: Pick up the Heart-stealing Stole [layer2]
-<<nobr>>
-<<set $ownedRelics.push($relic17)>>
-<<set $corruption -= ($relic17.corr - $corRed)>>
-<<set $tempTime = $relic17.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic17.pic]]
-<</nobr>>
+<<CollectRelic $relic17>>
 
 The air is thick with the moisture from the never-ending rain of dewdrops, the foliage overhead a vibrant, pulsing canopy of green that blots out any sign of the layer above. The ground underfoot is uneven, pitted with hidden roots and strewn with fallen leaves. With every step, you can feel the mulch yield beneath your weight, a constant reminder of the life that thrives, unseen, under your feet.
 
@@ -1356,13 +1312,7 @@ You may want to start wearing this Relic regularly, it can significantly speed u
 
 
 :: Pick up the Effacing Asperity [layer2]
-<<nobr>>
-<<set $ownedRelics.push($relic18)>>
-<<set $corruption -= ($relic18.corr - $corRed)>>
-<<set $tempTime = $relic18.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic18.pic]]
-<</nobr>>
+<<CollectRelic $relic18>>
 
 You arrive at a peculiar section of the second layer. A great archway of entwined ivy branches marks the entrance, beyond which the vegetation is an even denser, almost impenetrable maze. The undergrowth here is not just dense; it appears unnaturally slick, as if coated in a thick sheen of oil. The typically verdant plant-life glows an iridescent purple, evoking the lilac hue associated with the Effacing Asperity.
 
@@ -1377,13 +1327,7 @@ With a mix of awe and anticipation, you reach out and take hold of the Relic. It
 
 
 :: Pick up the Wholly Ale [layer2]
-<<nobr>>
-<<set $ownedRelics.push($relic19)>>
-<<set $corruption -= ($relic19.corr - $corRed)>>
-<<set $tempTime = $relic19.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic19.pic]]
-<</nobr>>
+<<CollectRelic $relic19>>
 
 As you navigate through the labyrinthine tangle of dense vegetation, the damp dewdrop drizzle that had been your constant companion begins to wane. A hush falls over the Abyss, as if you've entered a sanctum untouched by time. The dense foliage yields to a clearing; an expansive grotto within the heart of the thicket. Sunlight seeping through the canopy above reveals a verdant oasis; the air around you hums with a palpable serenity, untouched by the relentless clamor of the jungle.
 
@@ -1404,13 +1348,7 @@ This grotto, an oasis within the tumultuous Abyss, feels more like a shrine; a s
 
 
 :: Pick up the Memoir Remnant [layer2]
-<<nobr>>
-<<set $ownedRelics.push($relic20)>>
-<<set $corruption -= ($relic20.corr - $corRed)>>
-<<set $tempTime = $relic20.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic20.pic]]
-<</nobr>>
+<<CollectRelic $relic20>>
 
 Through this green maze, you begin to notice peculiar formations in the distance, jutting out and parting the thorny thicket in a manner reminiscent of human construction.
 
@@ -1431,13 +1369,7 @@ This seemingly ordinary bookshelf, now a living testament of your journey, gradu
 
 
 :: Pick up the Gleam Dazer [layer2]
-<<nobr>>
-<<set $ownedRelics.push($relic21)>>
-<<set $corruption -= ($relic21.corr - $corRed)>>
-<<set $tempTime = $relic21.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic21.pic]]
-<</nobr>>
+<<CollectRelic $relic21>>
 
 As you delve further into the second layer of the Abyss, the twisted maze of vegetation towers above you, casting an ever-deepening shadow on the path ahead. The atmosphere is humid, an everlasting mist of dew droplets cascading from the leaves overhead, merging into heavier droplets before pattering onto the emerald carpet below. The air is heavy with the fragrance of moss and wet bark, mingled with the exotic scent of unidentifiable flowers. Each step is slow and deliberate, as navigating this densely woven plant world demands patience and caution.
 

--- a/src/layer3.twee
+++ b/src/layer3.twee
@@ -1439,13 +1439,7 @@ The process lasts two days before the slime finally moves on and allows you to g
 
 
 :: Pick up the Sibyl Blend [layer3]
-<<nobr>>
-<<set $ownedRelics.push($relic22)>>
-<<set $corruption -= ($relic22.corr - $corRed)>>
-<<set $tempTime = $relic22.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic22.pic]]
-<</nobr>>
+<<CollectRelic $relic22>>
 
 You've been wandering these oppressive tunnels for hours, and the darkness, while not total, is becoming monotonous.
 
@@ -1470,13 +1464,7 @@ You can choose to start using this Relic to reduce the travel times to all futur
 
 
 :: Pick up the Pangea Shaker [layer3]
-<<nobr>>
-<<set $ownedRelics.push($relic23)>>
-<<set $corruption -= ($relic23.corr - $corRed)>>
-<<set $tempTime = $relic23.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic23.pic]]
-<</nobr>>
+<<CollectRelic $relic23>>
 
 After what feels like hours, your eye catches a glimpse of an unusual glow, different from the typical bioluminescent life around you. The glow originates from a wide chamber up ahead. As you approach, the glow brightens, revealing a cavernous expanse filled with towering columns of crystal jutting from the ground and ceiling, casting refracted light in all directions, a kaleidoscope of colors, very much like a rainbow.
 
@@ -1493,13 +1481,7 @@ And so, holding the Relic firmly in hand, you continue your descent into the Aby
 
 
 :: Pick up the From Seafoam [layer3]
-<<nobr>>
-<<set $ownedRelics.push($relic24)>>
-<<set $corruption -= ($relic24.corr - $corRed)>>
-<<set $tempTime = $relic24.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic24.pic]]
-<</nobr>>
+<<CollectRelic $relic24>>
 
 As you wander through the caverns of the third layer, a feeling of something different, something special, tugs at your curiosity. Turning a corner, you find yourself facing a wide, domed cavern. It's filled with light, its intensity rivaling that of the noonday sun. Unbelievably, the cavern is filled with water, as clear as crystal, illuminated by bioluminescent organisms. Tiny jellyfish-like creatures hover just beneath the surface, casting a soothing, sea-green glow that illuminates the cavern.
 
@@ -1522,13 +1504,7 @@ You can use this Relic to change your scent so that people perceive you as eithe
 
 
 :: Pick up the Orbweaver [layer3]
-<<nobr>>
-<<set $ownedRelics.push($relic25)>>
-<<set $corruption -= ($relic25.corr - $corRed)>>
-<<set $tempTime = $relic25.time>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic25.pic]]
-<</nobr>>
+<<CollectRelic $relic25>>
 
 Your touch glides over the cold, wet surface of the rocks as you traverse the narrow pathway, the echoes of your footsteps fading in the depth of the Abyss. The eerie glow from the moss and mushrooms casts an alien luminescence on your path, their pale greens and blues seeming out of place in the otherwise desolate darkness. They grow in clusters, their light pulsating like the heartbeat of the Abyss. As you delve deeper, their numbers dwindle, their gentle glow replaced by a starker darkness.
 
@@ -1553,13 +1529,7 @@ This Relic possesses the ability to function as a substitute for a rope. Althoug
 
 
 :: Pick up the Soulseeker [layer3]
-<<nobr>>
-<<set $ownedRelics.push($relic26)>>
-<<set $corruption -= ($relic26.corr - $corRed)>>
-<<set $tempTime = $relic26.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic26.pic]]
-<</nobr>>
+<<CollectRelic $relic26>>
 
 After traversing the network of tunnels for what feels like an eternity, you arrive at a peculiar sight—an enormous, hanging stalactite, its surface smooth and glowing gently. This natural cathedral is steeped in silence, except for the soft dripping of water somewhere in the distance. There's a stillness to this place that feels different, as if the Abyss itself is holding its breath in anticipation.
 
@@ -1576,13 +1546,7 @@ You feel a hum emanating from the rods, a silent resonance matching the rhythm o
 
 
 :: Pick up the Tranquility Knell [layer3]
-<<nobr>>
-<<set $ownedRelics.push($relic27)>>
-<<set $corruption -= ($relic27.corr - $corRed)>>
-<<set $tempTime = $relic27.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic27.pic]]
-<</nobr>>
+<<CollectRelic $relic27>>
 
 The winding, serpentine tunnels echo with the sounds of your footfalls and the faint rustling of unseen organisms. Every so often, the chime of trickling water resonates through the rocky labyrinth, hinting at hidden underground waterways. The path before you dips down sharply into an inky darkness where the moss fails to illuminate.
 
@@ -1607,13 +1571,7 @@ Perhaps this Relic could be useful to evade a predator that senses its prey thro
 
 
 :: Pick up the Lightning Rook [layer3]
-<<nobr>>
-<<set $ownedRelics.push($relic28)>>
-<<set $corruption -= ($relic28.corr - $corRed)>>
-<<set $tempTime = $relic28.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic28.pic]]
-<</nobr>>
+<<CollectRelic $relic28>>
 
 A sense of foreboding surrounds you as you delve deeper into the cavernous labyrinth before you. The stone walls are now adorned with intricate, glass-like formations, their transparent surfaces reflecting the glow of the nearby flora. This new environment resonates with the very essence of your goal - Lightning Rook.
 
@@ -1632,13 +1590,7 @@ When this Relic is kept in close proximity, it can be used to enhance your comba
 
 
 :: Pick up the Acrobatic Accord [layer3]
-<<nobr>>
-<<set $ownedRelics.push($relic29)>>
-<<set $corruption -= ($relic29.corr - $corRed)>>
-<<set $tempTime = $relic29.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic29.pic]]
-<</nobr>>
+<<CollectRelic $relic29>>
 
 Taking a deep breath, you check your scuba gear and adjust the oxygen levels before taking the plunge into the chilly water. The tunnel is darker than the rest of the Abyss, so dark it feels almost tangible, wrapping around you like a tangible shroud. The bioluminescent moss begins to thin out, replaced by pulsing jellyfish that glow a surreal, ghostly blue. Their soft glow serves as your beacon, guiding you through the twisting maze of the underwater tunnel.
 
@@ -1655,13 +1607,7 @@ As you emerge from the underwater tunnel, back into the cavernous expanse of the
 
 
 :: Pick up the Managed Misfortune [layer3]
-<<nobr>>
-<<set $ownedRelics.push($relic30)>>
-<<set $corruption -= ($relic30.corr - $corRed)>>
-<<set $tempTime = $relic30.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic30.pic]]
-<</nobr>>
+<<CollectRelic $relic30>>
 
 Suddenly, you detect a distinct gleam, an alien radiance unlike the glow of the Abyss's flora. It pulses with a vibrant energy, a color shifting between shades of green, blue, and purple. It's coming from a cavern off the main path, an opening guarded by sharp stalactites and stalagmites. An inexplicable pull draws you towards it, as if the source of the light beckons to you.
 
@@ -1677,13 +1623,7 @@ You can use this Relic to temporarily store any Curses you pick up.
 [[Continue exploring the third layer|Layer3 Hub]]
 
 :: Pick up the Breathless Exhale [layer3]
-<<nobr>>
-<<set $ownedRelics.push($relic31)>>
-<<set $corruption -= ($relic31.corr - $corRed)>>
-<<set $tempTime = $relic31.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic31.pic]]
-<</nobr>>
+<<CollectRelic $relic31>>
 
 In the distance, you hear a faint whooshing sound, like the sigh of a sleeping giant. Your heart pounds in your chest as you follow the noise. The passage narrows, forcing you to crawl on your hands and knees. Sharp stalactites and stalagmites threaten to pierce your protective gear, but you press on. The whooshing sound grows louder, rhythmic and steady, like the pulse of the Abyss itself.
 
@@ -1704,13 +1644,7 @@ Harnessing the energy of this Relic, you may be able to ward off potential threa
 
 
 :: Pick up the Sharing Shears [layer3]
-<<nobr>>
-<<set $ownedRelics.push($relic32)>>
-<<set $corruption -= ($relic32.corr - $corRed)>>
-<<set $tempTime = $relic32.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic32.pic]]
-<</nobr>>
+<<CollectRelic $relic32>>
 
 As you carefully negotiate your way through the darkened tunnels of the third layer of the Abyss, you feel a change in the air. There is a certain tangibility, a prickling sensation on your skin, hinting that you might be close to your objective.
 
@@ -1733,13 +1667,7 @@ The porcelain stalagmite remains split in two, the halves still glowing with an 
 
 
 :: Pick up the Rose-tinted Spectacles [layer3]
-<<nobr>>
-<<set $ownedRelics.push($relic33)>>
-<<set $corruption -= ($relic33.corr - $corRed)>>
-<<set $tempTime = $relic33.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic33.pic]]
-<</nobr>>
+<<CollectRelic $relic33>>
 
 As you continue down the spiraling path you're headed down, you come to a large cavern. The ceiling arches high above you, disappearing into an inky abyss. At the center of this cavern lies an unusual structure, one that stands in stark contrast to the natural formations of the cave. It's an immense circular platform made of polished obsidian, set into the floor of the cave. A complex network of lines etched into its surface glows with the same luminescence as the moss and fungi surrounding it. Razor-sharp obsidian shards seem to move and protrude from the glowing lines in a seemingly random pattern, leaving nearly no room to move without injuring yourself.
 

--- a/src/layer4.twee
+++ b/src/layer4.twee
@@ -946,13 +946,7 @@ The magic of the shrine wisps through the air menacingly as your victim struggle
 [[Continue with your journey|Layer4 Hub]]
 
 :: Pick up the Ghost-righter Writing Down [layer4]
-<<nobr>>
-<<set $ownedRelics.push($relic34)>>
-<<set $corruption -= ($relic34.corr - $corRed)>>
-<<set $tempTime = $relic34.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic34.pic]]
-<</nobr>>
+<<CollectRelic $relic34>>
 
 You have successfully taken the $relic34.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -961,13 +955,7 @@ You have successfully taken the $relic34.name Relic. Hopefully you can make good
 
 
 :: Pick up the Gilded Prison [layer4]
-<<nobr>>
-<<set $ownedRelics.push($relic35)>>
-<<set $corruption -= ($relic35.corr - $corRed)>>
-<<set $tempTime = $relic35.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic35.pic]]
-<</nobr>>
+<<CollectRelic $relic35>>
 
 You have successfully taken the $relic35.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -976,13 +964,7 @@ You have successfully taken the $relic35.name Relic. Hopefully you can make good
 
 
 :: Pick up the Omoikane Circuit [layer4]
-<<nobr>>
-<<set $ownedRelics.push($relic36)>>
-<<set $corruption -= ($relic36.corr - $corRed)>>
-<<set $tempTime = $relic36.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic36.pic]]
-<</nobr>>
+<<CollectRelic $relic36>>
 
 You have successfully taken the $relic36.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -991,13 +973,7 @@ You have successfully taken the $relic36.name Relic. Hopefully you can make good
 
 
 :: Pick up the Afar Wanderer [layer4]
-<<nobr>>
-<<set $ownedRelics.push($relic37)>>
-<<set $corruption -= ($relic37.corr - $corRed)>>
-<<set $tempTime = $relic37.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic37.pic]]
-<</nobr>>
+<<CollectRelic $relic37>>
 
 You have successfully taken the $relic37.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -1006,13 +982,7 @@ You have successfully taken the $relic37.name Relic. Hopefully you can make good
 
 
 :: Pick up the Kin Shifter [layer4]
-<<nobr>>
-<<set $ownedRelics.push($relic38)>>
-<<set $corruption -= ($relic38.corr - $corRed)>>
-<<set $tempTime = $relic38.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic38.pic]]
-<</nobr>>
+<<CollectRelic $relic38>>
 
 You have successfully taken the $relic38.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -1023,13 +993,7 @@ You can use this Relic to copy other Relics you have to get more uses out of the
 
 
 :: Pick up the Brave Vector [layer4]
-<<nobr>>
-<<set $ownedRelics.push($relic39)>>
-<<set $corruption -= ($relic39.corr - $corRed)>>
-<<set $tempTime = $relic39.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic39.pic]]
-<</nobr>>
+<<CollectRelic $relic39>>
 
 You have successfully taken the $relic39.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -1040,13 +1004,7 @@ While this Relic may not be very functional in its current form as a bent pipe, 
 
 
 :: Pick up the Devil's Own [layer4]
-<<nobr>>
-<<set $ownedRelics.push($relic40)>>
-<<set $corruption -= ($relic40.corr - $corRed)>>
-<<set $tempTime = $relic40.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic40.pic]]
-<</nobr>>
+<<CollectRelic $relic40>>
 
 You have successfully taken the $relic40.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -1057,13 +1015,7 @@ If you have Cherry, this Relic will provide the useful boon of a single use rero
 
 
 :: Pick up the Verve Cell [layer4]
-<<nobr>>
-<<set $ownedRelics.push($relic41)>>
-<<set $corruption -= ($relic41.corr - $corRed)>>
-<<set $tempTime = $relic41.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic41.pic]]
-<</nobr>>
+<<CollectRelic $relic41>>
 
 You have successfully taken the $relic41.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -1072,13 +1024,7 @@ You have successfully taken the $relic41.name Relic. Hopefully you can make good
 
 
 :: Pick up the Vessel Vivisector [layer4]
-<<nobr>>
-<<set $ownedRelics.push($relic42)>>
-<<set $corruption -= ($relic42.corr - $corRed)>>
-<<set $tempTime = $relic42.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic42.pic]]
-<</nobr>>
+<<CollectRelic $relic42>>
 
 You have successfully taken the $relic42.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -1087,13 +1033,7 @@ You have successfully taken the $relic42.name Relic. Hopefully you can make good
 
 
 :: Pick up the Sated Artist [layer4]
-<<nobr>>
-<<set $ownedRelics.push($relic43)>>
-<<set $corruption -= ($relic43.corr - $corRed)>>
-<<set $tempTime = $relic43.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic43.pic]]
-<</nobr>>
+<<CollectRelic $relic43>>
 
 You have successfully taken the $relic43.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -1102,13 +1042,7 @@ You have successfully taken the $relic43.name Relic. Hopefully you can make good
 
 
 :: Pick up the Timekeeper's Keepsake [layer4]
-<<nobr>>
-<<set $ownedRelics.push($relic44)>>
-<<set $corruption -= ($relic44.corr - $corRed)>>
-<<set $tempTime = $relic44.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic44.pic]]
-<</nobr>>
+<<CollectRelic $relic44>>
 
 You have successfully taken the $relic44.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -1117,13 +1051,7 @@ You have successfully taken the $relic44.name Relic. Hopefully you can make good
 
 
 :: Pick up the Creator's Bolt [layer4]
-<<nobr>>
-<<set $ownedRelics.push($relic45)>>
-<<set $corruption -= ($relic45.corr - $corRed)>>
-<<set $tempTime = $relic45.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic45.pic]]
-<</nobr>>
+<<CollectRelic $relic45>>
 
 You have successfully taken the $relic45.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -1132,13 +1060,7 @@ You have successfully taken the $relic45.name Relic. Hopefully you can make good
 
 
 :: Pick up the Perpetual Repose [layer4]
-<<nobr>>
-<<set $ownedRelics.push($relic46)>>
-<<set $corruption -= ($relic46.corr - $corRed)>>
-<<set $tempTime = $relic46.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic46.pic]]
-<</nobr>>
+<<CollectRelic $relic46>>
 
 You have successfully taken the $relic46.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -1147,13 +1069,7 @@ You have successfully taken the $relic46.name Relic. Hopefully you can make good
 
 
 :: Pick up the Toral Wave [layer4]
-<<nobr>>
-<<set $ownedRelics.push($relic47)>>
-<<set $corruption -= ($relic47.corr - $corRed)>>
-<<set $tempTime = $relic47.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic47.pic]]
-<</nobr>>
+<<CollectRelic $relic47>>
 
 You have successfully taken the $relic47.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -1164,13 +1080,7 @@ A source of electricity like this would be hard to use in combat, but perhaps if
 
 
 :: Pick up the Flamel's Folly [layer4]
-<<nobr>>
-<<set $ownedRelics.push($relic48)>>
-<<set $corruption -= ($relic48.corr - $corRed)>>
-<<set $tempTime = $relic48.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic48.pic]]
-<</nobr>>
+<<CollectRelic $relic48>>
 
 You have successfully taken the $relic48.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 

--- a/src/layer5.twee
+++ b/src/layer5.twee
@@ -637,14 +637,7 @@ Having dealt with the booby trap, you are able to move forwards freely and obtai
 
 
 :: Pocket Hoard [layer5]
-
-<<nobr>>
-<<set $ownedRelics.push($relic49)>>
-<<set $corruption -= ($relic49.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic49.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic49.pic]]
-<</nobr>>
+<<CollectRelic $relic49>>
 
 You have successfully taken the $relic49.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -655,13 +648,7 @@ A trip to the One-sided Tunnel might be worthwhile now to empower your new Relic
 
 
 :: Sunbeam [layer5]
-<<nobr>>
-<<set $ownedRelics.push($relic50)>>
-<<set $corruption -= ($relic50.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic50.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic50.pic]]
-<</nobr>>
+<<CollectRelic $relic50>>
 
 You have successfully taken the $relic50.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -672,13 +659,7 @@ This Relic can only see its true potential unleashed in the hands of a skilled s
 
 
 :: Moonwatcher [layer5]
-<<nobr>>
-<<set $ownedRelics.push($relic51)>>
-<<set $corruption -= ($relic51.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic51.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic51.pic]]
-<</nobr>>
+<<CollectRelic $relic51>>
 
 You have successfully taken the $relic51.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -687,13 +668,7 @@ You have successfully taken the $relic51.name Relic. Hopefully you can make good
 
 
 :: Siren's Call [layer5]
-<<nobr>>
-<<set $ownedRelics.push($relic52)>>
-<<set $corruption -= ($relic52.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic52.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic52.pic]]
-<</nobr>>
+<<CollectRelic $relic52>>
 
 You have successfully taken the $relic52.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -702,13 +677,7 @@ You have successfully taken the $relic52.name Relic. Hopefully you can make good
 
 
 :: Zelus Band [layer5]
-<<nobr>>
-<<set $ownedRelics.push($relic53)>>
-<<set $corruption -= ($relic53.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic53.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic53.pic]]
-<</nobr>>
+<<CollectRelic $relic53>>
 
 You have successfully taken the $relic53.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -717,13 +686,7 @@ You have successfully taken the $relic53.name Relic. Hopefully you can make good
 
 
 :: Everhevea [layer5]
-<<nobr>>
-<<set $ownedRelics.push($relic54)>>
-<<set $corruption -= ($relic54.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic54.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic54.pic]]
-<</nobr>>
+<<CollectRelic $relic54>>
 
 You have successfully taken the $relic54.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -734,13 +697,7 @@ The Everhevea can be used as 2 flasks for as long as you hold it, so at the very
 
 
 :: Reflex Emblem [layer5]
-<<nobr>>
-<<set $ownedRelics.push($relic55)>>
-<<set $corruption -= ($relic55.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic55.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic55.pic]]
-<</nobr>>
+<<CollectRelic $relic55>>
 
 You have successfully taken the $relic55.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -749,13 +706,7 @@ You have successfully taken the $relic55.name Relic. Hopefully you can make good
 
 
 :: Twin Polaris [layer5]
-<<nobr>>
-<<set $ownedRelics.push($relic56)>>
-<<set $corruption -= ($relic56.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic56.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic56.pic]]
-<</nobr>>
+<<CollectRelic $relic56>>
 
 You have successfully taken the $relic56.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -764,13 +715,7 @@ You have successfully taken the $relic56.name Relic. Hopefully you can make good
 
 
 :: Superpositional Skewer [layer5]
-<<nobr>>
-<<set $ownedRelics.push($relic57)>>
-<<set $corruption -= ($relic57.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic57.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic57.pic]]
-<</nobr>>
+<<CollectRelic $relic57>>
 
 You have successfully taken the $relic57.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -780,14 +725,8 @@ You have successfully taken the $relic57.name Relic. Hopefully you can make good
 
 :: Empath Coil [layer5]
 <<nobr>>
-<<set $ownedRelics.push($relic58)>>
-<<set $corruption -= ($relic58.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic58.time-$SibylBuff>>
-<<if !$slingshot>>
-	<<set $items[20].count -= 1>>
-<</if>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic58.pic]]
+<<if !$slingshot>><<set $items[20].count -= 1>><</if>>
+<<CollectRelic $relic58>>
 <</nobr>>
 
 You have successfully taken the $relic58.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
@@ -799,13 +738,7 @@ This may be able to channel electricity, but without a source that ability is no
 
 
 :: Heavenly Merrymaker [layer5]
-<<nobr>>
-<<set $ownedRelics.push($relic59)>>
-<<set $corruption -= ($relic59.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic59.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic59.pic]]
-<</nobr>>
+<<CollectRelic $relic59>>
 
 You have successfully taken the $relic59.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -814,13 +747,7 @@ You have successfully taken the $relic59.name Relic. Hopefully you can make good
 
 
 :: Vain Sculpt [layer5]
-<<nobr>>
-<<set $ownedRelics.push($relic60)>>
-<<set $corruption -= ($relic60.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic60.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic60.pic]]
-<</nobr>>
+<<CollectRelic $relic60>>
 
 You have successfully taken the $relic60.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 

--- a/src/layer6.twee
+++ b/src/layer6.twee
@@ -465,13 +465,7 @@ You may pick up a copy of an old Relic for 20 dubloons and 2x its corruption cos
 
 
 :: Pick up the Ring of the Devourer [layer6]
-<<nobr>>
-<<set $ownedRelics.push($relic61)>>
-<<set $corruption -= ($relic61.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic61.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic61.pic]]
-<</nobr>>
+<<CollectRelic $relic61>>
 
 You have successfully taken the $relic61.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -482,13 +476,7 @@ Note: This Relic's functionality is not currently implemented.
 
 
 :: Pick up the Pulse Bloom [layer6]
-<<nobr>>
-<<set $ownedRelics.push($relic62)>>
-<<set $corruption -= ($relic62.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic62.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic62.pic]]
-<</nobr>>
+<<CollectRelic $relic62>>
 
 You have successfully taken the $relic62.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -497,13 +485,7 @@ You have successfully taken the $relic62.name Relic. Hopefully you can make good
 
 
 :: Pick up the Out of Mind [layer6]
-<<nobr>>
-<<set $ownedRelics.push($relic63)>>
-<<set $corruption -= ($relic63.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic63.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic63.pic]]
-<</nobr>>
+<<CollectRelic $relic63>>
 
 You have successfully taken the $relic63.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -512,14 +494,7 @@ You have successfully taken the $relic63.name Relic. Hopefully you can make good
 
 
 :: Pick up the Still Film [layer6]
-<<nobr>>
-<<set $ownedRelics.push($relic64)>>
-<<set $corruption -= ($relic64.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic64.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic64.pic]]
-<</nobr>>
-
+<<CollectRelic $relic64>>
 
 You have successfully taken the $relic64.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -528,14 +503,7 @@ You have successfully taken the $relic64.name Relic. Hopefully you can make good
 
 
 :: Pick up the Forbidden Grimoire [layer6]
-<<nobr>>
-<<set $ownedRelics.push($relic65)>>
-<<set $corruption -= ($relic65.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic65.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic65.pic]]
-<</nobr>>
-
+<<CollectRelic $relic65>>
 
 You have successfully taken the $relic65.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -546,14 +514,7 @@ You can use this to improve the boons granted by your companions one time, choos
 
 
 :: Pick up the Luminous Phantasmagoria [layer6]
-<<nobr>>
-<<set $ownedRelics.push($relic66)>>
-<<set $corruption -= ($relic66.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic66.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic66.pic]]
-<</nobr>>
-
+<<CollectRelic $relic66>>
 
 You have successfully taken the $relic66.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -562,14 +523,7 @@ You have successfully taken the $relic66.name Relic. Hopefully you can make good
 
 
 :: Pick up the Relativity Eye [layer6]
-<<nobr>>
-<<set $ownedRelics.push($relic67)>>
-<<set $corruption -= ($relic67.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic67.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic67.pic]]
-<</nobr>>
-
+<<CollectRelic $relic67>>
 
 You have successfully taken the $relic67.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -578,13 +532,7 @@ You have successfully taken the $relic67.name Relic. Hopefully you can make good
 
 
 :: Pick up the Return to Sender [layer6]
-<<nobr>>
-<<set $ownedRelics.push($relic68)>>
-<<set $corruption -= ($relic68.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic68.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic68.pic]]
-<</nobr>>
+<<CollectRelic $relic68>>
 
 You have successfully taken the $relic68.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -593,13 +541,7 @@ You have successfully taken the $relic68.name Relic. Hopefully you can make good
 
 
 :: Pick up the Yliaster Materia [layer6]
-<<nobr>>
-<<set $ownedRelics.push($relic69)>>
-<<set $corruption -= ($relic69.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic69.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic69.pic]]
-<</nobr>>
+<<CollectRelic $relic69>>
 
 You have successfully taken the $relic69.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -608,13 +550,7 @@ You have successfully taken the $relic69.name Relic. Hopefully you can make good
 
 
 :: Pick up the Aeonglass [layer6]
-<<nobr>>
-<<set $ownedRelics.push($relic70)>>
-<<set $corruption -= ($relic70.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic70.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic70.pic]]
-<</nobr>>
+<<CollectRelic $relic70>>
 
 You have successfully taken the $relic70.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -623,13 +559,7 @@ You have successfully taken the $relic70.name Relic. Hopefully you can make good
 
 
 :: Pick up the Apparatus Diaboli [layer6]
-<<nobr>>
-<<set $ownedRelics.push($relic71)>>
-<<set $corruption -= ($relic71.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic71.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic71.pic]]
-<</nobr>>
+<<CollectRelic $relic71>>
 
 You have successfully taken the $relic71.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -638,13 +568,7 @@ You have successfully taken the $relic71.name Relic. Hopefully you can make good
 
 
 :: Pick up the Heavy is the Head [layer6]
-<<nobr>>
-<<set $ownedRelics.push($relic72)>>
-<<set $corruption -= ($relic72.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic72.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic72.pic]]
-<</nobr>>
+<<CollectRelic $relic72>>
 
 You have successfully taken the $relic72.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 

--- a/src/layer7.twee
+++ b/src/layer7.twee
@@ -392,14 +392,7 @@ If you're not dissuaded and choose to continue onward, it will take you 8 days t
 
 
 :: Pick up the Daedalus Mechanism [layer7]
-<<nobr>>
-<<set $ownedRelics.push($relic73)>>
-<<set $corruption -= ($relic73.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic73.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic73.pic]]
-
-<</nobr>>
+<<CollectRelic $relic73>>
 
 You have successfully taken the $relic73.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -409,13 +402,8 @@ You have successfully taken the $relic73.name Relic. Hopefully you can make good
 
 :: Pick up the Blind Divine [layer7]
 <<nobr>>
-<<if $slingshot == 0>><<set $items[20].count -= 4>><</if>>
-<<set $ownedRelics.push($relic74)>>
-<<set $corruption -= ($relic74.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic74.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic74.pic]]
-
+<<if !$slingshot>><<set $items[20].count -= 4>><</if>>
+<<CollectRelic $relic74>>
 <</nobr>>
 
 You have successfully taken the $relic74.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
@@ -427,14 +415,7 @@ This Relic grants you the ability to see in any dark place, removing the need fo
 
 
 :: Pick up the Lambent Specter [layer7]
-<<nobr>>
-<<set $ownedRelics.push($relic75)>>
-<<set $corruption -= ($relic75.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic75.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic75.pic]]
-
-<</nobr>>
+<<CollectRelic $relic75>>
 
 You have successfully taken the $relic75.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -445,14 +426,7 @@ This Relic grants you the power to create a golem, a steadfast and loyal compani
 
 
 :: Pick up the Phoenix Obol [layer7]
-<<nobr>>
-<<set $ownedRelics.push($relic76)>>
-<<set $corruption -= ($relic76.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic76.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic76.pic]]
-
-<</nobr>>
+<<CollectRelic $relic76>>
 
 You have successfully taken the $relic76.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -461,14 +435,7 @@ You have successfully taken the $relic76.name Relic. Hopefully you can make good
 
 
 :: Pick up the Granted Granite [layer7]
-<<nobr>>
-<<set $ownedRelics.push($relic77)>>
-<<set $corruption -= ($relic77.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic77.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic77.pic]]
-
-<</nobr>>
+<<CollectRelic $relic77>>
 
 You have successfully taken the $relic77.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -477,14 +444,7 @@ You have successfully taken the $relic77.name Relic. Hopefully you can make good
 
 
 :: Pick up the Joyous Sunder [layer7]
-<<nobr>>
-<<set $ownedRelics.push($relic78)>>
-<<set $corruption -= ($relic78.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic78.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic78.pic]]
-
-<</nobr>>
+<<CollectRelic $relic78>>
 
 You have successfully taken the $relic78.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -493,14 +453,7 @@ You have successfully taken the $relic78.name Relic. Hopefully you can make good
 
 
 :: Pick up the Azure Aozora [layer7]
-<<nobr>>
-<<set $ownedRelics.push($relic79)>>
-<<set $corruption -= ($relic79.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic79.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic79.pic]]
-
-<</nobr>>
+<<CollectRelic $relic79>>
 
 You have successfully taken the $relic79.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -509,14 +462,7 @@ You have successfully taken the $relic79.name Relic. Hopefully you can make good
 
 
 :: Pick up the Glare Vantage [layer7]
-<<nobr>>
-<<set $ownedRelics.push($relic80)>>
-<<set $corruption -= ($relic80.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic80.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic80.pic]]
-
-<</nobr>>
+<<CollectRelic $relic80>>
 
 You have successfully taken the $relic80.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -527,14 +473,7 @@ If you don't already have a source of light, the Glare Vantage will provide you 
 
 
 :: Pick up the Final Stage [layer7]
-<<nobr>>
-<<set $ownedRelics.push($relic81)>>
-<<set $corruption -= ($relic81.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic81.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic81.pic]]
-
-<</nobr>>
+<<CollectRelic $relic81>>
 
 You have successfully taken the $relic81.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -544,14 +483,9 @@ You have successfully taken the $relic81.name Relic. Hopefully you can make good
 
 :: Pick up the Solace Lace [layer7]
 <<nobr>>
-<<set $ownedRelics.push($relic82)>>
-<<set $corruption -= ($relic82.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic82.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic82.pic]]
+<<CollectRelic $relic82>>
 <<set $heat = 1>>
 <<set $cool = 1>>
-
 <</nobr>>
 
 You have successfully taken the $relic82.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
@@ -563,14 +497,7 @@ This Relic provides you with comfort in the cold to reduce travel times by 2 day
 
 
 :: Pick up the Red Thread Flourish [layer7]
-<<nobr>>
-<<set $ownedRelics.push($relic83)>>
-<<set $corruption -= ($relic83.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic83.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic83.pic]]
-
-<</nobr>>
+<<CollectRelic $relic83>>
 
 You have successfully taken the $relic83.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -579,14 +506,7 @@ You have successfully taken the $relic83.name Relic. Hopefully you can make good
 
 
 :: Pick up the Triage Rain [layer7]
-<<nobr>>
-<<set $ownedRelics.push($relic84)>>
-<<set $corruption -= ($relic84.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic84.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic84.pic]]
-
-<</nobr>>
+<<CollectRelic $relic84>>
 
 You have successfully taken the $relic84.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 

--- a/src/layer8.twee
+++ b/src/layer8.twee
@@ -405,14 +405,8 @@ You can consider your equipment, allies, and general health to take into account
 <</if>>
 
 :: Pick up the Voila Viola [layer8]
-<<nobr>>
-<<set $ownedRelics.push($relic85)>>
-<<set $corruption -= ($relic85.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic85.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic85.pic]]
+<<CollectRelic $relic85>>
 
-<</nobr>>
 You have successfully taken the $relic85.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 This may be useful against certain aquatic or aqueous enemies, if you can use it properly.
@@ -422,14 +416,8 @@ This may be useful against certain aquatic or aqueous enemies, if you can use it
 
 
 :: Pick up the Between Whispers [layer8]
-<<nobr>>
-<<set $ownedRelics.push($relic86)>>
-<<set $corruption -= ($relic86.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic86.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic86.pic]]
+<<CollectRelic $relic86>>
 
-<</nobr>>
 You have successfully taken the $relic86.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 8|Layer8 Relics]]
@@ -437,14 +425,8 @@ You have successfully taken the $relic86.name Relic. Hopefully you can make good
 
 
 :: Pick up the Absolute Oracle [layer8]
-<<nobr>>
-<<set $ownedRelics.push($relic87)>>
-<<set $corruption -= ($relic87.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic87.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic87.pic]]
+<<CollectRelic $relic87>>
 
-<</nobr>>
 You have successfully taken the $relic87.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 8|Layer8 Relics]]
@@ -452,14 +434,8 @@ You have successfully taken the $relic87.name Relic. Hopefully you can make good
 
 
 :: Pick up the Memory Reign [layer8]
-<<nobr>>
-<<set $ownedRelics.push($relic88)>>
-<<set $corruption -= ($relic88.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic88.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic88.pic]]
+<<CollectRelic $relic88>>
 
-<</nobr>>
 You have successfully taken the $relic88.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 8|Layer8 Relics]]
@@ -467,14 +443,8 @@ You have successfully taken the $relic88.name Relic. Hopefully you can make good
 
 
 :: Pick up the Drifting Aperture [layer8]
-<<nobr>>
-<<set $ownedRelics.push($relic89)>>
-<<set $corruption -= ($relic89.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic89.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic89.pic]]
+<<CollectRelic $relic89>>
 
-<</nobr>>
 You have successfully taken the $relic89.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 8|Layer8 Relics]]
@@ -482,14 +452,8 @@ You have successfully taken the $relic89.name Relic. Hopefully you can make good
 
 
 :: Pick up the Aegis Coffin [layer8]
-<<nobr>>
-<<set $ownedRelics.push($relic90)>>
-<<set $corruption -= ($relic90.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic90.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic90.pic]]
+<<CollectRelic $relic90>>
 
-<</nobr>>
 You have successfully taken the $relic90.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 By laying within this otherworldly Relic, you can undergo a miraculous transformation, replacing your vulnerable skeletal structure with one forged from the remarkably strong and resilient orichalcum. This invaluable gift will fortify you against the countless dangers lurking within the Abyss.
@@ -499,14 +463,8 @@ By laying within this otherworldly Relic, you can undergo a miraculous transform
 
 
 :: Pick up the Gaia Theory [layer8]
-<<nobr>>
-<<set $ownedRelics.push($relic91)>>
-<<set $corruption -= ($relic91.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic91.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic91.pic]]
+<<CollectRelic $relic91>>
 
-<</nobr>>
 You have successfully taken the $relic91.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 8|Layer8 Relics]]
@@ -514,14 +472,8 @@ You have successfully taken the $relic91.name Relic. Hopefully you can make good
 
 
 :: Pick up the Glory's Grasp[layer8]
-<<nobr>>
-<<set $ownedRelics.push($relic92)>>
-<<set $corruption -= ($relic92.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic92.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic92.pic]]
+<<CollectRelic $relic92>>
 
-<</nobr>>
 You have successfully taken the $relic92.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 If your arm is lost, you can use this Relic to overcome the handicap and use this Relic as a weapon against certain threats.
@@ -531,14 +483,8 @@ If your arm is lost, you can use this Relic to overcome the handicap and use thi
 
 
 :: Pick up the Pneuma Wisp [layer8]
-<<nobr>>
-<<set $ownedRelics.push($relic93)>>
-<<set $corruption -= ($relic93.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic93.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic93.pic]]
+<<CollectRelic $relic93>>
 
-<</nobr>>
 You have successfully taken the $relic93.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 This Relic should let you reach anything that requires scuba gear any allow you to move through underwater environments without worry o drowning.
@@ -548,14 +494,8 @@ This Relic should let you reach anything that requires scuba gear any allow you 
 
 
 :: Pick up the World's End Lock [layer8]
-<<nobr>>
-<<set $ownedRelics.push($relic94)>>
-<<set $corruption -= ($relic94.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic94.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic94.pic]]
+<<CollectRelic $relic94>>
 
-<</nobr>>
 You have successfully taken the $relic94.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 8|Layer8 Relics]]
@@ -563,14 +503,8 @@ You have successfully taken the $relic94.name Relic. Hopefully you can make good
 
 
 :: Pick up the Fray Goo [layer8]
-<<nobr>>
-<<set $ownedRelics.push($relic95)>>
-<<set $corruption -= ($relic95.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic95.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic95.pic]]
+<<CollectRelic $relic95>>
 
-<</nobr>>
 You have successfully taken the $relic95.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 8|Layer8 Relics]]
@@ -578,14 +512,8 @@ You have successfully taken the $relic95.name Relic. Hopefully you can make good
 
 
 :: Pick up the Null Void [layer8]
-<<nobr>>
-<<set $ownedRelics.push($relic96)>>
-<<set $corruption -= ($relic96.corr - $corRed + (5 * Math.trunc($hexflame / 10)))>>
-<<set $tempTime = $relic96.time-$SibylBuff>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
-[img[setup.ImagePath + $relic96.pic]]
+<<CollectRelic $relic96>>
 
-<</nobr>>
 You have successfully taken the $relic96.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 8|Layer8 Relics]]

--- a/src/relics.twee
+++ b/src/relics.twee
@@ -1609,11 +1609,15 @@ The one supernatural effect not cancelled is the unbreakability of Eternal Repos
 <<for _name range _args[0]>>
     <div>
     <<set _relic = $relics.find(r => r.name === _name)>>
+    <<set _corr = Math.max(_relic.corr - $corRed + ($currentLayer != 6 ? 5 * Math.trunc($hexflame / 10) : 0), 0)>>
+    <<set _time = Math.max(_relic.time - $SibylBuff, 0)>>
     [img[setup.ImagePath + _relic.pic]]
     <h2>_name<<if setup.functionalRelics.contains(_name)>> ☸<</if>></h2>
     <p class="cost">
-    Cost: <<print _relic.corr>> corruption
-    <<if _relic.time > 0>>+ <<print _relic.time>> day<<if _relic.time > 1>>s<</if>><</if>>
+        <<if _corr || _time>>Cost:<<else>>Free!<</if>>
+        <<if _corr > 0>>_corr corruption<</if>>
+        <<if _corr > 0 && _time > 0>> + <</if>>
+        <<if _time > 0>>_time day<<if _time > 1>>s<</if>><</if>>
     </p>
     <p>
     <<if _totalRelics.some(e => e.name === _name)>>

--- a/src/widgets.twee
+++ b/src/widgets.twee
@@ -3145,6 +3145,23 @@
 	<</if>>
 <</if>>
 
+:: Collect Relic widget [widget nobr]
+<<widget "CollectRelic">>
+<<capture _relic>>
+	<<set _relic = _args[0]>>
+	<<set $ownedRelics.push(_relic)>>
+	<<if _relic.time - $SibylBuff > 0>>
+		<<set $tempTime = _relic.time - $SibylBuff>>
+		<<include "GeneralTimeSetup">>
+		<<include "GeneralTimeStats">>
+	<</if>>
+	<<set $corruption -= Math.max(_relic.corr - $corRed + ($currentLayer != 6 ? 5 * Math.trunc($hexflame / 10) : 0), 0)>>
+	<<if _relic.pic>>
+		[img[setup.ImagePath + _relic.pic]]<br>
+	<</if>>
+<</capture>>
+<</widget>>
+
 :: Equiped items and Relics widget [widget nobr]
 <<widget "Equipment">>
 

--- a/t3lt.twee-config.yml
+++ b/t3lt.twee-config.yml
@@ -36,6 +36,10 @@ sugarcube-2:
       name: CloneSelf
       parameters:
         - ""
+    CollectRelic:
+      name: CollectRelic
+      parameters:
+        - "var"
     ConversationChoices:
       name: ConversationChoices
       parameters:


### PR DESCRIPTION
This replaces all the relic collection stat change and image display boilerplate with a macro. It also fixes some inconsistencies where some relics didn't take all the bonuses and penalties into account.

In addition, I tuned the cost display in `<<RelicGrid>>` a bit to take `$SibylBoost` and the corruption modifiers into account. However, the displayed time is still wrong as the `GeneralTimeSetup` passage further modifies travel time, potentially decreasing it to 0. Unfortunately that passage also modifies several other variables so we can't just silently include it to figure out the reduction.

By the way, is the `$hexflame` corruption penalty meant to apply on layer 6? The text implies that it doesn't: 
> increasing travel times by `<<print Math.trunc($hexflame / 10)>>` and increasing corruption gain by `<<print (5 * Math.trunc($hexflame / 10))>>` _**on every layer other than layer 6**_.

(emphasis mine) but there was no existing exception for this. I added one to the macro, but I can remove it again if that's not the intent.

Although this is a big change, it's mostly mechanical - the most interesting parts are the new macro in `widgets.twee` and the adjustments to `<<RelicGrid>>` in `relics.twee`. A few relics have some additional logic (for example the `Empath Coil`) - for those I left the `<<nobr>>` in place but still used the macro.