### PR TITLE
GeneralTime Part 2

### DIFF
--- a/src/global.twee
+++ b/src/global.twee
@@ -732,7 +732,7 @@ This will also consume food/water/etc. as necessary based on your current layer.
 :: Adjust time2 [noreturn]
 <<nobr>>
 <<set _tempTime = parseInt($temp)>>
-/*<<include "GeneralTimeStats">>*/
+/*<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>*/
 <<set $time += _tempTime>>
 <</nobr>>
 
@@ -1007,7 +1007,7 @@ It emits of a brigth flash of light that forces you to close your eyes, and you 
 	You have pushed yourself quite a bit, which hampers your recovery. So it takes 7 days until you feel fit enough to begin your journey once again. And your weakened condition will increase your next 3 travel times by 1 day each.
 	<<set $status.duration += 3>>\
 	<<set $status.penalty += 1>>\
-	<<set $tempTime=7>><<include "GeneralTimeStats">>\
+	<<set $tempTime=7>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>\
 <<elseif $hiredCompanions.length==1>>\
 	You spend the next few days with $hiredCompanions[0].name at your side recovering, both emotionally as well as physically. $hiredCompanions[0].name helps you a lot and after a few days you start walking around a little bit again.
 	It takes 7 days until you feel fit enough to begin your journey once again.
@@ -1018,7 +1018,7 @@ It emits of a brigth flash of light that forces you to close your eyes, and you 
 		<<set $status.duration += 3>>\
 		<<set $status.penalty += 1>>\
 	<</if>>
-	<<set $tempTime=4>><<include "GeneralTimeStats">>\
+	<<set $tempTime=4>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>\
 <<elseif $hiredCompanions.length>1>>\
 	You spend the next few days with $hiredCompanions[0].name at your side recovering, both emotionally as well as physically. Your companions help you a lot and after a few days you start walking around a little bit again.
 	It takes 7 days until you feel fit enough to begin your journey once again.
@@ -1029,7 +1029,7 @@ It emits of a brigth flash of light that forces you to close your eyes, and you 
 		<<set $status.duration += 3>>\
 		<<set $status.penalty += 1>>\
 	<</if>>
-	<<set $tempTime=4>><<include "GeneralTimeStats">>\
+	<<set $tempTime=4>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>\
 <</if>>\
 
 [[You cast your eyes once more on the path ahead, it's time to get moving once again|_string]]
@@ -1086,7 +1086,7 @@ Cherry's medical expertise greatly aids $hiredCompanions[_temp1].name in her rec
 In the end, you don't truly resume your travels in earnest until after 7 days.
 <<set $tempTime=7>>
 <</if>>
-<<include "GeneralTimeStats">>\
+<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>\
 
 [[You cast your eyes once more on the central location of this layer, ready to get moving again|_string]]
 
@@ -1867,72 +1867,19 @@ How many dubloons would you like to pay back?
 <</widget>>
 
 :: GeneralTimeSetup [nobr]
-
-/* If travel time wasn't eliminated entirely, apply multiplicative modifiers (travel speed). */
-<<if $tempTime > 0>>
-	<<set _travelSpeed = 1>>
-	/* Halve travel speed if player has a size handicap (Colossal-able, or Minish-ish with no one to carry them). */
-	<<if $SizeHandicap>>
-		The burden of your inconvenient size hampers your progress, increasing your travel time.<br>
-		<<set _travelSpeed /= 2>>
-	<</if>>
-	/* Increase/decrease travel speed by 10% for every level of physical fitness. */
-	<<if $app.HandicapMovement < 0>>
-		Hindered by your physical shortcomings, your travel time increases as you struggle to keep pace.<br>
-	<<elseif $app.HandicapMovement > 0>>
-		Your exceptional physical condition is reducing your travel time.<br>
-	<</if>>
-	<<set _travelSpeed *= 1 + $app.HandicapMovement / 10>>
-	/* Double travel speed if player has the Aeonglass with Endless Time relic active. */
-	<<if $EndlessAeonglass>>
-		The enhanced Aeonglass, shimmering with a timeless aura, grants you the remarkable ability to reduce your travel time by half.<br>
-		<<set _travelSpeed *= 2>>
-	<</if>>
-	/* Compute the actual travel time depending on whether the player is using energy rations. */
-	<<if $useEnergyrations>>
-		/* Calculate the number of energy rations consumed per day. */
-		<<set _consumptionPerDay = 1>>
-		<<if $hiredCompanions.some(e => e.name === $companionTwin.name)>>
-			<<set _consumptionPerDay *= 2>> /* Two mouths to feed (other companions get the effect for free). */
-		<</if>>
-		<<if $playerCurses.some(e => e.name === "Minish-ish")>>
-			<<set _consumptionPerDay /= 4>> /* You eat a lot less than normal (your twin shares your curses). */
-		<</if>>
-		/* Double travel speed while you have energy rations. */
-		<<set _travelSpeed *= 2>>
-		/* Compute the actual travel time. */
-		<<if Math.ceil(_consumptionPerDay * $tempTime / _travelSpeed) <= $items[24].count>>
-			/* Enough energy rations to last the whole journey. */
-			<<set $items[24].count -= Math.ceil(_consumptionPerDay * $tempTime / _travelSpeed)>>
-			<<set $items[1].count += Math.ceil(_consumptionPerDay * $tempTime / _travelSpeed)>>
-			<<set $tempTime = Math.ceil($tempTime / _travelSpeed)>>
-		<<else>>
-			/* Not enough energy rations to last the whole journey. */
-			<<set _travelRemaining = $tempTime - _travelSpeed * $items[24].count / _consumptionPerDay>>
-			/* The remaining distance is traveled at half the speed. */
-			<<set _travelSpeed /= 2>>
-			<<set $tempTime = Math.ceil($items[24].count / _consumptionPerDay + _travelRemaining / _travelSpeed)>>
-			<<set $items[1].count += $items[24].count>>
-			<<set $items[24].count = 0>>
-		<</if>>
-		<<if $items[24].count <= 0>>
-			<<set $useEnergyrations = false>>
-		<</if>>
-	<<else>>
-		<<set $tempTime = Math.ceil($tempTime / _travelSpeed)>>
-	<</if>>
-<</if>>
-
 /* Ensure the $heat and $cool variables are set correctly. */
 <<set $heat = $slwear || ($warmCloth && !$dollevent2) ? 1 : 0>>
 <<set $cool = $slwear || ($coolCloth && !$dollevent2) ? 1 : 0>>
 
+/* Start by computing the overall additive modifier. */
+<<set _additiveModifier = 0>>
+
 /* Apply time reduction from having Khemia with you. */
-<<set $tempTime -= $timeRed>>
+<<set _additiveModifier -= $timeRed>>
 
 /* Apply status penalty, if any. */
 <<if $status.duration > 0>>
-	<<set $tempTime += $status.penalty>>
+	<<set _additiveModifier += $status.penalty>>
 	/* Decrement status duration and remove status penalty if duration is now 0. */
 	<<set $status.duration -= 1>>
 	<<if $status.duration < 1>>
@@ -1942,7 +1889,7 @@ How many dubloons would you like to pay back?
 
 /* Add jinxed flame count penalty unless we're on layer 6. */
 <<if $currentLayer != 6>>
-	<<set $tempTime += Math.trunc($hexflame / 10)>>
+	<<set _additiveModifier += Math.trunc($hexflame / 10)>>
 <</if>>
 
 /* Apply other layer-specific effects. */
@@ -1950,24 +1897,24 @@ How many dubloons would you like to pay back?
 	<<case 2>>
 		/* Reduce travel time if player has a cutting tool. */
 		<<if setup.haveCuttingTool()>>
-			<<set $tempTime -= 1>>
+			<<set _additiveModifier -= 1>>
 		<</if>>
 	<<case 3>>
 		/* Reduce travel time if player has a light source. */
 		<<if setup.haveTravelLightSource()>>
-			<<set $tempTime -= 1>>
+			<<set _additiveModifier -= 1>>
 		<</if>>
 		/* Apply Chlorophyll curse penalty, if any. */
 		<<if $playerCurses.some(e => e.name === "Chlorophyll")>>
 			Now that you rely on light for your metabolism, the darkness in this layer is making you sluggish.<br>
-			<<set $tempTime += 1>>
+			<<set _additiveModifier += 1>>
 		<</if>>
 	<<case 4>>
 		/* Reduce travel time if player has a heat source. */
 		<<if $heat>>
-			<<set $tempTime -= 2>>
+			<<set _additiveModifier -= 2>>
 		<<elseif $torchUse == 1 && $items[9].count > 0>>
-			<<set $tempTime -= 2>>
+			<<set _additiveModifier -= 2>>
 			/* Decrement number of torches and stop using torches if the count is now 0. */
 			<<set $items[9].count -= 1>>
 			<<if $items[9].count < 1>>
@@ -1976,31 +1923,94 @@ How many dubloons would you like to pay back?
 		<<elseif $playerCurses.some(e => e.name === "Cold Blooded")>>
 			/* Apply Cold Blooded curse penalty. */
 			Now that you're cold blooded you're slowed down quite a bit by the freezing temperatures on this layer.<br>
-			<<set $tempTime += 2>>
+			<<set _additiveModifier += 2>>
 			/* Reduce penalty if player has fur. */
 			<<if $app.skinType.includes("furred")>>
 				However, your fur is somewhat protective and mitigates the effects of the cold.<br>
-				<<set $tempTime -= 1>>
+				<<set _additiveModifier -= 1>>
 			<</if>>
 		<</if>>
 	<<case 5 6>>
 		/* Reduce travel time if player has a way to keep from overheating. */
 		<<if $cool>>
-			<<set $tempTime -= 1>>
+			<<set _additiveModifier -= 1>>
 		<</if>>
 	<<case 8>>
 		/* Reduce travel time if player has some form of compass. */
 		<<if $items[12].count || $items[17].count || $items[21].count>>
 			The comforting presence of a device that discerns north from south in this bewildering maze bolsters your confidence and allows you to navigate more efficiently.<br>
-			<<set $tempTime -= 3>>
+			<<set _additiveModifier -= 3>>
 		<</if>>
 		/* Reduce travel time if player has the Star Compass relic. */
-		<<set $tempTime -= 5>>
+		<<set _additiveModifier -= 5>>
 <</switch>>
 
-/* Prevent travel time from becoming negative. */
-<<if $tempTime < 0>>
-	<<set $tempTime = 0>>
+/* If the additive modifier is a time reduction, apply it to the base time. */
+<<if _additiveModifier < 0>>
+	<<set $tempTime += _additiveModifier>>
+<</if>>
+
+/* If travel time wasn't eliminated entirely, apply multiplicative modifiers. */
+<<if $tempTime > 0>>
+	<<set _multiplicativeModifier = 1>>
+	/* Double travel time if player has a size handicap (Colossal-able, or Minish-ish with no one to carry them). */
+	<<if $SizeHandicap>>
+		The burden of your inconvenient size hampers your progress, increasing your travel time.<br>
+		<<set _multiplicativeModifier *= 2>>
+	<</if>>
+	/* Increase/decrease time by 10% for every level of physical fitness. */
+	<<if $app.HandicapMovement < 0>>
+		Hindered by your physical shortcomings, your travel time increases as you struggle to keep pace.<br>
+		<<set _multiplicativeModifier *= 1 - $app.HandicapMovement / 10>>
+	<<elseif $app.HandicapMovement > 0>>
+		Your exceptional physical condition is reducing your travel time.<br>
+		<<set _multiplicativeModifier /= 1 + $app.HandicapMovement / 10>>
+	<</if>>
+	/* Halve travel time if player has the Aeonglass with Endless Time relic active. */
+	<<if $EndlessAeonglass>>
+		The enhanced Aeonglass, shimmering with a timeless aura, grants you the remarkable ability to reduce your travel time by half.<br>
+		<<set _multiplicativeModifier /= 2>>
+	<</if>>
+	/* Apply the multiplicative modifiers. */
+	<<set $tempTime *= _multiplicativeModifier>>
+	/* Adjust the travel time if the player is using energy rations. */
+	<<if $useEnergyrations>>
+		/* Calculate the number of energy rations consumed per day. */
+		<<set _consumptionPerDay = 1>>
+		<<if $hiredCompanions.some(e => e.name === $companionTwin.name)>>
+			<<set _consumptionPerDay *= 2>> /* Two mouths to feed (other companions get the effect for free). */
+		<</if>>
+		<<if $playerCurses.some(e => e.name === "Minish-ish")>>
+			<<set _consumptionPerDay /= 4>> /* You eat a lot less than normal (your twin shares your curses). */
+		<</if>>
+		/* Using energy rations halves the travel time, so we need at most half the time worth. */
+		<<set _daysOfEnergyRations = Math.min($tempTime / 2, $items[24].count / _consumptionPerDay)>>
+		/* Every day with an energy ration counts for twice as much. */
+		<<set $tempTime -= _daysOfEnergyRations>>
+		/* Round up the number of days of energy rations to a whole number, as GeneralTimeStats iterates per day. */
+		<<set _daysOfEnergyRations = Math.ceil(_daysOfEnergyRations)>>
+		/* If we used up all the energy rations we had, stop using them. */
+		<<if Math.ceil(_consumptionPerDay * _daysOfEnergyRations) >= $items[24].count>>
+			<<set $useEnergyrations = false>>
+		<</if>>
+	<</if>>
+<</if>>
+
+/* If the additive modifier is a time penalty, apply it to the modified time. */
+<<if _additiveModifier > 0>>
+	<<set $tempTime += _additiveModifier>>
+<</if>>
+
+/* Don't allow travel time to become negative. */
+<<if $tempTime < 0>><<set $tempTime = 0>><</if>>
+
+/* Round travel time to a whole number of days. */
+<<set $tempTime = Math.round($tempTime)>>
+
+<<if _daysOfEnergyRations && _daysOfEnergyRations > $tempTime>>
+	/* Ensure all days of energy rations end up used. */
+	<<set $items[24].count -= _consumptionPerDay * (_daysOfEnergyRations - $tempTime)>>
+	<<set _daysOfEnergyRations = $tempTime>>
 <</if>>
 
 :: GeneralTimeStats [nobr]
@@ -2105,7 +2115,11 @@ How many dubloons would you like to pay back?
 		<<set $forageFood = 1>>
 	<</if>>
 	<<for ++$starving; $starving > 0; --$starving>>
-		<<if !$forageFood>>
+		<<if _daysOfEnergyRations>>
+			/* If we used energy rations to speed up travel, use those first (regardless of foraging settings). */
+			<<set $items[24].count -= _consumptionPerDay>>
+			<<set _daysOfEnergyRations -= 1>>
+		<<elseif !$forageFood>>
 			<<if $items[1].count >= _consumptionPerDay>>
 				<<set $items[1].count -= _consumptionPerDay>>
 			<<elseif $items[1].count + $items[24].count >= _consumptionPerDay>>
@@ -2265,10 +2279,6 @@ How many dubloons would you like to pay back?
 	<</for>>
 <</for>>
 
-/* Ensure that we aren't left with a fractional number of rations. */
-<<set $items[1].count = Math.floor($items[1].count)>>
-<<set $items[24].count = Math.floor($items[24].count)>>
-
 <<for _i = 0; _i < $tempTime; ++_i>>
 	<<if !$forageWater && $dehydrated > 1 && $currentLayer != 3 && $currentLayer != 5 && $items[0].count + $items[3].count + $items[25].count < _consumptionPerDay>>
 		@@.alert2; In order to avoid death by dehydration, you are currently foraging for water on this layer, no matter the consequences.<br>
@@ -2344,6 +2354,19 @@ How many dubloons would you like to pay back?
 	<</if>>
 <</for>>
 
+/* Increase the elapsed time. */
+<<set $time += $tempTime>>
+
+<</capture>>
+
+:: GeneralTimeFinal [nobr]
+/* Ensure that _daysOfEnergyRations is now 0. */
+<<set _daysOfEnergyRations = 0>>
+
+/* Ensure that we aren't left with a fractional number of rations. */
+<<set $items[1].count = Math.floor($items[1].count)>>
+<<set $items[24].count = Math.floor($items[24].count)>>
+
 /* Ensure that we aren't left with a fractional amount of water. */
 <<set $items[0].count = Math.floor($items[0].count)>>
 <<set $items[2].count = Math.ceil($items[2].count)>> /* Empty flasks */
@@ -2352,11 +2375,6 @@ How many dubloons would you like to pay back?
 <<for _i = 0; _i < $flaskMatrix.length; ++_i>>
 	<<set $flaskMatrix[_i] = Math.floor($flaskMatrix[_i])>>
 <</for>>
-
-/* Increase the elapsed time. */
-<<set $time += $tempTime>>
-
-<</capture>>
 
 :: Drinking code [nobr]
 <<FlaskFirst>>
@@ -2461,6 +2479,7 @@ How many days would you like to rest here?
 		<<set $tempTime = 1>>
 		<<include "GeneralTimeStats">>
 	<</for>>
+	<<include "GeneralTimeFinal">>
 
 <</link>><</nobr>>
 

--- a/src/layer1.twee
+++ b/src/layer1.twee
@@ -945,8 +945,7 @@ But gradually, a newfound certainty washes over you - the realization that your 
 <<set $corruption -= $playerCurses[$temp].corr>>
 <<set $iconUsed = 1>>
 <<set $tempTime=3>>
-<<include "GeneralTimeSetup">>
-<<include "GeneralTimeStats">>
+<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 The Curse, $playerCurses[$temp].name, has been successfully removed and your corruption has been refunded.<br>
 <<RemoveCurse $playerCurses[$temp]>>
 <</nobr>>
@@ -988,6 +987,7 @@ Traveling back to the surface from here will take 1 day, and will cost 10 corrup
 	<<set $tempTime=1>>
 	<<include "GeneralTimeStats">>
 <</for>>
+<<include "GeneralTimeFinal">>
 
 <<set $corruption -= (10 - $corRed)>>
 

--- a/src/layer2.twee
+++ b/src/layer2.twee
@@ -2,7 +2,7 @@
 <<nobr>>
 <<masteraudio stop>><<audio "layer2" volume 0.2 play loop>>
 <<set $tempTime = 2>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
+<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 <<set $timeL2T1 = 0>>
 <<set $currentLayer = 2>>
 <</nobr>>\
@@ -529,7 +529,7 @@ What type of fur would you like to gain?
 <<set $corruption += 100>>
 <<set $brokerUsed = 1>>
 <<set $tempTime = 2>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
+<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 <</nobr>>
 [img[setup.ImagePath+'Wonders/empty-handedbroker.png']]
 
@@ -578,7 +578,7 @@ Whose body do you find yourself in?
 <<set $starUsed = 1>>
 <<set $swapComp = $temp>>
 <<set $tempTime = 3>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
+<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 <<set $hiredCompanions[$swapComp].carry = $temp2>>
 <<CarryAdjust>>
 <</nobr>>
@@ -1490,6 +1490,7 @@ A few tests and you can confirm you have pure water to fill your flasks with! No
 	<</if>>
 	
 <</for>>
+<<include "GeneralTimeFinal">>
 
 <</nobr>><<if $layerExitTime == 0 && !($timeL2T1 > 3 && $hiredCompanions.length < 4)>>
 Subtle changes in your surroundings continue, large rocks start to appear in your path, and the entire terrain changes from the lush rainforest you previously found yourself in to a more temperate forest. But slowly the trees become more sparse and the rocks become more common.
@@ -1525,6 +1526,7 @@ Subtle changes in your surroundings continue, large rocks start to appear in you
 	<</if>>
 
 <</for>>
+<<include "GeneralTimeFinal">>
 
 
 <</nobr>><<if $layerExitTime == 0 && !($timeL2T1 > 3 && $hiredCompanions.length < 4)>>

--- a/src/layer3.twee
+++ b/src/layer3.twee
@@ -201,12 +201,12 @@ You have already used the scales on your journey. You may not use them again.
 	Would you like to use the Skewed Shrine to give a Curse to one of your willing companions at the cost of <<print ($skewedUsed * 5)>> dubloons?<br>
 	<<link "Yes, use the Skewed Shrine to transfer a Curse" "Layer3 Skewed1a">>
 		<<set $tempTime = 3>>
-		<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
+		<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 	<</link>><br><br>
 	Would you like to use the Skewed Shrine to force a Curse upon one of your unwilling companions at the cost of <<print ($skewedUsed * 5)>> dubloons?<br>
 	<<link "Yes, use the Skewed Shrine to force a Curse" "Layer3 Skewed 2a">>
 		<<set $tempTime = 3>>
-		<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
+		<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 	<</link>><br><br>
 <<else>>
 	None of your companions trust you at this shrine anymore. None will get close enough for you to use the shrine with them. They watch you with eyes full of fear and anger, as if they could bolt at any moment and leave you alone in the Abyss.<br><br>
@@ -327,6 +327,7 @@ In the deeper parts of the layer, a cold breeze occasionally blows through the c
 	<</if>>
 
 <</for>>
+<<include "GeneralTimeFinal">>
 <<if $layerExitTime == 0 && !($timeL3T1 > 5) && !($timeL3T2 > 4)>>
 	<<set $corruption -= (25 - $corRed)>>
 	<br>You continue through the dark winding caverns for days on end. After a long and monotonous journey, broken up only by evading threats that may have interrupted you, you notice that the caves are opening up. The sheer stone walls morphing into large rock formations, then shrinking and making way for the jungle of the second layer. A familiar sound of eternal rainfall welcomes you back to the second layer.
@@ -344,7 +345,7 @@ In the deeper parts of the layer, a cold breeze occasionally blows through the c
 <<set $dubloons += $temp>>
 <<set $scalesUsed = 1>>
 <<set $tempTime = 2>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
+<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 <</nobr>>
 [img[setup.ImagePath+'Wonders/gossameryscales.png']]
 
@@ -361,7 +362,7 @@ Once you pick them up, the luster of the scales fades, indicating that they will
 <<set $corruption += $temp>>
 <<set $scalesUsed = 1>>
 <<set $tempTime = 2>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
+<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 <</nobr>>
 [img[setup.ImagePath+'Wonders/gossameryscales.png']]
 
@@ -854,7 +855,7 @@ On the other hand, the idea of each encounter feeling like your first time holds
 <<set $tempTime = (Math.max(4 -$abyssKnow - $riverVisit, 0))>>
 <<set $riverVisit = 1>>
 
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
+<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 
 <<for _i = 0; _i < 999; _i++>>
 	<<if $items[2].count > 0>>
@@ -1333,6 +1334,7 @@ Please enter your new skin/eye color:
 	<</if>>
 
 <</for>>
+<<include "GeneralTimeFinal">>
 <</nobr>>
 <<if $layerExitTime == 0 && !($timeL3T1 > 5) && !($timeL3T2 > 4)>>
 	<<nobr>>

--- a/src/layer4.twee
+++ b/src/layer4.twee
@@ -235,12 +235,12 @@ The Brave Vector Relic you can find here is a perfect example of something you m
 	Would you like to use the Steady Shrine to copy a Curse to one of your willing companions at the cost of <<print ($skewedUsed * 5)>> dubloons?<br>
 	<<link "Yes, use the Steady Shrine to copy a Curse" "Layer4 Steady1a">>
 		<<set $tempTime = 3>>
-		<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
+		<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 	<</link>><br><br>
 	Would you like to use the Steady Shrine to forcibly copy a Curse onto one of your unwilling companions at the cost of <<print ($skewedUsed * 5)>> dubloons?<br>
 	<<link "Yes, use the Steady Shrine to forcibly copy a Curse" "Layer4 Steady 2a">>
 		<<set $tempTime = 3>>
-		<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
+		<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 	<</link>><br><br>
 <<else>>
 	None of your companions trust you at this shrine anymore. None will get close enough for you to use the shrine with them. They watch you with eyes full of fear and anger, as if they could bolt at any moment and leave you alone in the Abyss.<br><br>
@@ -857,7 +857,7 @@ Which Curse would you like to forcibly copy onto your unwilling companion?
 <<nobr>>
 <<set $purityUsed = 1>>
 <<set $tempTime = 5>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
+<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 <</nobr>>
 [img[setup.ImagePath+'Wonders/puritytree.png']]
 
@@ -1151,6 +1151,7 @@ You have successfully taken the $relic48.name Relic. Hopefully you can make good
 	<</if>>
 	*/
 <</for>>
+<<include "GeneralTimeFinal">>
 
 <<if $layerExitTime == 0 && !($timeL4T1 > 6)>>
 	<<nobr>>
@@ -1239,7 +1240,7 @@ You have successfully taken the $relic48.name Relic. Hopefully you can make good
 		<<break>>
 	<</if>>*/
 <</for>>
-
+<<include "GeneralTimeFinal">>
 
 <</nobr>>
 <<if $layerExitTime == 0 && !($timeL4T1 > 6)>>

--- a/src/layer5.twee
+++ b/src/layer5.twee
@@ -150,7 +150,7 @@ Use the following option only if you have specifically considered your inventory
 
 :: Layer5 Threat1 Main [layer5]
 <<set $tempTime = 1>>\
-<<include "GeneralTimeStats">>\
+<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>\
 <<set $timeL5T1 -= 8>>\
 [img[setup.ImagePath+'Threats/mayflyscuttler.png']]
 
@@ -301,7 +301,7 @@ You can also wait at the Oasis if you'd like to pass the time while waiting for 
 		<<set $items[0].count += (5 - $items[3].count)>>
 	<</if>>
 	<<set $tempTime = parseInt($temp)>>
-	<<include "GeneralTimeStats">>
+	<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 <</link>><br><br><</nobr>>
 <</nobr>>
 
@@ -497,8 +497,7 @@ Layer 5 is the last layer that anyone on the surface currently has any reliable 
 	<<set $status.penalty = 0>>
 <</if>>
 <<set $tempTime = (Math.max(4 - ($oasisVisit * 2) - $abyssKnow, 0))>>
-<<include "GeneralTimeSetup">>
-<<include "GeneralTimeStats">>
+<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 
 <<for $i = 0; $i < 999; $i++>>
 	<<if $items[2].count > 0>>
@@ -1397,7 +1396,7 @@ Please enter your new exoskeleton color:
 :: Layer5 Tunnel [layer5]
 <<nobr>>
 <<set $tempTime = 2>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
+<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 <</nobr>>
 [img[setup.ImagePath+'Wonders/one-sidedtunnel.png']]
 
@@ -1451,7 +1450,7 @@ Testing your Pocket Hoard, you stick a hand into the pink rucksack, but find you
 <<nobr>>
 <<if $vaultWait == 0>>
 	<<set $tempTime = 3>>
-	<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
+	<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 <<else>>
 	<<set $vaultWait = 0>>
 <</if>>
@@ -1468,7 +1467,7 @@ You can wait here for a while if you'd like to check when the door is open. If y
 <<nobr>><<link "Wait" "Layer5 Vault">>
 	<<set $tempTime = parseInt($temp)>>
 	<<set $vaultWait = 1>>
-	<<include "GeneralTimeStats">>
+	<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 <</link>><br><br><</nobr>>
 
 <<if (60 - $time + $vaultTimer) > 0>>
@@ -1551,6 +1550,7 @@ The radiant sun empowers your Breathless Exhale Relic, its energy pulsating with
 	<</if>>
 
 <</for>>
+<<include "GeneralTimeFinal">>
 <</nobr>>
 <<if $layerExitTime == 0 && !($timeL5T2 > 8) && !($timeL5T1 > 7)>>
 	<<set $timeL4T1 = 0>>\
@@ -1601,7 +1601,7 @@ Use the following option only if you have specifically considered your inventory
 
 :: Layer5 Threat1 Ascend [layer5]
 <<set $tempTime = 1>>\
-<<include "GeneralTimeStats">>\
+<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>\
 <<set $timeL5T1 -= 8>>\
 [img[setup.ImagePath+'Threats/mayflyscuttler.png']]
 
@@ -1648,6 +1648,7 @@ Use the following option only if you have specifically considered your inventory
 		<<set $layerExitTime -= 1>><<break>>
 	<</if>>
 <</for>>
+<<include "GeneralTimeFinal">>
 
 <<if $layerExitTime == 0 && !($timeL5T2 > 8) && !($timeL5T1 > 7)>>
 <<set $timeL6T1 = 0>>
@@ -1695,7 +1696,7 @@ Use the following option only if you have specifically considered your inventory
 
 :: Layer5 Threat1 Descend [layer5]
 <<set $tempTime = 1>>\
-<<include "GeneralTimeStats">>\
+<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>\
 <<set $timeL5T1 -= 8>>\
 [img[setup.ImagePath+'Threats/mayflyscuttler.png']]
 

--- a/src/layer6.twee
+++ b/src/layer6.twee
@@ -433,7 +433,7 @@ There is a very easily accessible source of water on this layer, the River Dycx,
 <<nobr>>
 <<set $totalRelics = $ownedRelics.concat($soldRelics)>>
 <<set $tempTime = 3>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
+<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 <</nobr>><<if $mawUse == 0>>
 As you press through the thicket of incessantly writhing tentacles, the tentacles subtly change their rhythm. The heat has long ago seared your sense of comfort away, replaced with a strange duality of torment and transcendence. The harsh, yet strangely savory, scent of burning flesh punctuates the air, becoming richer and more distinct. Suddenly, the sea of tentacles parts like the Red Sea before Moses, revealing a broad expanse of barren rock.
 
@@ -1096,7 +1096,7 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 
 :: Layer6 Threat1 Main2 [layer6]
 <<set $tempTime = $tentacleFucked>>\
-<<include "GeneralTimeStats">>\
+<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>\
 
 <<if $khemiaFucked == 0>>
 	After an intense encounter with the greater tentacle beast, you are left in a sorry state, needing to be left stationary for $tentacleFucked days. Slowly you regain your sensations and manage to prepare yourself to get going and continue your travels on the sixth layer.
@@ -1144,7 +1144,7 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 		<<set $layerExitTime -= 1>><<break>>
 	<</if>>
 <</for>>
-
+<<include "GeneralTimeFinal">>
 
 <</nobr>><<if $layerExitTime == 0 && !($timeL6T2 > 7 && $dragonKill < 5) && !($timeL6T1 > 14)>>
 	<<nobr>>
@@ -1276,7 +1276,7 @@ Use the following option only if you have specifically considered your inventory
 
 :: Layer6 Threat1 Ascend2 [layer6]
 <<set $tempTime = $tentacleFucked>>\
-<<include "GeneralTimeStats">>\
+<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>\
 
 <<if $khemiaFucked == 0>>
 	After an intense encounter with the greater tentacle beast, you are left in a sorry state, needing to be left stationary for $tentacleFucked days. Slowly you regain your sensations and manage to prepare yourself to get going and continue your travels on the sixth layer.
@@ -1318,7 +1318,7 @@ Use the following option only if you have specifically considered your inventory
 		<<set $layerExitTime -= 1>><<break>>
 	<</if>>
 <</for>>
-
+<<include "GeneralTimeFinal">>
 
 <</nobr>><<if $layerExitTime == 0 && !($timeL6T2 > 7 && $dragonKill < 5) && !($timeL6T1 > 14)>>
 <<set $timeL7T2 = 0>>
@@ -1441,7 +1441,7 @@ Use the following option only if you have specifically considered your inventory
 
 :: Layer6 Threat1 Descend2 [layer6]
 <<set $tempTime = $tentacleFucked>>\
-<<include "GeneralTimeStats">>\
+<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>\
 
 <<if $khemiaFucked == 0>>
 	After an intense encounter with the greater tentacle beast, you are left in a sorry state, needing to be left stationary for $tentacleFucked days. Slowly you regain your sensations and manage to prepare yourself to get going and continue your travels on the sixth layer.
@@ -1677,7 +1677,7 @@ Use the following option only if you have specifically considered your inventory
 :: Layer6 Threat1 2 [layer6]
 [img[setup.ImagePath+'Threats/greatertentaclebeast.png']]
 <<set $tempTime = $tentacleFucked>>\
-<<include "GeneralTimeStats">>\
+<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>\
 
 <<if $khemiaFucked == 0 && $app.vagina == 1 && $app.breastsCor > 0>>\
 	In a flash, the greater tentacle beast lunges toward you, its countless tendrils erupting from the ground and surrounding you in a suffocating embrace. The slick, sinewy tendrils coil around your limbs, binding you tightly as they explore every inch of your body with perverse curiosity. Their touch is deceptively gentle, yet insistent, sending shivers down your spine as they delicately caress your $app.breastsLabel cup breasts, teasing your nipples, and exploring the soft flesh of your inner thighs.

--- a/src/layer7.twee
+++ b/src/layer7.twee
@@ -332,7 +332,7 @@ If you're not dissuaded and choose to continue onward, it will take you 8 days t
 <<nobr>>
 <<set $timeL7T2 -= 6>>
 <<set $tempTime = 1>>
-<<include "GeneralTimeStats">>
+<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 <</nobr>>
 [img[setup.ImagePath+'Threats/securityrobot.png']]
 <<if $playerCurses.some(e => e.name === "Hypno Happytime") && $layer7Hypno < 3>><<set $layer7Hypno += 1>>
@@ -1381,7 +1381,7 @@ You retrieve your Relics and find that you have successfully switched the abilit
 [[Continue your business on the seventh layer|Layer7 Hub]]<br><br>
 
 <<set $tempTime = 2>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">>
+<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 <<set $dubloons -= 4>>
 
 <<set $temp = $relicSwap.length>>
@@ -1463,7 +1463,7 @@ You have no choice, you gain consciousness a few times to see yourself in a surg
 		<<set $layerExitTime -= 1>><<break>>
 	<</if>>
 <</for>>
-
+<<include "GeneralTimeFinal">>
 
 <</nobr>>
 <<if $layerExitTime == 0 && !($dubloons < 0) && !($timeL7T2 > 5)>>
@@ -1492,7 +1492,7 @@ You have no choice, you gain consciousness a few times to see yourself in a surg
 <<nobr>>
 <<set $timeL7T2 -= 6>>
 <<set $tempTime = 1>>
-<<include "GeneralTimeStats">>
+<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 <</nobr>>
 [img[setup.ImagePath+'Threats/securityrobot.png']]
 
@@ -1609,7 +1609,7 @@ You have no choice, you gain consciousness a few times to see yourself in a surg
 	<</if>>
 
 <</for>>
-
+<<include "GeneralTimeFinal">>
 
 <</nobr>><<if $layerExitTime == 0 && !($dubloons < 0) && !($timeL7T2 > 5)>>
 
@@ -1629,7 +1629,7 @@ You have no choice, you gain consciousness a few times to see yourself in a surg
 <<nobr>>
 <<set $timeL7T2 -= 6>>
 <<set $tempTime = 1>>
-<<include "GeneralTimeSetup">>	<<include "GeneralTimeStats">>
+<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 <</nobr>>
 [img[setup.ImagePath+'Threats/securityrobot.png']]
 
@@ -1706,7 +1706,7 @@ You have no choice, you gain consciousness a few times to see yourself in a surg
 <<if $tempTime < 0>>
 	<<set $tempTime = 0>>
 <</if>>
-<<include "GeneralTimeStats">>
+<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 <</nobr>>
 [img[setup.ImagePath+'Foraging/heavylifting.png']]
 
@@ -1733,7 +1733,7 @@ You have worked $temp1 days and moved $temp2 loads of "construction material" to
 <<if $tempTime < 0>>
 	<<set $tempTime = 0>>
 <</if>>
-<<include "GeneralTimeStats">>
+<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 <</nobr>>
 [img[setup.ImagePath+'Foraging/landexcavation.png']]
 
@@ -1760,7 +1760,7 @@ You have worked $temp1 days and excavated $temp2 2x2x2 cubic meters of earth to 
 <<if $tempTime < 0>>
 	<<set $tempTime = 0>>
 <</if>>
-<<include "GeneralTimeStats">>
+<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 <</nobr>>
 [img[setup.ImagePath+'Foraging/citypainter.png']]
 
@@ -1787,7 +1787,7 @@ You have worked $temp1 days and painted $temp2 square km of building surface to 
 <<if $tempTime < 0>>
 	<<set $tempTime = 0>>
 <</if>>
-<<include "GeneralTimeStats">>
+<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 <</nobr>>
 [img[setup.ImagePath+'Foraging/energygenerator.png']]
 
@@ -1814,7 +1814,7 @@ You have worked $temp1 days and generated <<print ($temp2 / 4)>> kWh of energy t
 <<if $tempTime < 0>>
 	<<set $tempTime = 0>>
 <</if>>
-<<include "GeneralTimeStats">>
+<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 <</nobr>>
 [img[setup.ImagePath+'Foraging/energygenerator.png']]
 
@@ -1832,7 +1832,7 @@ You have worked $temp1 days and brought robots to artificial orgasm $temp2 times
 <<nobr>>
 <<set $timeL7T2 -= 6>>
 <<set $tempTime = 1>>
-<<include "GeneralTimeStats">>
+<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 <</nobr>>
 [img[setup.ImagePath+'Threats/securityrobot.png']]
 

--- a/src/layer8.twee
+++ b/src/layer8.twee
@@ -1349,7 +1349,7 @@ Ready? Getting back up out of this terrible prison and back to layer 7 will take
 	<</if>>
 	<<set $L8loopLim=true>>
 <</for>>
-
+<<include "GeneralTimeFinal">>
 
 <</nobr>>
 <<if $layerExitTime == 0 && !(($timeL8T2a > 6 && !$hiredCompanions.some(e => e.name === "Maru") && $L8T1aCount < 2) || ($timeL8T2a > 7 && $L8T1aCount < 2)) && !(($timeL8T2b > 20 && !$hiredCompanions.some(e => e.name === "Maru")) || $timeL8T2b > 23)>>
@@ -1408,7 +1408,7 @@ If you continue your descent in spite of everything, descending past this layer'
 	<</if>>
 	<<set $L8loopLim=true>>
 <</for>>
-
+<<include "GeneralTimeFinal">>
 
 <<if $layerExitTime == 0 && !(($timeL8T2a > 6 && !$hiredCompanions.some(e => e.name === "Maru") && $L8T1aCount < 2) || ($timeL8T2a > 7 && $L8T1aCount < 2)) && !(($timeL8T2b > 20 && !$hiredCompanions.some(e => e.name === "Maru")) || $timeL8T2b > 23)>>
 

--- a/src/widgets.twee
+++ b/src/widgets.twee
@@ -2112,7 +2112,7 @@
 			Uncertain of how to handle the egg<<if _eggs>1>>s<</if>>, you ultimately decide to dispose of <<if _eggs>1>>them<<else>>it<</if>>. Exhausted from the ordeal, you can do nothing but rest, your day effectively wasted.
 			<br><br>
 			<<set $tempTime=1>>
-			<<include "GeneralTimeStats">>
+			<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 		<<else>>
 			<<if !settings.MenCycleToggleFilter>>
 				<<if $menFirstCycle == true>>
@@ -3013,8 +3013,7 @@
 	<<set $ownedRelics.push(_relic)>>
 	<<if _relic.time - $SibylBuff > 0>>
 		<<set $tempTime = _relic.time - $SibylBuff>>
-		<<include "GeneralTimeSetup">>
-		<<include "GeneralTimeStats">>
+		<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 	<</if>>
 	<<set $corruption -= Math.max(_relic.corr - $corRed + ($currentLayer != 6 ? 5 * Math.trunc($hexflame / 10) : 0), 0)>>
 	<<if _relic.pic>>


### PR DESCRIPTION
This implements the hybrid approach I mentioned on Discord, where a net additive penalty is always applied in full, but a net additive time reduction influences the multiplicative adjustments. I think this way the calculations are always correct (the energy ration calculation in particular needs to be applied _after_ any reductions).

Additionally:
* The energy ration calculation is simplified somewhat.
* Instead of transforming energy rations into regular rations (which doesn't work if you're foraging), we now pass the number of days of energy rations to use into `GeneralTimeStats` so they get used first.
* Travel time is now rounded using `Math.round` instead of `Math.ceil` so that multiplicative modifiers can reduce it to 0 (e.g. if travel time would end up as 0.25 days). Easy to revert if you think only additive modifiers should be able to do that.
* Rations and water are now rounded down in a separate passage, `GeneralTimeFinal`. Rounding them every time in `GeneralTimeStats` doesn't work if `GeneralTimeStats` is called in a loop (and you have the Minish-ish curse). Adding another passage is a bit ugly, but this should keep things consistent.

With this I think all my concerns about the internal logic of these passages are resolved. Next I'll modify `GeneralTimeSetup` so it can be used for the relic grid and so on.