### PR TITLE
Turn passage `GeneralTimeSetup` into macro `AdjustTravelTime`

### DIFF
--- a/src/companionSetup.twee
+++ b/src/companionSetup.twee
@@ -693,7 +693,7 @@ The rest of the world just sees you as a pair of twins who did everything togeth
 		<</if>>
 		<br>
 	<</for>>
-	<<if $items[21].count > 0>>
+	<<if setup.haveSmartphoneAI>>
 		<<if $currentLayer==0>>
 			[[Ask Ai for information on this layer|AI ConvoL0]]<br>
 		<<elseif $currentLayer==1>>

--- a/src/global.twee
+++ b/src/global.twee
@@ -1922,7 +1922,15 @@ How many dubloons would you like to pay back?
 <</capture>>
 <</widget>>
 
-:: GeneralTimeSetup [nobr]
+:: AdjustedTravelTime widget [widget nobr]
+<<widget "AdjustedTravelTime">>
+/*
+	_args[0]: string     = the variable to write to, as a string (e.g. "$tempTime")
+	_args[1]: var|number = the raw, unadjusted travel time
+	_args[2]: [bool]     = whether to avoid adjustments beyond the travel time (optional, defaults to false)
+*/
+<<set _inputTime = _args[1]>>
+
 /* Ensure the $heat and $cool variables are set correctly. */
 <<set $heat = $slwear || ($warmCloth && !$dollevent2) ? 1 : 0>>
 <<set $cool = $slwear || ($coolCloth && !$dollevent2) ? 1 : 0>>
@@ -2003,11 +2011,11 @@ How many dubloons would you like to pay back?
 
 /* If the additive modifier is a time reduction, apply it to the base time. */
 <<if _additiveModifier < 0>>
-	<<set $tempTime += _additiveModifier>>
+	<<set _inputTime += _additiveModifier>>
 <</if>>
 
 /* If travel time wasn't eliminated entirely, apply multiplicative modifiers. */
-<<if $tempTime > 0>>
+<<if _inputTime > 0>>
 	<<set _multiplicativeModifier = 1>>
 	/* Double travel time if player has a size handicap (Colossal-able, or Minish-ish with no one to carry them). */
 	<<if $SizeHandicap>>
@@ -2028,7 +2036,7 @@ How many dubloons would you like to pay back?
 		<<set _multiplicativeModifier /= 2>>
 	<</if>>
 	/* Apply the multiplicative modifiers. */
-	<<set $tempTime *= _multiplicativeModifier>>
+	<<set _inputTime *= _multiplicativeModifier>>
 	/* Adjust the travel time if the player is using energy rations. */
 	<<if $useEnergyrations>>
 		/* Calculate the number of energy rations consumed per day. */
@@ -2040,34 +2048,43 @@ How many dubloons would you like to pay back?
 			<<set _consumptionPerDay /= 4>> /* You eat a lot less than normal (your twin shares your curses). */
 		<</if>>
 		/* Using energy rations halves the travel time, so we need at most half the time worth. */
-		<<set _daysOfEnergyRations = Math.min($tempTime / 2, $items[24].count / _consumptionPerDay)>>
+		<<set _daysOfEnergyRations = Math.min(_inputTime / 2, $items[24].count / _consumptionPerDay)>>
 		/* Every day with an energy ration counts for twice as much. */
-		<<set $tempTime -= _daysOfEnergyRations>>
-		/* Round up the number of days of energy rations to a whole number, as GeneralTimeStats iterates per day. */
-		<<set _daysOfEnergyRations = Math.ceil(_daysOfEnergyRations)>>
-		/* If we used up all the energy rations we had, stop using them. */
-		<<if Math.ceil(_consumptionPerDay * _daysOfEnergyRations) >= $items[24].count>>
-			<<set $useEnergyrations = false>>
+		<<set _inputTime -= _daysOfEnergyRations>>
+		<<if !_args[2]>>
+			/* Round up the number of days of energy rations to a whole number, as GeneralTimeStats iterates per day. */
+			<<set _daysOfEnergyRations = Math.ceil(_daysOfEnergyRations)>>
+			/* If we used up all the energy rations we had, stop using them. */
+			<<if Math.ceil(_consumptionPerDay * _daysOfEnergyRations) >= $items[24].count>>
+				<<set $useEnergyrations = false>>
+			<</if>>
 		<</if>>
 	<</if>>
 <</if>>
 
 /* If the additive modifier is a time penalty, apply it to the modified time. */
 <<if _additiveModifier > 0>>
-	<<set $tempTime += _additiveModifier>>
+	<<set _inputTime += _additiveModifier>>
 <</if>>
 
 /* Don't allow travel time to become negative. */
-<<if $tempTime < 0>><<set $tempTime = 0>><</if>>
+<<if _inputTime < 0>><<set _inputTime = 0>><</if>>
 
 /* Round travel time to a whole number of days. */
-<<set $tempTime = Math.round($tempTime)>>
+<<set _inputTime = Math.round(_inputTime)>>
 
-<<if _daysOfEnergyRations && _daysOfEnergyRations > $tempTime>>
-	/* Ensure all days of energy rations end up used. */
-	<<set $items[24].count -= _consumptionPerDay * (_daysOfEnergyRations - $tempTime)>>
-	<<set _daysOfEnergyRations = $tempTime>>
+<<if !_args[2]>>
+	<<if _daysOfEnergyRations && _daysOfEnergyRations > _inputTime>>
+		/* Ensure all days of energy rations end up used. */
+		<<set $items[24].count -= _consumptionPerDay * (_daysOfEnergyRations - _inputTime)>>
+		<<set _daysOfEnergyRations = _inputTime>>
+	<</if>>
 <</if>>
+
+/* Write to the output variable. */
+<<print "<<set " + _args[0] + " = " + _inputTime + ">>">>
+
+<</widget>>
 
 :: GeneralTimeStats [nobr]
 <<capture _i>>

--- a/src/global.twee
+++ b/src/global.twee
@@ -34,6 +34,66 @@ setup.calcCarriedWeight = function() {
 	);
 }
 
+:: Sell or unsell relic [script]
+setup.sellRelic = relicOrNameOrIndex => {
+	const vars = variables();
+	let relic, name, index;
+	switch (typeof relicOrNameOrIndex) {
+		case 'string':
+			name = relicOrNameOrIndex;
+			index = vars.ownedRelics.findIndex(relic => relic.name == name);
+			if (index >= 0) {
+				relic = vars.ownedRelics[index];
+			} else {
+				console.error(`Relic '${name}' not found in $ownedRelics!`);
+			}
+			break;
+		case 'number':
+			index = relicOrNameOrIndex;
+			if (0 <= index && index < vars.ownedRelics.length) {
+				relic = vars.ownedRelics[index];
+				name = relic.name;
+			} else {
+				console.error(`${index} is not a valid index in $ownedRelics!`);
+			}
+			break;
+		default:
+			relic = relicOrNameOrIndex;
+			if (relic) {
+				name = relic.name;
+				index = vars.ownedRelics.findIndex(relic => relic.name == name);
+				if (index < 0) console.error(`Relic '${name}' not found in $ownedRelics!`);
+			} else {
+				console.error('Passed relic was undefined!');
+			}
+	}
+	if (0 <= index && index < vars.ownedRelics.length) vars.ownedRelics.splice(index, 1);
+	if (relic) vars.soldRelics.push(relic);
+};
+setup.unsellRelic = relicOrName => {
+	const vars = variables();
+	let relic, name, index;
+	if (typeof relicOrName == 'string') {
+		name = relicOrName;
+		index = vars.soldRelics.findLastIndex(relic => relic.name == name);
+		if (index >= 0) {
+			relic = vars.soldRelics[index];
+		} else {
+			relic = vars.relics.findLast(relic => relic.name == name);
+		}
+		if (!relic) console.error(`Relic '${name}' does not exist!`);
+	} else {
+		relic = relicOrName;
+		if (relic) {
+			name = relic.name;
+			index = vars.soldRelics.findLastIndex(relic => relic.name == name);
+		} else {
+			console.error('Passed relic was undefined!');
+		}
+	}
+	if (index >= 0) vars.soldRelics.splice(index, 1);
+	if (relic) vars.ownedRelics.push(relic);
+};
 
 :: Check Availability of Cutting Tool [script]
 setup.haveCuttingTool = function() {
@@ -49,10 +109,26 @@ setup.haveScubaGear = function() {
 	);
 }
 
+:: Smartphone helpers [script]
+Object.defineProperty(setup, 'smartphoneRegular', {
+	get: () => variables().items[17],
+});
+Object.defineProperty(setup, 'haveSmartphoneRegular', {
+	get: () => variables().items[17].count > 0,
+	set: have => { variables().items[17].count = have ? 1 : 0; },
+});
+Object.defineProperty(setup, 'haveSmartphoneAI', {
+	get: () => variables().items[21].count > 0,
+	set: have => { variables().items[21].count = have ? 1 : 0; },
+});
+Object.defineProperty(setup, 'haveSmartphone', {
+	get: () => setup.haveSmartphoneRegular || setup.haveSmartphoneAI,
+});
+
 :: Check Availability of Light Source [script]
 // Light sources that are not going to run out during an expedition.
 setup.haveUnlimitedLightSource = function() {
-	return variables().light != 0 || variables().items[10].count > 0 || variables().items[17].count > 0 || variables().items[21].count > 0 || variables().ownedRelics.some(
+	return variables().light != 0 || variables().items[10].count > 0 || setup.haveSmartphone || variables().ownedRelics.some(
 		r => r.name === "Sunbeam" || r.name === "Glare Vantage"|| variables().BDwear
 	);
 }
@@ -71,7 +147,7 @@ setup.haveTravelLightSource = function() {
 
 :: Check Availability of notepad [script]
 setup.haveNotepad = function() {
-	return variables().notepad != 0 || variables().items[17].count > 0 ||  variables().items[21].count > 0 || variables().items[26].count > 0;
+	return variables().notepad != 0 || setup.haveSmartphone || variables().items[26].count > 0;
 }
 
 :: Check Availability of rope [script]
@@ -224,7 +300,7 @@ Click this if you have found something that can be used for swimming underwater,
 
 <<if $abyssKnow == 1>>Click this if you'd like to disable the use of your abyssal knowledge from the encyclopedia, smartphone or Saeko (This will result in more side effects from foraging):
 	[[Turn off abyssal knowledge|Adjustments][$abyssKnowCheatoff = true]]
-<<elseif $abyssKnow == 0 && ($hiredCompanions.some(e => e.name === "Saeko") || $items[5].count > 0 || $items[17].count>0 || $items[21].count > 0)>>Click this if you'd like to enable the use of your abyssal knowledge from the encyclopedia or Saeko (This will result in less side effects from foraging):
+<<elseif $abyssKnow == 0 && ($hiredCompanions.some(e => e.name === "Saeko") || $items[5].count > 0 || setup.haveSmartphone)>>Click this if you'd like to enable the use of your abyssal knowledge from the encyclopedia or Saeko (This will result in less side effects from foraging):
 	[[Turn on abyssal knowledge|Adjustments][$abyssKnowCheatoff = false]]
 <</if>>
 If you would like to use a Relic or combination of Relics to trade with the surface, similar to a commerce balloons function, then use the following:
@@ -789,23 +865,24 @@ Choose the Relic you would like to sell:
 		<<if $ownedRelics[$i].name=="Creepy Doll" && $creepydoll.affec > 5>>
 			You can't seem to part ways with the Creepy Doll<br>
 		<<elseif $ownedRelics[$i].name=="Chain of Lorelei">>
-			<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Balloon Sell1][$colwear=0,$dubloons += ($ownedRelics[$i].value + $sellAdd), $soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i)]]">><br>
+			<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Balloon Sell1][$colwear=0,$dubloons += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
 		<<elseif $ownedRelics[$i].name=="Heart-stealing Stole">>
-			<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Balloon Sell1][$hsswear=0,$dubloons += ($ownedRelics[$i].value + $sellAdd), $soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i)]]">><br>
+			<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Balloon Sell1][$hsswear=0,$dubloons += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
 		<<elseif $ownedRelics[$i].name=="Solace Lace">>
-			<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Balloon Sell1][$slwear=0,$dubloons += ($ownedRelics[$i].value + $sellAdd), $soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i)]]">><br>
+			<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Balloon Sell1][$slwear=0,$dubloons += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
 		<<elseif $ownedRelics[$i].name=="Sibyl Blend">>
-			<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Balloon Sell1][$SibylBuff=0,$dubloons += ($ownedRelics[$i].value + $sellAdd), $soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i)]]">><br>
+			<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Balloon Sell1][$SibylBuff=0,$dubloons += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
 		<<elseif $ownedRelics[$i].name=="World Stone" && $LilyPromise>>
-			<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Balloon Sell1][$dubloons += ($ownedRelics[$i].value + $sellAdd), $soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i), $companionLily.affec-=(5-$hsswear)]]">> <br>You promised Lily she could use the World Stone, selling it now will surely dissapoint her greatly. <br>
+			<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Balloon Sell1][$dubloons += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i), $companionLily.affec -= (5 - $hsswear)]]">>
+			You promised Lily she could use the World Stone, selling it now will surely dissapoint her greatly.<br>
 		<<elseif $ownedRelics[$i].name=="Everhevea">>
 			<<if $items[2].count >= 2>>
-				<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Balloon Sell1][$dubloons += ($ownedRelics[$i].value + $sellAdd), $soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i), $items[2].count-=2]]">>
+				<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Balloon Sell1][$dubloons += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i), $items[2].count -= 2]]">>
 			<<else>>
 				You need to empty the Everheavea to sell it (have at least two empty flasks in your inventory) <br>
 			<</if>>
 		<<else>>
-			<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Balloon Sell1][$dubloons += ($ownedRelics[$i].value + $sellAdd), $soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i)]]">><br>
+			<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Balloon Sell1][$dubloons += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
 		<</if>>
 	<</capture>>
 <</for>>
@@ -901,7 +978,7 @@ Helpful people on the surface managed to find your items safely, retrieving all 
 	<<for _i = 0; _i < $ownedRelics.length; _i++>>
 		<<capture _i>>
 			<<if $ownedRelics[_i].name=="Phoenix Obol">>
-				[[Open your eyes to find yourself back in the Abyss, your hand clutching a scorched coin, now devoid of its sigil|_string][$soldRelics.push($ownedRelics[_i]), $ownedRelics.deleteAt(_i),$starving=0,$dehydrated=0,$SemenDemonBalance=0,$gameOver=false]]
+				[[Open your eyes to find yourself back in the Abyss, your hand clutching a scorched coin, now devoid of its sigil|_string][setup.sellRelic(_i),$starving=0,$dehydrated=0,$SemenDemonBalance=0,$gameOver=false]]
 			<</if>>
 		<</capture>>
 	<</for>>
@@ -1123,7 +1200,7 @@ If you are over 18, please go back and enter an age above 18 to continue.
 <<if $abyssKnow == 1>>
 	<br>You currently have abyssal knowledge granted by the encyclopedia, smartphone or Saeko. You can choose to disable it if you would like more side effects from foraging:<br>
 	[[Turn off abyssal knowledge|Adjustments][$abyssKnowCheatoff = true]]<br>
-<<elseif $abyssKnow == 0 && ($hiredCompanions.some(e => e.name === "Saeko") || $items[5].count > 0 || $items[17].count>0 || $items[21].count > 0)>>
+<<elseif $abyssKnow == 0 && ($hiredCompanions.some(e => e.name === "Saeko") || $items[5].count > 0 || setup.haveSmartphone)>>
 	<br>You currently have abyssal knowledge by the encyclopedia, smartphone or Saeko, but you are not using it. You can choose to enable it if you would like less side effects from foraging:<br>
 	[[Turn on abyssal knowledge|Adjustments][$abyssKnowCheatoff = false]]<br>
 <</if>>
@@ -1455,9 +1532,9 @@ If you are over 18, please go back and enter an age above 18 to continue.
 	<</if>>
 <</if>>
 
-<<if $ownedRelics.some(e => e.name === "Kin Shifter")>>
+<<if $ownedRelics.some(e => e.name === "Kin Shifter") && $ownedRelics.length > 1>>
 	<br>A glob of putty-like slime lays ready for you to copy other Relics, if you desire to.<br>
-	[[Use the Kin Shifter to copy Relics|Kin Shifter Use][$tempValue = 0]]<br><br>
+	[[Use the Kin Shifter to copy Relics|Kin Shifter Use]]<br><br>
 <</if>>
 
 <<if $ownedRelics.some(e => e.name === "Forbidden Grimoire") && $hiredCompanions.length > 0>>
@@ -1693,52 +1770,31 @@ B: (20)->(30)->(40) = total 90, over 70, done.
 C: (120) done, only possible configuration for duplicating a Relic worth this much.
 
 <<nobr>>
-The current total value of Relics you have copied is $tempValue dubloons.<br><br>
+<<if !$relic38.copiedValue>><<set $relic38.copiedValue = 0>><</if>>
+The current total value of Relics you have copied is $relic38.copiedValue dubloons.<br><br>
 
-<<if $tempValue == 0>>
-<<if $ownedRelics.length==1>>
-	<<set $temp=0>>
-<<else>>
-	<<for $i = 0; $i < $ownedRelics.length && !$endloop; $i++>>
-		<<if $ownedRelics[$i].name=="Kin Shifter" >>
-			<<set $temp=$i>>
-			<<set $endloop=false>>
+<<if $relic38.copiedValue < 70>>
+	Please choose the Relic you would like to copy:<br>
+	<<for _relic range $ownedRelics>>
+		<<if _relic.name != "Kin Shifter" && (!$relic38.copiedValue || _relic.value <= 70)>>
+			<<capture _relic>>
+				<<if _relic.name == "Managed Misfortune">>
+					_relic.name for _relic.value dubloons [[Copy|Kin Shifter Use][$ownedRelics.push(_relic), $relic38.copiedValue += _relic.value, $ManagedMisfortuneMax += 2]]<br>
+				<<else>>
+					_relic.name for _relic.value dubloons [[Copy|Kin Shifter Use][$ownedRelics.push(_relic), $relic38.copiedValue += _relic.value]]<br>
+				<</if>>
+			<</capture>>
 		<</if>>
 	<</for>>
-	<<set $soldRelics.push($ownedRelics[$temp])>>
-	<<set $ownedRelics.deleteAt($temp)>>
-<</if>>
-
-Please choose the Relic you would like to copy:<br>
-<<for $i = 0; $i < $ownedRelics.length; $i++>>
-	<<capture $i>>
-			<<if $ownedRelics[$i].name == "Managed Misfortune">>
-				<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value)>><<print " dubloons ">><<print "[[Copy|Kin Shifter Use][$ownedRelics.push($ownedRelics[$i]), $tempValue += $ownedRelics[$i].value, $ManagedMisfortuneMax=4]]">><br>
-			<<else>>
-				<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value)>><<print " dubloons ">><<print "[[Copy|Kin Shifter Use][$ownedRelics.push($ownedRelics[$i]), $tempValue += $ownedRelics[$i].value]]">><br>
-			<</if>>
-	<</capture>>
-<</for>>
-
-<<elseif $tempValue <= 69>>
-Please choose the Relic you would like to copy:<br>
-<<for $i = 0; $i < $ownedRelics.length; $i++>>
-	<<capture $i>>
-		<<if $ownedRelics[$i].value <= 70>>
-			<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value)>><<print " dubloons ">><<print "[[Copy|Kin Shifter Use][$ownedRelics.push($ownedRelics[$i]), $tempValue += $ownedRelics[$i].value]]">><br>
-		<</if>>
-	<</capture>>
-<</for>>
-
 <<else>>
-As you touched the final Relic to the Kin Shifter, the last of the goo was used up and your Relic was copied. The cute eyes faded as the slime transmuted into the new Relic you chose. <br><br>
+	<<set setup.sellRelic("Kin Shifter")>>
+	As you touched the final Relic to the Kin Shifter, the last of the goo was used up and your Relic was copied. The cute eyes faded as the slime transmuted into the new Relic you chose.<br><br>
 
-Now that you have become better equipped, you can continue your journey.<br><br>
-
-[[Return to exploring|$layerReturn]]
-
+	Now that you have become better equipped, you can continue your journey.<br>
 <</if>>
 <</nobr>>
+
+[[Return to exploring|$layerReturn]]
 
 :: Daedalus Mechanism Select [noreturn]
 
@@ -1937,7 +1993,7 @@ How many dubloons would you like to pay back?
 		<</if>>
 	<<case 8>>
 		/* Reduce travel time if player has some form of compass. */
-		<<if $items[12].count || $items[17].count || $items[21].count>>
+		<<if $items[12].count || setup.haveSmartphone>>
 			The comforting presence of a device that discerns north from south in this bewildering maze bolsters your confidence and allows you to navigate more efficiently.<br>
 			<<set _additiveModifier -= 3>>
 		<</if>>
@@ -2310,7 +2366,7 @@ How many dubloons would you like to pay back?
 					<<include "Drinking code">>
 				<<case 6>>
 					<<set $waterL6 += 1>>
-					<<if !($hiredCompanions.some(e => e.name === "Saeko") && ($items[17].count || $items[21].count))>>
+					<<if !($hiredCompanions.some(e => e.name === "Saeko") && setup.haveSmartphone)>>
 						<<set $hexflame += 1>>
 					<</if>>
 				<<case 7>>
@@ -2333,14 +2389,14 @@ How many dubloons would you like to pay back?
 					<<include "Drinking code">>
 				<<case 6>>
 					<<set $waterL6 += 1>>
-					<<if !($hiredCompanions.some(e => e.name === "Saeko") && ($items[17].count || $items[21].count))>>
+					<<if !($hiredCompanions.some(e => e.name === "Saeko") && setup.haveSmartphone)>>
 						<<set $hexflame += 1>>
 					<</if>>
 				<<case 7>>
 					<<include "Drinking code">>
 				<<case 8>>
 					<<set $waterL8 += 1>>
-					<<if !($hiredCompanions.some(e => e.name === "Saeko") && ($items[17].count || $items[21].count))>>
+					<<if !($hiredCompanions.some(e => e.name === "Saeko") && setup.haveSmartphone)>>
 						<<set $IQdrop += 0.5>>
 					<<else>>
 						<<set $IQdrop += 0.05>>
@@ -3061,7 +3117,8 @@ Items:<br>
 			<<elseif $ownedRelics[_i].name=="Sibyl Blend">>
 				<<print "[[$ownedRelics[_i].name|Relic Info][$temp = _i]] $ownedRelics[_i].weight kg | [[Drop|Drop Items Menu][$SibylBuff=0, $ownedRelics.deleteAt(_i)]]">><br>
 			<<elseif $ownedRelics[_i].name=="World Stone" && $LilyPromise>>
-				<<print "[[$ownedRelics[_i].name|Relic Info][$temp = _i]] $ownedRelics[_i].weight kg | [[Drop|Drop Items Menu][$ownedRelics.deleteAt(_i), $companionLily.affec-=(5-$hsswear)]]">> <br>You promised Lily she could use the World Stone, Droping it now will surely dissapoint her greatly. <br>
+				<<print "[[$ownedRelics[_i].name|Relic Info][$temp = _i]] $ownedRelics[_i].weight kg | [[Drop|Drop Items Menu][$ownedRelics.deleteAt(_i), $companionLily.affec -= (5 - $hsswear)]]">>
+				You promised Lily she could use the World Stone, Droping it now will surely dissapoint her greatly.<br>
 			<<elseif $ownedRelics[_i].name=="Everhevea">>
 				<<if $items[2].count >= 2>>
 					<<print "[[$ownedRelics[_i].name|Relic Info][$temp = _i]] $ownedRelics[_i].weight kg | [[Drop|Drop Items Menu][$ownedRelics.deleteAt(_i), $items[2].count-=2]]">><br>

--- a/src/layer1.twee
+++ b/src/layer1.twee
@@ -80,7 +80,7 @@ Her thoughts trail off, and after a moment, she stands and resumes the journey w
 <br>
 What do you want to do while you're here?<br><br>
 [[Use Items and Relics]]<br>
-<<if $hiredCompanions.length > 0 || $items[21].count>0>>
+<<if $hiredCompanions.length > 0 || setup.haveSmartphoneAI>>
 [[Interact with your party|Party overview]] <<CheckParty>><br>
 <</if>>
 <</nobr>>
@@ -1083,34 +1083,34 @@ Choose the Relic you would like to hand over to the bandits:
 		<<if $ownedRelics[$i].name=="Creepy Doll" && $creepydoll.affec > 5>>
 			You would never hand over your Dolly... Uh, the Creepy Doll, you mean.<br>
 		<<elseif $ownedRelics[$i].name=="Chain of Lorelei">>
-			<<print $ownedRelics[$i].name>><<print " worth ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Hand over|Relic Surrender][$colwear=0, $surrVal += ($ownedRelics[$i].value + $sellAdd), $soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i)]]">><br>
+			<<print $ownedRelics[$i].name>><<print " worth ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Hand over|Relic Surrender][$colwear=0, $surrVal += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
 
 		<<elseif $ownedRelics[$i].name=="Heart-stealing Stole">>
-			<<print $ownedRelics[$i].name>><<print " worth ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Hand over|Relic Surrender][$hsswear=0, $surrVal += ($ownedRelics[$i].value + $sellAdd), $soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i)]]">><br>
+			<<print $ownedRelics[$i].name>><<print " worth ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Hand over|Relic Surrender][$hsswear=0, $surrVal += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
 
 		<<elseif $ownedRelics[$i].name=="Sibyl Blend">>
-			<<print $ownedRelics[$i].name>><<print " worth ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Hand over|Relic Surrender][$SibylBuff=0,$surrVal += ($ownedRelics[$i].value + $sellAdd), $soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i)]]">><br>
+			<<print $ownedRelics[$i].name>><<print " worth ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Hand over|Relic Surrender][$SibylBuff=0,$surrVal += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
 		<<elseif $ownedRelics[$i].name=="World Stone" && $LilyPromise>>
-			<<print $ownedRelics[$i].name>><<print " worth ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Hand over|Relic Surrender][$surrVal += ($ownedRelics[$i].value + $sellAdd), $soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i), $companionLily.affec-=(3-$hsswear)]]">> 
-			<br> You promised Lily she could use the World Stone. Although you are not exactly selling it, you feel she would still be dissapointed if you gave it away <br>
+			<<print $ownedRelics[$i].name>><<print " worth ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Hand over|Relic Surrender][$surrVal += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i), $companionLily.affec -= (3-$hsswear)]]">> 
+			<br>You promised Lily she could use the World Stone. Although you are not exactly selling it, you feel she would still be dissapointed if you gave it away.<br>
 		<<elseif $ownedRelics[$i].name=="Everhevea">>
 			<<if $items[2].count >= 2>>
-				<<print $ownedRelics[$i].name>><<print " worth ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Hand over|Relic Surrender][$surrVal += ($ownedRelics[$i].value + $sellAdd), $soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i), $items[2].count-=2]]">>
+				<<print $ownedRelics[$i].name>><<print " worth ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Hand over|Relic Surrender][$surrVal += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i), $items[2].count -= 2]]">>
 			<<else>>
 				You need to empty the Everheavea to hand it over (have at least two empty flasks in your inventory) <br>
 			<</if>>
 		<<elseif $ownedRelics[$i].name=="Daedalus Mechanism">>
-			<<print $ownedRelics[$i].name>><<print " worth ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Hand over|Relic Surrender][$DaedalusEquip = false, $DaedalusFly = false, $surrVal += ($ownedRelics[$i].value + $sellAdd), $soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i)]]">><br>
+			<<print $ownedRelics[$i].name>><<print " worth ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Hand over|Relic Surrender][$DaedalusEquip = false, $DaedalusFly = false, $surrVal += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
 		<<elseif $ownedRelics[$i].name=="Blind Divine">>
-			<<print $ownedRelics[$i].name>><<print " worth ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Hand over|Relic Surrender][$BDwear = false, $surrVal += ($ownedRelics[$i].value + $sellAdd), $soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i)]]">><br>
+			<<print $ownedRelics[$i].name>><<print " worth ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Hand over|Relic Surrender][$BDwear = false, $surrVal += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
 		<<elseif $ownedRelics[$i].name=="Heavy is the Head">>
-			<<print $ownedRelics[$i].name>><<print " worth ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Hand over|Relic Surrender][$HeavyHeadwear= false, $surrVal += ($ownedRelics[$i].value + $sellAdd), $soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i)]]">><br>
+			<<print $ownedRelics[$i].name>><<print " worth ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Hand over|Relic Surrender][$HeavyHeadwear= false, $surrVal += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
 		<<elseif $ownedRelics[$i].name=="Moonwatcher" & $BionicEye >>
 			<<print $ownedRelics[$i].name>> You can't give away Relics that have become part of your body.<br>
 		<<elseif $ownedRelics[$i].name=="Glory's Grasp" & $BionicArm >>
 			<<print $ownedRelics[$i].name>> You can't give away Relics that have become part of your body.<br>
 		<<else>>
-			<<print $ownedRelics[$i].name>><<print " worth ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Hand over|Relic Surrender][$surrVal += ($ownedRelics[$i].value + $sellAdd), $soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i)]]">><br>
+			<<print $ownedRelics[$i].name>><<print " worth ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Hand over|Relic Surrender][$surrVal += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
 		<</if>>
 	<</capture>>
 <</for>>
@@ -1263,7 +1263,7 @@ Finally, the vision fades, leaving you standing once again where you were before
 	<</for>>
 <</if>>
 <</nobr>>
-[[Return|$previewReturn][$soldRelics.push($ownedRelics[$temp]), $ownedRelics.deleteAt($temp), $endloop=false]]
+[[Return|$previewReturn][setup.sellRelic($temp), $endloop=false]]
 
 :: Layer1 notes [image layer1 noreturn]
 

--- a/src/layer1.twee
+++ b/src/layer1.twee
@@ -944,8 +944,7 @@ But gradually, a newfound certainty washes over you - the realization that your 
 <<nobr>>
 <<set $corruption -= $playerCurses[$temp].corr>>
 <<set $iconUsed = 1>>
-<<set $tempTime=3>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" 3>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 The Curse, $playerCurses[$temp].name, has been successfully removed and your corruption has been refunded.<br>
 <<RemoveCurse $playerCurses[$temp]>>
 <</nobr>>
@@ -978,8 +977,7 @@ Traveling back to the surface from here will take 1 day, and will cost 10 corrup
 <</if>>
 <<if $layerExit == 0>>
 	<<set $layerExit = 1>>
-	<<set $tempTime=1>>
-	<<include "GeneralTimeSetup">>
+	<<AdjustedTravelTime "$tempTime" 1>>
 	<<set $layerExitTime=$tempTime>>
 <</if>>
 

--- a/src/layer2.twee
+++ b/src/layer2.twee
@@ -1,8 +1,7 @@
 :: Layer2 1 [layer2]
 <<nobr>>
 <<masteraudio stop>><<audio "layer2" volume 0.2 play loop>>
-<<set $tempTime = 2>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" 2>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 <<set $timeL2T1 = 0>>
 <<set $currentLayer = 2>>
 <</nobr>>\
@@ -528,8 +527,7 @@ What type of fur would you like to gain?
 <<nobr>>
 <<set $corruption += 100>>
 <<set $brokerUsed = 1>>
-<<set $tempTime = 2>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" 2>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 <</nobr>>
 [img[setup.ImagePath+'Wonders/empty-handedbroker.png']]
 
@@ -577,8 +575,7 @@ Whose body do you find yourself in?
 <<set $corruption += 70>>
 <<set $starUsed = 1>>
 <<set $swapComp = $temp>>
-<<set $tempTime = 3>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" 3>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 <<set $hiredCompanions[$swapComp].carry = $temp2>>
 <<CarryAdjust>>
 <</nobr>>
@@ -1472,8 +1469,7 @@ A few tests and you can confirm you have pure water to fill your flasks with! No
 <<nobr>>
 <<if $layerExit == 0>>
 	<<set $layerExit = 1>>
-	<<set $tempTime=5>>
-	<<include "GeneralTimeSetup">>
+	<<AdjustedTravelTime "$tempTime" 5>>
 	<<set $layerExitTime=$tempTime>>
 <</if>>
 
@@ -1510,7 +1506,7 @@ Subtle changes in your surroundings continue, large rocks start to appear in you
 	<<if $DaedalusFly==true>>
 		<<set $tempTime= Math.ceil($tempTime/2)>>
 	<</if>>
-	<<include "GeneralTimeSetup">>
+	<<AdjustedTravelTime "$tempTime" $tempTime>>
 	<<set $layerExitTime=$tempTime>>
 <</if>>
 <<for $layerExitTime; $layerExitTime >0; $layerExitTime-->>

--- a/src/layer2.twee
+++ b/src/layer2.twee
@@ -1756,7 +1756,7 @@ Finally, the vision fades, leaving you standing once again where you were before
 	<</for>>
 <</if>>
 <</nobr>>
-[[Return|$previewReturn][$soldRelics.push($ownedRelics[$temp]), $ownedRelics.deleteAt($temp), $endloop=false]]
+[[Return|$previewReturn][setup.sellRelic($temp), $endloop=false]]
 
 :: Layer2 notes [image layer2 noreturn]
 

--- a/src/layer3.twee
+++ b/src/layer3.twee
@@ -1740,7 +1740,7 @@ Finally, the vision fades, leaving you standing once again where you were before
 	<</for>>
 <</if>>
 <</nobr>>
-[[Return|$previewReturn][$soldRelics.push($ownedRelics[$temp]), $ownedRelics.deleteAt($temp), $endloop=false]]
+[[Return|$previewReturn][setup.sellRelic($temp), $endloop=false]]
 
 :: Layer3 notes [image layer3 noreturn]
 

--- a/src/layer3.twee
+++ b/src/layer3.twee
@@ -200,13 +200,11 @@ You have already used the scales on your journey. You may not use them again.
 <<elseif $skewedForced < 4>>
 	Would you like to use the Skewed Shrine to give a Curse to one of your willing companions at the cost of <<print ($skewedUsed * 5)>> dubloons?<br>
 	<<link "Yes, use the Skewed Shrine to transfer a Curse" "Layer3 Skewed1a">>
-		<<set $tempTime = 3>>
-		<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+		<<AdjustedTravelTime "$tempTime" 3>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 	<</link>><br><br>
 	Would you like to use the Skewed Shrine to force a Curse upon one of your unwilling companions at the cost of <<print ($skewedUsed * 5)>> dubloons?<br>
 	<<link "Yes, use the Skewed Shrine to force a Curse" "Layer3 Skewed 2a">>
-		<<set $tempTime = 3>>
-		<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+		<<AdjustedTravelTime "$tempTime" 3>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 	<</link>><br><br>
 <<else>>
 	None of your companions trust you at this shrine anymore. None will get close enough for you to use the shrine with them. They watch you with eyes full of fear and anger, as if they could bolt at any moment and leave you alone in the Abyss.<br><br>
@@ -269,7 +267,7 @@ In the deeper parts of the layer, a cold breeze occasionally blows through the c
 	<<if $DaedalusFly==true>>
 		<<set $tempTime= Math.ceil($tempTime/2)>>
 	<</if>>
-	<<include "GeneralTimeSetup">>
+	<<AdjustedTravelTime "$tempTime" $tempTime>>
 	<<set $layerExitTime=$tempTime>>
 <</if>>
 
@@ -344,8 +342,7 @@ In the deeper parts of the layer, a cold breeze occasionally blows through the c
 <<set $temp = Math.round($corruption / 5)>>
 <<set $dubloons += $temp>>
 <<set $scalesUsed = 1>>
-<<set $tempTime = 2>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" 2>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 <</nobr>>
 [img[setup.ImagePath+'Wonders/gossameryscales.png']]
 
@@ -361,8 +358,7 @@ Once you pick them up, the luster of the scales fades, indicating that they will
 <<set $temp = Math.round($dubloons / 5)>>
 <<set $corruption += $temp>>
 <<set $scalesUsed = 1>>
-<<set $tempTime = 2>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" 2>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 <</nobr>>
 [img[setup.ImagePath+'Wonders/gossameryscales.png']]
 
@@ -855,7 +851,7 @@ On the other hand, the idea of each encounter feeling like your first time holds
 <<set $tempTime = (Math.max(4 -$abyssKnow - $riverVisit, 0))>>
 <<set $riverVisit = 1>>
 
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" $tempTime>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 
 <<for _i = 0; _i < 999; _i++>>
 	<<if $items[2].count > 0>>
@@ -1277,8 +1273,7 @@ Please enter your new skin/eye color:
 <<nobr>>
 <<if $layerExit == 0>>
 	<<set $layerExit = 1>>
-	<<set $tempTime = 6>>
-	<<include "GeneralTimeSetup">>
+	<<AdjustedTravelTime "$tempTime" 6>>
 	<<set $layerExitTime=$tempTime>>
 <</if>>
 

--- a/src/layer4.twee
+++ b/src/layer4.twee
@@ -1515,7 +1515,7 @@ Finally, the vision fades, leaving you standing once again where you were before
 	<</for>>
 <</if>>
 <</nobr>>
-[[Return|$previewReturn][$soldRelics.push($ownedRelics[$temp]), $ownedRelics.deleteAt($temp), $endloop=false]]
+[[Return|$previewReturn][setup.sellRelic($temp), $endloop=false]]
 
 :: Layer4 notes [image layer4 noreturn]
 

--- a/src/layer4.twee
+++ b/src/layer4.twee
@@ -234,13 +234,11 @@ The Brave Vector Relic you can find here is a perfect example of something you m
 <<elseif $steadyForced < 4>>
 	Would you like to use the Steady Shrine to copy a Curse to one of your willing companions at the cost of <<print ($skewedUsed * 5)>> dubloons?<br>
 	<<link "Yes, use the Steady Shrine to copy a Curse" "Layer4 Steady1a">>
-		<<set $tempTime = 3>>
-		<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+		<<AdjustedTravelTime "$tempTime" 3>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 	<</link>><br><br>
 	Would you like to use the Steady Shrine to forcibly copy a Curse onto one of your unwilling companions at the cost of <<print ($skewedUsed * 5)>> dubloons?<br>
 	<<link "Yes, use the Steady Shrine to forcibly copy a Curse" "Layer4 Steady 2a">>
-		<<set $tempTime = 3>>
-		<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+		<<AdjustedTravelTime "$tempTime" 3>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 	<</link>><br><br>
 <<else>>
 	None of your companions trust you at this shrine anymore. None will get close enough for you to use the shrine with them. They watch you with eyes full of fear and anger, as if they could bolt at any moment and leave you alone in the Abyss.<br><br>
@@ -856,8 +854,7 @@ Which Curse would you like to forcibly copy onto your unwilling companion?
 :: Layer4 Purity 1 [layer4]
 <<nobr>>
 <<set $purityUsed = 1>>
-<<set $tempTime = 5>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" 5>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 <</nobr>>
 [img[setup.ImagePath+'Wonders/puritytree.png']]
 
@@ -1097,7 +1094,7 @@ You have successfully taken the $relic48.name Relic. Hopefully you can make good
 		<<set $tempTime = 19>>
 	<</if>>
 
-	<<include "GeneralTimeSetup">>
+	<<AdjustedTravelTime "$tempTime" $tempTime>>
 	<<set $layerExitTime=$tempTime>>
 
 <</if>>
@@ -1182,7 +1179,7 @@ You have successfully taken the $relic48.name Relic. Hopefully you can make good
 	<<if $DaedalusFly==true>>
 		<<set $tempTime= Math.ceil($tempTime/2)>>
 	<</if>>
-	<<include "GeneralTimeSetup">>
+	<<AdjustedTravelTime "$tempTime" $tempTime>>
 	<<set $layerExitTime=$tempTime>>
 <</if>>
 

--- a/src/layer5.twee
+++ b/src/layer5.twee
@@ -432,7 +432,8 @@ Already taken
 Do you want to walk through the One-sided Tunnel and send your items back up to the surface?
 
 [[Walk through the tunnel|Layer5 Tunnel]]
-<<if $totalRelics.some(e => e.name === "Superpositional Skewer") && $items[7].count > 0>>
+<<set _totalRelics = $ownedRelics.concat($soldRelics)>>
+<<if _totalRelics.some(e => e.name === "Superpositional Skewer") && $items[7].count > 0>>
 
 	You can also utilize your Superpositional Skewer to sync with your commerce balloon, then swap it with a rock or something after you leave the Tunnel, which would allow you to instantly retrieve your items if you wish to. 
 
@@ -1210,8 +1211,7 @@ The Relics you have found with Cherry's Chaotic Luck are $relics[$temp1].name an
 		<<set $corruption += Math.floor(Math.max(($relics[$temp2].corr / 2) - $corRed, 0))>>
 
 		<<set _temp = $ownedRelics.findIndex(e=> e.name==="Devil's Own")>>
-		<<set $soldRelics.push($ownedRelics[_temp])>>
-		<<set $ownedRelics.deleteAt(_temp)>>
+		<<set setup.sellRelic(_temp)>>
 	<</link>>
 
 <</if>>
@@ -1303,8 +1303,7 @@ Please enter your new exoskeleton color:
 		<<RemoveCurse $curses[$temp2]>>
 
 		<<set _temp = $ownedRelics.findIndex(e=> e.name==="Devil's Own")>>
-		<<set $soldRelics.push($ownedRelics[_temp])>>
-		<<set $ownedRelics.deleteAt(_temp)>>
+		<<set setup.sellRelic(_temp)>>
 	<</link>>
 
 <</if>>
@@ -1386,8 +1385,7 @@ Please enter your new exoskeleton color:
 		<</if>>
 		<<RemoveCurse $curses[$temp2]>>
 		<<set _temp = $ownedRelics.findIndex(e=> e.name==="Devil's Own")>>
-		<<set $soldRelics.push($ownedRelics[_temp])>>
-		<<set $ownedRelics.deleteAt(_temp)>>
+		<<set setup.sellRelic(_temp)>>
 	<</link>>
 
 <</if>>
@@ -1756,7 +1754,7 @@ Finally, the vision fades, leaving you standing once again where you were before
 	<</for>>
 <</if>>
 <</nobr>>
-[[Return|$previewReturn][$soldRelics.push($ownedRelics[$temp]), $ownedRelics.deleteAt($temp), $endloop=false]]
+[[Return|$previewReturn][setup.sellRelic($temp), $endloop=false]]
 
 :: Layer5 notes [image layer5 noreturn]
 

--- a/src/layer5.twee
+++ b/src/layer5.twee
@@ -498,7 +498,7 @@ Layer 5 is the last layer that anyone on the surface currently has any reliable 
 	<<set $status.penalty = 0>>
 <</if>>
 <<set $tempTime = (Math.max(4 - ($oasisVisit * 2) - $abyssKnow, 0))>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" $tempTime>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 
 <<for $i = 0; $i < 999; $i++>>
 	<<if $items[2].count > 0>>
@@ -1393,8 +1393,7 @@ Please enter your new exoskeleton color:
 
 :: Layer5 Tunnel [layer5]
 <<nobr>>
-<<set $tempTime = 2>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" 2>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 <</nobr>>
 [img[setup.ImagePath+'Wonders/one-sidedtunnel.png']]
 
@@ -1447,8 +1446,7 @@ Testing your Pocket Hoard, you stick a hand into the pink rucksack, but find you
 <<if $timeL5T1 < 8 && $timeL5T2 < 11>>[img[setup.ImagePath+'Wonders/miragevault.png']]
 <<nobr>>
 <<if $vaultWait == 0>>
-	<<set $tempTime = 3>>
-	<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+	<<AdjustedTravelTime "$tempTime" 3>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 <<else>>
 	<<set $vaultWait = 0>>
 <</if>>
@@ -1519,7 +1517,7 @@ The radiant sun empowers your Breathless Exhale Relic, its energy pulsating with
 	<<if $DaedalusFly==true>>
 		<<set $tempTime= Math.ceil($tempTime/2)>>
 	<</if>>
-	<<include "GeneralTimeSetup">>
+	<<AdjustedTravelTime "$tempTime" $tempTime>>
 	<<set $layerExitTime=$tempTime>>
 <</if>>
 
@@ -1616,8 +1614,7 @@ Use the following option only if you have specifically considered your inventory
 <<nobr>>
 <<if $layerExit == 0>>
 	<<set $layerExit = 1>>
-	<<set $tempTime = 13>>
-	<<include "GeneralTimeSetup">>
+	<<AdjustedTravelTime "$tempTime" 13>>
 	<<set $layerExitTime=$tempTime>>
 <</if>>
 

--- a/src/layer6.twee
+++ b/src/layer6.twee
@@ -432,8 +432,7 @@ There is a very easily accessible source of water on this layer, the River Dycx,
 [img[setup.ImagePath+'Clipped-Fin/Abyss Diver Page 7-wonders.png']]
 <<nobr>>
 <<set _totalRelics = $ownedRelics.concat($soldRelics)>>
-<<set $tempTime = 3>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" 3>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 <</nobr>><<if $mawUse == 0>>
 As you press through the thicket of incessantly writhing tentacles, the tentacles subtly change their rhythm. The heat has long ago seared your sense of comfort away, replaced with a strange duality of torment and transcendence. The harsh, yet strangely savory, scent of burning flesh punctuates the air, becoming richer and more distinct. Suddenly, the sea of tentacles parts like the Red Sea before Moses, revealing a broad expanse of barren rock.
 
@@ -1116,7 +1115,7 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 	<<if $DaedalusFly==true>>
 		<<set $tempTime= Math.ceil($tempTime/2)>>
 	<</if>>
-	<<include "GeneralTimeSetup">>
+	<<AdjustedTravelTime "$tempTime" $tempTime>>
 	<<set $layerExitTime=$tempTime>>
 <</if>>
 
@@ -1289,8 +1288,7 @@ Use the following option only if you have specifically considered your inventory
 <<nobr>>
 <<if $layerExit == 0>>
 	<<set $layerExit = 1>>
-	<<set $tempTime = 16>>
-	<<include "GeneralTimeSetup">>
+	<<AdjustedTravelTime "$tempTime" 16>>
 	<<set $layerExitTime=$tempTime>>
 <</if>>
 

--- a/src/layer6.twee
+++ b/src/layer6.twee
@@ -406,7 +406,7 @@ Use the following option only if you have specifically considered your inventory
 	<<if $items[2].count > 0>>
 		<<set $items[3].count += 1>>
 		<<set $items[2].count -= 1>>
-		<<if $hiredCompanions.some(e => e.name === "Saeko") && ($items[17].count || $items[21].count)>>
+		<<if $hiredCompanions.some(e => e.name === "Saeko") && setup.haveSmartphone>>
 			<<set $flaskMatrix[0]+=1>>
 		<<else>>
 			<<set $flaskMatrix[4]+=1>>
@@ -420,7 +420,7 @@ Use the following option only if you have specifically considered your inventory
 
 [img[setup.ImagePath+'Foraging/riverdycx.png']]
 
-<<if $hiredCompanions.some(e => e.name === "Saeko") && ($items[17].count || $items[21].count)>>
+<<if $hiredCompanions.some(e => e.name === "Saeko") && setup.haveSmartphone>>
 In an incredible collaboration with colleagues on the surface, Saeko managed to develop some incredibly innovative water filtration techniques. The water purified from the River Dycx using this technique is absolutely safe to drink, and it even has a pleasant, slightly sweet, cinnamon flavor to it. If this were more easily accessible maybe you could sell this as a unique drink to people on the surface.
 <<else>>
 There is a very easily accessible source of water on this layer, the River Dycx, which is bright red and leaves a cinnamon-like aftertaste in your mouth. Unfortunately it also leaves a bit of a burning hole in your heart, causing you to gain an additional jinxed flame counter for each day of water you drink here, making it even more unpleasant to leave. Watch out for how much water you drink here or you may find yourself never able to leave.
@@ -431,7 +431,7 @@ There is a very easily accessible source of water on this layer, the River Dycx,
 :: Layer6 Maw1 [image layer6]
 [img[setup.ImagePath+'Clipped-Fin/Abyss Diver Page 7-wonders.png']]
 <<nobr>>
-<<set $totalRelics = $ownedRelics.concat($soldRelics)>>
+<<set _totalRelics = $ownedRelics.concat($soldRelics)>>
 <<set $tempTime = 3>>
 <<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 <</nobr>><<if $mawUse == 0>>
@@ -445,7 +445,7 @@ With a horrifyingly human-like belch, the Maw spits forth the Relic you requeste
 You may pick up a new Relic for 10 dubloons and 1.5x its corruption cost:<br>
 <<for $i = 0; $i < 59; $i++>>
 	<<capture $i>>
-	<<if !$totalRelics.some(e => e.name === $relics[$i].name) && $relics[$i].name != "Kin Shifter">>
+	<<if !_totalRelics.some(e => e.name === $relics[$i].name) && $relics[$i].name != "Kin Shifter">>
 		<<print "[[$relics[$i].name|Layer6 Maw1][$temp = $i, $dubloons -= 10, $corruption -= Math.round(Math.max(($relics[$i].corr * 3 / 2) - $corRed, 10)), $ownedRelics.push($relics[$i])]]">><<print " ">><<print Math.round(Math.max(($relics[$i].corr * 3 / 2) - $corRed, 10))>><<print " corruption points">><br>
 	<</if>>
 	<</capture>>
@@ -453,7 +453,7 @@ You may pick up a new Relic for 10 dubloons and 1.5x its corruption cost:<br>
 You may pick up a copy of an old Relic for 20 dubloons and 2x its corruption cost:<br>
 <<for $i = 0; $i < 59; $i++>>
 	<<capture $i>>
-	<<if $totalRelics.some(e => e.name === $relics[$i].name) && $relics[$i].name != "Kin Shifter">>
+	<<if _totalRelics.some(e => e.name === $relics[$i].name) && $relics[$i].name != "Kin Shifter">>
 		<<print "[[$relics[$i].name|Layer6 Maw1][$temp = $i, $dubloons -= 20, $corruption -= Math.round(Math.max(($relics[$i].corr * 2) - $corRed, 10)), $ownedRelics.push($relics[$i])]]">><<print " ">><<print Math.round(Math.max(($relics[$i].corr * 2) - $corRed, 10))>><<print " corruption points">><br>
 	<</if>>
 	<</capture>>
@@ -968,8 +968,7 @@ The Relics you have found with Cherry's Chaotic Luck are $relics[$temp1].name an
 		<<set $corruption += Math.floor(Math.max(($relics[$temp2].corr / 2) - $corRed, 0))>>
 
 		<<set _temp = $ownedRelics.findIndex(e=> e.name==="Devil's Own")>>
-		<<set $soldRelics.push($ownedRelics[_temp])>>
-		<<set $ownedRelics.deleteAt(_temp)>>
+		<<set setup.sellRelic(_temp)>>
 	<</link>>
 
 <</if>>
@@ -1033,8 +1032,7 @@ The Curses you have obtained with Cherry's Chaotic Luck are $curses[$temp1].name
 		<</if>>
 		<<RemoveCurse $curses[$temp2]>>
 		<<set _temp = $ownedRelics.findIndex(e=> e.name==="Devil's Own")>>
-		<<set $soldRelics.push($ownedRelics[_temp])>>
-		<<set $ownedRelics.deleteAt(_temp)>>
+		<<set setup.sellRelic(_temp)>>
 	<</link>>
 
 <</if>>
@@ -1087,8 +1085,7 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 		<</if>>
 		<<RemoveCurse $curses[$temp2]>>
 		<<set _temp = $ownedRelics.findIndex(e=> e.name==="Devil's Own")>>
-		<<set $soldRelics.push($ownedRelics[_temp])>>
-		<<set $ownedRelics.deleteAt(_temp)>>
+		<<set setup.sellRelic(_temp)>>
 	<</link>>
 
 <</if>>
@@ -1502,7 +1499,7 @@ Finally, the vision fades, leaving you standing once again where you were before
 	<</for>>
 <</if>>
 <</nobr>>
-[[Return|$previewReturn][$soldRelics.push($ownedRelics[$temp]), $ownedRelics.deleteAt($temp), $endloop=false]]
+[[Return|$previewReturn][setup.sellRelic($temp), $endloop=false]]
 
 :: Layer6 notes [image layer6 noreturn]
 

--- a/src/layer7.twee
+++ b/src/layer7.twee
@@ -1378,8 +1378,7 @@ You retrieve your Relics and find that you have successfully switched the abilit
 
 [[Continue your business on the seventh layer|Layer7 Hub]]<br><br>
 
-<<set $tempTime = 2>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" 2>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 <<set $dubloons -= 4>>
 
 <<set $temp = $relicSwap.length>>
@@ -1410,7 +1409,7 @@ You have no choice, you gain consciousness a few times to see yourself in a surg
 	<<if $DaedalusFly==true>>
 		<<set $tempTime= Math.ceil($tempTime/2)>>
 	<</if>>
-	<<include "GeneralTimeSetup">>
+	<<AdjustedTravelTime "$tempTime" $tempTime>>
 	<<set $layerExitTime=$tempTime>>
 <</if>>
 
@@ -1554,8 +1553,7 @@ You have no choice, you gain consciousness a few times to see yourself in a surg
 <<nobr>>
 <<if $layerExit == 0>>
 	<<set $layerExit = 1>>
-	<<set $tempTime = 8>>
-	<<include "GeneralTimeSetup">>
+	<<AdjustedTravelTime "$tempTime" 8>>
 	<<set $layerExitTime=$tempTime>>
 <</if>>
 
@@ -1626,8 +1624,7 @@ You have no choice, you gain consciousness a few times to see yourself in a surg
 :: Layer7 Threat2 Descend [layer7]
 <<nobr>>
 <<set $timeL7T2 -= 6>>
-<<set $tempTime = 1>>
-<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" 1>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 <</nobr>>
 [img[setup.ImagePath+'Threats/securityrobot.png']]
 

--- a/src/layer7.twee
+++ b/src/layer7.twee
@@ -57,7 +57,7 @@ Finally, the vision fades, leaving you standing once again where you were before
 	<</for>>
 <</if>>
 <</nobr>>
-[[Return|$previewReturn][$soldRelics.push($ownedRelics[$temp]), $ownedRelics.deleteAt($temp), $endloop=false]]
+[[Return|$previewReturn][setup.sellRelic($temp), $endloop=false]]
 
 :: Layer7 notes [image layer7 noreturn]
 
@@ -639,31 +639,32 @@ Choose the Relic you would like to sell:
 		<<if $ownedRelics[$i].name=="Creepy Doll" && $creepydoll.affec > 5>>
 			You can't seem to part ways with the Creepy Doll<br>
 		<<elseif $ownedRelics[$i].name=="Chain of Lorelei">>
-			<<print $ownedRelics[$i].name>><<print " for ">><<print (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2)))>><<print " dubloons ">><<print "[[Sell|Layer7 Recycle][$colwear=0,$dubloons += (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2))), $soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i)]]">><br>
+			<<print $ownedRelics[$i].name>><<print " for ">><<print (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2)))>><<print " dubloons ">><<print "[[Sell|Layer7 Recycle][$colwear=0,$dubloons += (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2))), setup.sellRelic($i)]]">><br>
 		<<elseif $ownedRelics[$i].name=="Heart-stealing Stole">>
-			<<print $ownedRelics[$i].name>><<print " for ">><<print (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2)))>><<print " dubloons ">><<print "[[Sell|Layer7 Recycle][$hsswear=0,$dubloons += (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2))), $soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i)]]">><br>
+			<<print $ownedRelics[$i].name>><<print " for ">><<print (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2)))>><<print " dubloons ">><<print "[[Sell|Layer7 Recycle][$hsswear=0,$dubloons += (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2))), setup.sellRelic($i)]]">><br>
 		<<elseif $ownedRelics[$i].name=="Sibyl Blend">>
-			<<print $ownedRelics[$i].name>><<print " for ">><<print (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2)))>><<print " dubloons ">><<print "[[Sell|Layer7 Recycle][$SibylBuff=0,$dubloons += (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2))), $soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i)]]">><br>
+			<<print $ownedRelics[$i].name>><<print " for ">><<print (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2)))>><<print " dubloons ">><<print "[[Sell|Layer7 Recycle][$SibylBuff=0,$dubloons += (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2))), setup.sellRelic($i)]]">><br>
 		<<elseif $ownedRelics[$i].name=="World Stone" && $LilyPromise>>
-			<<print $ownedRelics[$i].name>><<print " for ">><<print (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2)))>><<print " dubloons ">><<print "[[Sell|Layer7 Recycle][$dubloons += (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2))), $soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i), $companionLily.affec-=(5-$hsswear)]]">> <br>You promised Lily she could use the World Stone at the end of your journey, recycling it now will surely disappoint her quite a lot. <br>
+			<<print $ownedRelics[$i].name>><<print " for ">><<print (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2)))>><<print " dubloons ">><<print "[[Sell|Layer7 Recycle][$dubloons += (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2))), setup.sellRelic($i), $companionLily.affec -= (5 - $hsswear)]]">>
+			You promised Lily she could use the World Stone at the end of your journey, recycling it now will surely disappoint her quite a lot. <br>
 		<<elseif $ownedRelics[$i].name=="Everhevea">>
 			<<if $items[2].count >= 2>>
-				<<print $ownedRelics[$i].name>><<print " for ">><<print (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2)))>><<print " dubloons ">><<print "[[Sell|Layer7 Recycle][$dubloons += (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2))), $soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i), $items[2].count-=2]]">>
+				<<print $ownedRelics[$i].name>><<print " for ">><<print (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2)))>><<print " dubloons ">><<print "[[Sell|Layer7 Recycle][$dubloons += (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2))), setup.sellRelic($i), $items[2].count -= 2]]">>
 			<<else>>
 				You need to empty the Everheavea to recycle it (have at least two empty flasks in your inventory) <br>
 			<</if>>
 		<<elseif $ownedRelics[$i].name=="Daedalus Mechanism">>
-			<<print $ownedRelics[$i].name>><<print " for ">><<print (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2)))>><<print " dubloons ">><<print "[[Sell|Layer7 Recycle][$DaedalusEquip = false, $DaedalusFly = false, $dubloons += (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2))), $soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i)]]">><br>
+			<<print $ownedRelics[$i].name>><<print " for ">><<print (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2)))>><<print " dubloons ">><<print "[[Sell|Layer7 Recycle][$DaedalusEquip = false, $DaedalusFly = false, $dubloons += (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2))), setup.sellRelic($i)]]">><br>
 		<<elseif $ownedRelics[$i].name=="Blind Divine">>
-			<<print $ownedRelics[$i].name>><<print " for ">><<print (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2)))>><<print " dubloons ">><<print "[[Sell|Layer7 Recycle][$BDwear = false, $dubloons += (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2))), $soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i)]]">><br>
+			<<print $ownedRelics[$i].name>><<print " for ">><<print (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2)))>><<print " dubloons ">><<print "[[Sell|Layer7 Recycle][$BDwear = false, $dubloons += (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2))), setup.sellRelic($i)]]">><br>
 		<<elseif $ownedRelics[$i].name=="Heavy is the Head">>
-			<<print $ownedRelics[$i].name>><<print " for ">><<print (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2)))>><<print " dubloons ">><<print "[[Sell|Layer7 Recycle][$HeavyHeadwear= false, $dubloons += (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2))), $soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i)]]">><br>
+			<<print $ownedRelics[$i].name>><<print " for ">><<print (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2)))>><<print " dubloons ">><<print "[[Sell|Layer7 Recycle][$HeavyHeadwear= false, $dubloons += (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2))), setup.sellRelic($i)]]">><br>
 		<<elseif $ownedRelics[$i].name=="Moonwatcher" & $BionicEye >>
 			<<print $ownedRelics[$i].name>> You can't sell Relics that have become part of your body.<br>
 		<<elseif $ownedRelics[$i].name=="Glory's Grasp" & $BionicArm >>
 			<<print $ownedRelics[$i].name>> You can't sell Relics that have become part of your body.<br>		
 		<<else>>
-			<<print $ownedRelics[$i].name>><<print " for ">><<print (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2)))>><<print " dubloons ">><<print "[[Sell|Layer7 Recycle][$dubloons += (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2))), $soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i)]]">><br>
+			<<print $ownedRelics[$i].name>><<print " for ">><<print (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2)))>><<print " dubloons ">><<print "[[Sell|Layer7 Recycle][$dubloons += (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2))), setup.sellRelic($i)]]">><br>
 		<</if>>
 	<</capture>>
 <</for>>
@@ -1211,8 +1212,7 @@ The Relics you have found with Cherry's Chaotic Luck are $relics[$temp1].name an
 		<<set $corruption += Math.floor(Math.max(($relics[$temp2].corr / 2) - $corRed, 0))>>
 
 		<<set _temp = $ownedRelics.findIndex(e=> e.name==="Devil's Own")>>
-		<<set $soldRelics.push($ownedRelics[_temp])>>
-		<<set $ownedRelics.deleteAt(_temp)>>
+		<<set setup.sellRelic(_temp)>>
 	<</link>>
 
 <</if>>
@@ -1284,8 +1284,7 @@ The Curses you have obtained with Cherry's Chaotic Luck are $curses[$temp1].name
 		<<RemoveCurse $curses[$temp2]>>
 
 		<<set _temp = $ownedRelics.findIndex(e=> e.name==="Devil's Own")>>
-		<<set $soldRelics.push($ownedRelics[_temp])>>
-		<<set $ownedRelics.deleteAt(_temp)>>
+		<<set setup.sellRelic(_temp)>>
 	<</link>>
 
 <</if>>
@@ -1350,8 +1349,7 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 		<</if>>
 		<<RemoveCurse $curses[$temp2]>>
 		<<set _temp = $ownedRelics.findIndex(e=> e.name==="Devil's Own")>>
-		<<set $soldRelics.push($ownedRelics[_temp])>>
-		<<set $ownedRelics.deleteAt(_temp)>>
+		<<set setup.sellRelic(_temp)>>
 	<</link>>
 
 <</if>>

--- a/src/layer8.twee
+++ b/src/layer8.twee
@@ -1318,7 +1318,7 @@ Ready? Getting back up out of this terrible prison and back to layer 7 will take
 	<<if $DaedalusFly==true>>
 		<<set $tempTime= Math.ceil($tempTime/2)>>
 	<</if>>
-	<<include "GeneralTimeSetup">>
+	<<AdjustedTravelTime "$tempTime" $tempTime>>
 	<<set $layerExitTime=$tempTime>>
 <</if>>
 
@@ -1376,8 +1376,7 @@ If you continue your descent in spite of everything, descending past this layer'
 <<nobr>>
 <<if $layerExit == 0>>
 	<<set $layerExit = 1>>
-	<<set $tempTime = 45>>
-	<<include "GeneralTimeSetup">>
+	<<AdjustedTravelTime "$tempTime" 45>>
 	<<set $layerExitTime=$tempTime>>
 <</if>>
 

--- a/src/layer8.twee
+++ b/src/layer8.twee
@@ -70,7 +70,7 @@ Finally, the vision fades, leaving you standing once again where you were before
 	<</for>>
 <</if>>
 <</nobr>>
-[[Return|$previewReturn][$soldRelics.push($ownedRelics[$temp]), $ownedRelics.deleteAt($temp), $endloop=false]]
+[[Return|$previewReturn][setup.sellRelic($temp), $endloop=false]]
 
 :: Layer8 notes [image layer8 noreturn]
 
@@ -273,7 +273,7 @@ Choose a Relic to temporally limit-break:
 <<for _i = 0; _i < $ownedRelics.length; _i++>>
 	<<capture _i>>
 		<<if $ownedRelics[_i].name == "Aeonglass">>
-			<<print "[[$ownedRelics[_i].name|Layer8 Time][$timeUsed = 1, $soldRelics.push($ownedRelics[_i]), $ownedRelics.deleteAt(_i), $ownedRelics.push($relic70_ET), $timeRelic = $relic70_ET.name]]">><br>
+			<<print "[[$ownedRelics[_i].name|Layer8 Time][$timeUsed = 1, setup.sellRelic(_i), $ownedRelics.push($relic70_ET), $timeRelic = $relic70_ET.name]]">><br>
 		<<elseif $spaceRelic != $ownedRelics[_i].name>>
 			<<print "[[$ownedRelics[_i].name|Layer8 Time][$timeUsed = 1, $timeRelic = $ownedRelics[_i].name]]">><br>
 		<</if>>
@@ -335,7 +335,7 @@ If you decide to start foraging for food or water, it means that you will not co
 	<<if $items[2].count > 0>>
 		<<set $items[3].count += 1>>
 		<<set $items[2].count -= 1>>
-		<<if $hiredCompanions.some(e => e.name === "Saeko") && ($items[17].count || $items[21].count)>>
+		<<if $hiredCompanions.some(e => e.name === "Saeko") && setup.haveSmartphone>>
 			<<set $flaskMatrix[5]+=1>>
 		<<else>>
 			<<set $flaskMatrix[6]+=1>>
@@ -348,7 +348,7 @@ If you decide to start foraging for food or water, it means that you will not co
 <</nobr>>
 [img[setup.ImagePath+'Foraging/lethetaps.png']]
 
-<<if $hiredCompanions.some(e => e.name === "Saeko") && ($items[17].count || $items[21].count)>>
+<<if $hiredCompanions.some(e => e.name === "Saeko") && setup.haveSmartphone>>
 In an incredible collaboration with colleagues on the surface, Saeko managed to develop some incredibly innovative water filtration techniques. The water purified from Lethe Taps using this technique is much safer to drink, though still hazardous. It's probably only 1/10th as dangerous as it would normally be, though you'll still be on a quick path to <<if $app.sex == "male">>himbo<<else>>bimbo<</if>>fication if you drink too much.
 <<else>>
 There is a very easily accessible source of water on this layer, the Lethe Taps, that are freely available everywhere and taste surprisingly like the tap water from the surface. Unfortunately, it also leaves you feeling a little hazy after a drink, and that is not simply a temporary effect. Each day of water you drink from these taps decreases you IQ by about half a point, leaving your mind in a subtly creeping fog that will leave you a <<if $app.sex == "male">>himbo<<else>>bimbo<</if>> in no time at all.
@@ -1110,8 +1110,7 @@ The Relics you have found with Cherry's Chaotic Luck are $relics[$temp1].name an
 		<<set $corruption += Math.floor(Math.max(($relics[$temp2].corr / 2) - $corRed, 0))>>
 
 		<<set _temp = $ownedRelics.findIndex(e=> e.name==="Devil's Own")>>
-		<<set $soldRelics.push($ownedRelics[_temp])>>
-		<<set $ownedRelics.deleteAt(_temp)>>
+		<<set setup.sellRelic(_temp)>>
 	<</link>>
 
 <</if>>
@@ -1203,8 +1202,7 @@ The Curses you have obtained with Cherry's Chaotic Luck are $curses[$temp1].name
 		<<RemoveCurse $curses[$temp2]>>
 
 		<<set _temp = $ownedRelics.findIndex(e=> e.name === "Devil's Own")>>
-		<<set $soldRelics.push($ownedRelics[_temp])>>
-		<<set $ownedRelics.deleteAt(_temp)>>
+		<<set setup.sellRelic(_temp)>>
 	<</link>>
 
 <</if>>
@@ -1289,8 +1287,7 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 		<</if>>
 		<<RemoveCurse $curses[$temp2]>>
 		<<set _temp = $ownedRelics.findIndex(e=> e.name === "Devil's Own")>>
-		<<set $soldRelics.push($ownedRelics[_temp])>>
-		<<set $ownedRelics.deleteAt(_temp)>>
+		<<set setup.sellRelic(_temp)>>
 	<</link>>
 
 <</if>>

--- a/src/relics.twee
+++ b/src/relics.twee
@@ -339,6 +339,7 @@ weight: 1,
 value: 70,
 time: 5,
 corr: 40,
+copiedValue: 0,
 pic: "Relics/kinshifter.png"
 }>>
 
@@ -986,7 +987,6 @@ pic: "Relics/starlitconquest.png"
 <<set $relics = [$relic1, $relic2, $relic3, $relic4, $relic5, $relic6, $relic7, $relic8, $relic9, $relic10, $relic11, $relic12, $relic13, $relic14, $relic15, $relic16, $relic17, $relic18, $relic19, $relic20, $relic21, $relic22, $relic23, $relic24, $relic25, $relic26, $relic27, $relic28, $relic29, $relic30, $relic31, $relic32, $relic33, $relic34, $relic35, $relic36, $relic37, $relic38, $relic39, $relic40, $relic41, $relic42, $relic43, $relic44, $relic45, $relic46, $relic47, $relic48, $relic49, $relic50, $relic51, $relic52, $relic53, $relic54, $relic55, $relic56, $relic57, $relic58, $relic59, $relic60, $relic61, $relic62, $relic63, $relic64, $relic65, $relic66, $relic67, $relic68, $relic69, $relic70, $relic71, $relic72, $relic73, $relic74, $relic75, $relic76, $relic77, $relic78, $relic79, $relic80, $relic81, $relic82, $relic83, $relic84, $relic85, $relic86, $relic87, $relic88, $relic89, $relic90, $relic91, $relic92, $relic93, $relic94, $relic95, $relic96, $relic97, $relic98, $relic99, $relic100, $relic101, $relic102, $relic103, $relic104, $relic105, $relic106, $relic107, $relic108]>>
 <<set $ownedRelics = []>>
 <<set $soldRelics = []>>
-<<set $totalRelics = []>>
 <<set $innRelics = []>>
 <<set $relicSwap = []>>
 
@@ -1632,7 +1632,7 @@ The one supernatural effect not cancelled is the unbreakability of Eternal Repos
         @@.unreachable;Located in an underwater tunnel (with murky, undrinkable water.) Requires scuba gear to retrieve.@@
     <<elseif _name === "Gilded Prison" && !setup.haveCuttingTool() && $torchUse == 0>>
         @@.unreachable;The entrance to the cave this Relic's located in is completely covered with hard icicles. You can either slash them away with a cutting tool, or spend 1 extra day melting them with a source of heat (doesn't use up an extra torch if you used one reaching the Relic.)@@
-    <<elseif _name === "Omoikane Circuit" &&  $items[21].count > 0>>
+    <<elseif _name === "Omoikane Circuit" && setup.haveSmartphoneAI>>
         Already taken
     <<elseif _name === "Timekeeper's Keepsake" && !setup.haveRope()>>
         @@.unreachable;Located at the bottom of an icy pit, far too slippery on all sides to be climbed by hand. Requires some rope.@@

--- a/src/surface.twee
+++ b/src/surface.twee
@@ -120,7 +120,7 @@ A large, hulking machine stands motionless near the entrance to the Abyss. You o
 <<if $hiredCompanions.length == 0>>
 <b>[[Check out the companions available to hire|Surface Companions]]</b><br><br>
 <</if>>
-<<if $hiredCompanions.length > 0 || $items[21].count>0>>
+<<if $hiredCompanions.length > 0 || setup.haveSmartphoneAI>>
 [[Interact with your party|Party overview]] <<CheckParty>><br>
 <</if>>
 <<if $fear == "">>
@@ -522,11 +522,11 @@ How many warding braces would you like to buy?
 
 :: Buy Smartphone [item]
 <<set $temp = 1>>
-[img[setup.ImagePath+$items[17].image]]
+[img[setup.ImagePath + setup.smartphoneRegular.image]]
 
 You have bought a smartphone.
 
-[[Confirm|previous()][$items[17].count += parseInt($temp), $dubloons -= (parseInt($temp)*$items[17].cost)]]
+[[Confirm|previous()][setup.haveSmartphoneRegular = true, $dubloons -= setup.smartphoneRegular.cost]]
 <<back>>
 
 :: Buy Inn Room Pass [item]
@@ -680,35 +680,36 @@ Cashing out, really? Where is your sense of adventure?
 			<<if $ownedRelics[$i].name=="Creepy Doll" && $creepydoll.affec > 5>>
 				You can't seem to part ways with the Creepy Doll<br>
 			<<elseif $ownedRelics[$i].name=="Chain of Lorelei">>
-				<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Surface Sell 1][$colwear=0, $dubloons += ($ownedRelics[$i].value + $sellAdd), $soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i)]]">><br>
+				<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Surface Sell 1][$colwear=0, $dubloons += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
 			<<elseif $ownedRelics[$i].name=="Heart-stealing Stole">>
-				<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Surface Sell 1][$hsswear=0, $dubloons += ($ownedRelics[$i].value + $sellAdd), $soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i)]]">><br>
+				<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Surface Sell 1][$hsswear=0, $dubloons += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
 			<<elseif $ownedRelics[$i].name=="Solace Lace">>
-				<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Surface Sell 1][$slwear=0, $dubloons += ($ownedRelics[$i].value + $sellAdd), $soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i)]]">><br>
+				<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Surface Sell 1][$slwear=0, $dubloons += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
 			<<elseif $ownedRelics[$i].name=="Sibyl Blend">>
-				<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Surface Sell 1][$SibylBuff=0, $dubloons += ($ownedRelics[$i].value + $sellAdd), $soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i)]]">><br>
+				<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Surface Sell 1][$SibylBuff=0, $dubloons += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
 			<<elseif $ownedRelics[$i].name=="World Stone" && $LilyPromise>>
-				<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Surface Sell 1][$dubloons += ($ownedRelics[$i].value + $sellAdd), $soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i), $companionLily.affec-=(5-$hsswear)]]">> <br>You promised Lily she could use the World Stone at the end of your journey, selling it now will surely disappoint her greatly. <br>
+				<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Surface Sell 1][$dubloons += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i), $companionLily.affec -= (5 - $hsswear)]]">>
+				You promised Lily she could use the World Stone at the end of your journey, selling it now will surely disappoint her greatly. <br>
 			<<elseif $ownedRelics[$i].name=="Everhevea">>
 				<<if $items[2].count >= 2>>
-					<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Surface Sell 1][$dubloons += ($ownedRelics[$i].value + $sellAdd), $soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i), $items[2].count-=2]]">><br>
+					<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Surface Sell 1][$dubloons += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i), $items[2].count -= 2]]">><br>
 				<<else>>
 					You need to empty the Everheavea to sell it (have at least two empty flasks in your inventory) <br>
 				<</if>>
 			<<elseif $ownedRelics[$i].name=="Daedalus Mechanism">>
-				<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Surface Sell 1][$DaedalusEquip = false, $DaedalusFly = false, $dubloons += ($ownedRelics[$i].value + $sellAdd), $soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i)]]">><br>
+				<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Surface Sell 1][$DaedalusEquip = false, $DaedalusFly = false, $dubloons += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
 			<<elseif $ownedRelics[$i].name=="Blind Divine">>
-				<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Surface Sell 1][$BDwear = false, $dubloons += ($ownedRelics[$i].value + $sellAdd), $soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i)]]">><br>
+				<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Surface Sell 1][$BDwear = false, $dubloons += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
 			<<elseif $ownedRelics[$i].name=="Heavy is the Head">>
-				<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Surface Sell 1][$HeavyHeadwear= false, $dubloons += ($ownedRelics[$i].value + $sellAdd), $soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i)]]">><br>
+				<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Surface Sell 1][$HeavyHeadwear= false, $dubloons += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
 			<<elseif $ownedRelics[$i].name=="Brave Vector">>
-				<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Surface Sell 1][$dubloons += ($ownedRelics[$i].value + $sellAdd), $soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i), $slingshot = 0]]">><br>
+				<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Surface Sell 1][$dubloons += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i), $slingshot = 0]]">><br>
 			<<elseif $ownedRelics[$i].name=="Moonwatcher" & $BionicEye >>
 				<<print $ownedRelics[$i].name>> You can not sell Relics that have become part of your body.<br>
 			<<elseif $ownedRelics[$i].name=="Glory's Grasp" & $BionicArm >>
 				<<print $ownedRelics[$i].name>> You can not sell Relics that have become part of your body.<br>
 			<<else>>
-				<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Surface Sell 1][$dubloons += ($ownedRelics[$i].value + $sellAdd), $soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i)]]">><br>
+				<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Surface Sell 1][$dubloons += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
 			<</if>>
 		<</capture>>
 	<</for>>
@@ -745,10 +746,10 @@ You step into the Relic Workshop of Outset Town. The air is thick with the smell
 	<br>You muse over what you can do with the Rømer Stones, taking advantage over their ability for limitless small-scale heating or cooling.<br><br>
 	You can either craft self-warming winter gear using winter clothes available, or you could use some light summer clothing to craft some self-cooling summer gear. Either one of these will require using all of the Rømer stones to craft.<br>
 		<<if $warmCloth == 0>>
-		[[Use the Rømer Stones for self-warming winter gear|Surface Workshop][$soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i), $items[22].count = 1,$warmCloth=1]]<br>
+		[[Use the Rømer Stones for self-warming winter gear|Surface Workshop][setup.sellRelic($i), $items[22].count = 1,$warmCloth=1]]<br>
 		<</if>>
 		<<if $coolCloth == 0>>
-		[[Use the Rømer Stones for self-cooling summer gear|Surface Workshop][$soldRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i), $items[23].count = 1, $coolCloth=1]]<br>
+		[[Use the Rømer Stones for self-cooling summer gear|Surface Workshop][setup.sellRelic($i), $items[23].count = 1, $coolCloth=1]]<br>
 		<</if>>
 	<</if>>
 	<<if $ownedRelics[$i].name == "Creepy Doll" && $dollevent==false>>
@@ -771,15 +772,15 @@ You step into the Relic Workshop of Outset Town. The air is thick with the smell
 		<br>The allure of Glory's Grasp replacing your organic arm with a bionic one is not lost on you. The notion carries with it a certain charm and intrigue. Here, in the Relic Workshop, they can ensure a secure and proficient installation.<br>
 		[[Proceed with the installation of Glory's Grasp as your bionic arm|Surface Workshop][$BionicArm=true]]<br>
 	<</if>>
-	<<if $ownedRelics[$i].name == "Omoikane Circuit" && $items[17].count > 0>>
+	<<if $ownedRelics[$i].name == "Omoikane Circuit" && setup.haveSmartphoneRegular>>
 		<br>The Omoikane Circuit, you've heard, is a Relic specifically designed for integration with your phone. Why not seize this opportunity to upgrade your device right here in the safety of the Relic Workshop?<br>
-		[[It's time to revolutionize your phone!|AI ConvoIn][$items[17].count = 0, $items[21].count = 1, $ownedRelics.deleteAt($i), $soldRelics.push($ownedRelics[$i]) ]]<br>
+		[[It's time to revolutionize your phone!|AI ConvoIn][setup.haveSmartphoneRegular = false, setup.haveSmartphoneAI = true, setup.sellRelic($i) ]]<br>
 	<</if>>
 	<</capture>>
 <</for>>
-<<if $items[21].count > 0>>
+<<if setup.haveSmartphoneAI>>
 	<br>Is listening to that snarky AI worth the spec upgrade to the Omoikone Smartphone?<br>
-	[[Hell no, time for a downgrade|AI ConvoOut][$items[17].count  = 1, $items[21].count  = 0, $ownedRelics.push($relic36) ]]<br>
+	[[Hell no, time for a downgrade|AI ConvoOut][setup.haveSmartphoneRegular = true, setup.haveSmartphoneAI = false, setup.unsellRelic("Omoikane Circuit")]]<br>
 <</if>>
 <</nobr>>
 
@@ -1203,7 +1204,7 @@ You want to throw the doll away, but your body simply refuses. At the moment it 
 	You can pick up any of the Relics you've previously stored in your inn room:<br>
 	<<for $i = 0; $i < $innRelics.length; $i++>>
 		<<capture $i>>
-			<<print $innRelics[$i].name + " [[Retrieve|passage()][$soldRelics.deleteWith(r => r.name === $innRelics[$i].name), $ownedRelics.push($innRelics[$i]), $innRelics.deleteAt($i)]]">><br>
+			<<print $innRelics[$i].name + " [[Retrieve|passage()][setup.unsellRelic($innRelics[$i]), $innRelics.deleteAt($i)]]">><br>
 		<</capture>>
 	<</for>>
 	<br>
@@ -1217,19 +1218,19 @@ You want to throw the doll away, but your body simply refuses. At the moment it 
 			<<if $ownedRelics[$i].name=="Creepy Doll" && $creepydoll.affec > 5>>
 				You can't seem to part ways with the Creepy Doll<br>
 			<<elseif $ownedRelics[$i].name=="Chain of Lorelei">>
-				<<print $ownedRelics[$i].name>><<print " [[Store|passage()][$colwear=0, $soldRelics.push($ownedRelics[$i]), $innRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i)]]">><br>
+				<<print $ownedRelics[$i].name>><<print " [[Store|passage()][$innRelics.push($ownedRelics[$i]), setup.sellRelic($i), $colwear = 0]]">><br>
 			<<elseif $ownedRelics[$i].name=="Heart-stealing Stole">>
-				<<print $ownedRelics[$i].name>><<print " [[Store|passage()][$hsswear=0, $soldRelics.push($ownedRelics[$i]), $innRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i)]]">><br>
+				<<print $ownedRelics[$i].name>><<print " [[Store|passage()][$innRelics.push($ownedRelics[$i]), setup.sellRelic($i), $hsswear = 0]]">><br>
 			<<elseif $ownedRelics[$i].name=="Solace Lace">>
-				<<print $ownedRelics[$i].name>><<print " [[Store|passage()][$slwear=0, $soldRelics.push($ownedRelics[$i]), $innRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i)]]">><br>
+				<<print $ownedRelics[$i].name>><<print " [[Store|passage()][$innRelics.push($ownedRelics[$i]), setup.sellRelic($i), $slwear = 0]]">><br>
 			<<elseif $ownedRelics[$i].name=="Sibyl Blend">>
-				<<print $ownedRelics[$i].name>><<print " [[Store|passage()][$SibylBuff=0, $soldRelics.push($ownedRelics[$i]), $innRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i)]]">><br>
+				<<print $ownedRelics[$i].name>><<print " [[Store|passage()][$innRelics.push($ownedRelics[$i]), setup.sellRelic($i), $SibylBuff = 0]]">><br>
 			<<elseif $ownedRelics[$i].name=="Everhevea">>
-				<<print $ownedRelics[$i].name>><<print " [[Store|passage()][$soldRelics.push($ownedRelics[$i]), $innRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i), $items[2].count-=2]]">><br>
+				<<print $ownedRelics[$i].name>><<print " [[Store|passage()][$innRelics.push($ownedRelics[$i]), setup.sellRelic($i), $items[2].count -= 2]]">><br>
 			<<elseif $ownedRelics[$i].name=="Brave Vector">>
-				<<print $ownedRelics[$i].name>><<print " [[Store|passage()][$soldRelics.push($ownedRelics[$i]), $innRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i), $slingshot = 0]]">><br>
+				<<print $ownedRelics[$i].name>><<print " [[Store|passage()][$innRelics.push($ownedRelics[$i]), setup.sellRelic($i), $slingshot = 0]]">><br>
 			<<else>>
-				<<print $ownedRelics[$i].name>><<print " [[Store|passage()][$soldRelics.push($ownedRelics[$i]), $innRelics.push($ownedRelics[$i]), $ownedRelics.deleteAt($i)]]">><br>
+				<<print $ownedRelics[$i].name>><<print " [[Store|passage()][$innRelics.push($ownedRelics[$i]), setup.sellRelic($i)]]">><br>
 			<</if>>
 		<</capture>>
 	<</for>>

--- a/src/widgets.twee
+++ b/src/widgets.twee
@@ -3097,7 +3097,7 @@
 
 <<if $abyssKnowCheatoff>>
 	<<set $abyssKnow = 0>>
-<<elseif $items[5].count > 0 || $items[17].count > 0 || $items[21].count > 0 || $hiredCompanions.some(c => c.name === "Saeko")>>
+<<elseif $items[5].count > 0 || setup.haveSmartphone || $hiredCompanions.some(c => c.name === "Saeko")>>
 	<<set $abyssKnow = 1>>
 <<else>>
 	<<set $abyssKnow = 0>>

--- a/src/widgets.twee
+++ b/src/widgets.twee
@@ -3013,7 +3013,7 @@
 	<<set $ownedRelics.push(_relic)>>
 	<<if _relic.time - $SibylBuff > 0>>
 		<<set $tempTime = _relic.time - $SibylBuff>>
-		<<include "GeneralTimeSetup">><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+		<<AdjustedTravelTime "$tempTime" $tempTime>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 	<</if>>
 	<<set $corruption -= Math.max(_relic.corr - $corRed + ($currentLayer != 6 ? 5 * Math.trunc($hexflame / 10) : 0), 0)>>
 	<<if _relic.pic>>

--- a/t3lt.twee-config.yml
+++ b/t3lt.twee-config.yml
@@ -1,5 +1,9 @@
 sugarcube-2:
   macros:
+    AdjustedTravelTime:
+      name: AdjustedTravelTime
+      parameters:
+        - "string &+ var|number |+ bool"
     AffectionChange:
       name: AffectionChange
       parameters:


### PR DESCRIPTION
Applies on top of https://github.com/FloricSpacer/AbyssDiver/pull/53 (there's a small merge conflict on layer 6 otherwise).

This turns the `GeneralTimeSetup` passage into macro `<<AdjustTravelTime>>`. This macro takes 3 parameters:
* The output variable to write to, as a string (this is currently set to `"$tempTime"` everywhere). This follows the model of the `<<radiobutton>>` builtin macro.
* The initial or raw, unmodified travel time, either as a variable or a macro. A lot of places can pass in a number, but some still use `$tempTime` (but this can now easily change).
* Whether to limit adjustments to *only* the travel time. This is basically just for energy rations, since the macro can disable their use and can make a small adjustment to the inventory to prepare for `GeneralTimeStats`. No code currently sets this optional parameter.

With this macro, we can compute the adjusted travel time at any point and store it in a temporary variable. By passing `true` as the 3rd argument, we avoid adjusting other stuff (the only exception is `$heat` and `$cool`, but those aren't dangerous to set).