### PR TITLE
Show true cost for relics along with original cost (if different)

### DIFF
--- a/src/global.twee
+++ b/src/global.twee
@@ -1925,9 +1925,10 @@ How many dubloons would you like to pay back?
 :: AdjustedTravelTime widget [widget nobr]
 <<widget "AdjustedTravelTime">>
 /*
-	_args[0]: string     = the variable to write to, as a string (e.g. "$tempTime")
-	_args[1]: var|number = the raw, unadjusted travel time
-	_args[2]: [bool]     = whether to avoid adjustments beyond the travel time (optional, defaults to false)
+	_args[0]: string       = the variable to write to, as a string (e.g. "$tempTime")
+	_args[1]: var|number   = the raw, unadjusted travel time
+	_args[2]: [bool]       = whether to avoid adjustments beyond the travel time (optional, defaults to false)
+	_args[3]: [var|number] = initial additive modifier (optional, can be negative)
 */
 <<set _inputTime = _args[1]>>
 
@@ -1936,7 +1937,7 @@ How many dubloons would you like to pay back?
 <<set $cool = $slwear || ($coolCloth && !$dollevent2) ? 1 : 0>>
 
 /* Start by computing the overall additive modifier. */
-<<set _additiveModifier = 0>>
+<<set _additiveModifier = _args[3] || 0>>
 
 /* Apply time reduction from having Khemia with you. */
 <<set _additiveModifier -= $timeRed>>

--- a/src/layer5.twee
+++ b/src/layer5.twee
@@ -353,14 +353,22 @@ You do not have a medkit to cure your status condition.<br>
 <<set _name = _layerRelics[_i]>>
 <<set _relic = $relics.find(r => r.name === _name)>>
 <<set _corr = Math.max(_relic.corr - $corRed + ($currentLayer != 6 ? 5 * Math.trunc($hexflame / 10) : 0), 0)>>
-<<set _time = Math.max(_relic.time - $SibylBuff, 0)>>
+<<silently>><<AdjustedTravelTime "_time" _relic.time true `-$SibylBuff`>><</silently>>
+<<set _corrStyle = _corr > _relic.corr ? "@@color:red;" : _corr < _relic.corr ? "@@color:green;" : "">>
+<<set _timeStyle = _time > _relic.time ? "@@color:red;" : _time < _relic.time ? "@@color:green;" : "">>
 [img[setup.ImagePath + _relic.pic]]
 <h2>_name <<if setup.functionalRelics.contains(_name)>> ☸<</if>></h2>
 <p class="cost">
-	<<if _corr || _time>>Cost:<<else>>Free!<</if>>
-	<<if _corr > 0>>_corr corruption<</if>>
-	<<if _corr > 0 && _time > 0>> + <</if>>
-	<<if _time > 0>>_time day<<if _time > 1>>s<</if>><</if>>
+	<<if _corr != _relic.corr || _time != _relic.time>><s>
+		<<if _relic.corr > 0 || _relic.time > 0>>Cost:<<else>>@@color:green;Free!@@<</if>>
+		<<if _relic.corr > 0>><<print _relic.corr + " corruption">><</if>>
+		<<if _relic.corr > 0 && _relic.time > 0>> and <</if>>
+		<<if _relic.time > 0>><<print _relic.time + (_relic.time == 1 ? " day" : " days")>><</if>>
+	</s><br><</if>>
+	<<if _corr > 0 || _time > 0>>Cost:<<else>>Free!<</if>>
+	<<if _corr > 0>><<print _corrStyle + _corr + " corruption" + (_corrStyle ? "@@" : "")>><</if>>
+	<<if _corr > 0 && _time > 0>> and <</if>>
+	<<if _time > 0>><<print _timeStyle + _time + (_time == 1 ? " day" : " days") + (_timeStyle ? "@@" : "")>><</if>>
 </p>
 <p>
 <<if _totalRelics.some(e => e.name === _name)>>

--- a/src/relics.twee
+++ b/src/relics.twee
@@ -1610,14 +1610,22 @@ The one supernatural effect not cancelled is the unbreakability of Eternal Repos
     <div>
     <<set _relic = $relics.find(r => r.name === _name)>>
     <<set _corr = Math.max(_relic.corr - $corRed + ($currentLayer != 6 ? 5 * Math.trunc($hexflame / 10) : 0), 0)>>
-    <<set _time = Math.max(_relic.time - $SibylBuff, 0)>>
+    <<silently>><<AdjustedTravelTime "_time" _relic.time true `-$SibylBuff`>><</silently>>
+    <<set _corrStyle = _corr > _relic.corr ? "@@color:red;" : _corr < _relic.corr ? "@@color:green;" : "">>
+    <<set _timeStyle = _time > _relic.time ? "@@color:red;" : _time < _relic.time ? "@@color:green;" : "">>
     [img[setup.ImagePath + _relic.pic]]
     <h2>_name<<if setup.functionalRelics.contains(_name)>> ☸<</if>></h2>
     <p class="cost">
-        <<if _corr || _time>>Cost:<<else>>Free!<</if>>
-        <<if _corr > 0>>_corr corruption<</if>>
-        <<if _corr > 0 && _time > 0>> + <</if>>
-        <<if _time > 0>>_time day<<if _time > 1>>s<</if>><</if>>
+        <<if _corr != _relic.corr || _time != _relic.time>><s>
+            <<if _relic.corr > 0 || _relic.time > 0>>Cost:<<else>>Free!<</if>>
+            <<if _relic.corr > 0>><<print _relic.corr + " corruption">><</if>>
+            <<if _relic.corr > 0 && _relic.time > 0>> and <</if>>
+            <<if _relic.time > 0>><<print _relic.time + (_relic.time == 1 ? " day" : " days")>><</if>>
+        </s><br><</if>>
+        <<if _corr > 0 || _time > 0>>Cost:<<else>>@@color:green;Free!@@<</if>>
+        <<if _corr > 0>><<print _corrStyle + _corr + " corruption" + (_corrStyle ? "@@" : "")>><</if>>
+        <<if _corr > 0 && _time > 0>> and <</if>>
+        <<if _time > 0>><<print _timeStyle + _time + (_time == 1 ? " day" : " days") + (_timeStyle ? "@@" : "")>><</if>>
     </p>
     <p>
     <<if _totalRelics.some(e => e.name === _name)>>

--- a/t3lt.twee-config.yml
+++ b/t3lt.twee-config.yml
@@ -3,7 +3,7 @@ sugarcube-2:
     AdjustedTravelTime:
       name: AdjustedTravelTime
       parameters:
-        - "string &+ var|number |+ bool"
+        - "string &+ var|number |+ bool |+ var|number"
     AffectionChange:
       name: AffectionChange
       parameters:


### PR DESCRIPTION
This finally brings it all together, with a few final touches:
* The Sibyl Blend bonus is an additive reduction, so pass it into the macro.
* If the true cost differs from the original cost, show the original cost above the true cost.
* Color the true time and corruption cost in green if they are reduced, and in red if they are increased.

Looks something like this (as shown on Discord):
![image](https://github.com/FloricSpacer/AbyssDiver/assets/133602907/7b793a15-c433-4368-a8f8-bf42f13e75d2)

In theory this mechanism can also be used to show the true cost for things like ascending between layers and looking for an oasis, but a lot of the text for that is currently hardcoded so I limited the scope to the relic grid for now :)