### PR TITLE
Move JS to script.js, make more use of getters, general cleanup

### DIFF
--- a/src/companionConversations.twee
+++ b/src/companionConversations.twee
@@ -1302,8 +1302,7 @@ He performs an improbable flip in the air, lashing out with the stick, and then 
 He's breathing heavily, but there's no trembling in his motions as he stands and looks over at you. He smirks.
 <<say $companionKhemia>>Impressed yet?<</say>>
 <<nobr>>
-<<set _cutCheck = setup.haveCuttingTool() ? 1 : 0>>
-<<if _cutCheck==1>>
+<<if setup.haveCuttingTool>>
 	<<ConversationChoices
 		[[Your skills are impressive. I'm glad to have you along, and that we've got a sword for you to use.| Khemia Convo1 Impressive]]
 		[[Yeah... Would you mind practicing against me?| Khemia Convo1 Practice]] 

--- a/src/global.twee
+++ b/src/global.twee
@@ -1863,7 +1863,9 @@ How many dubloons would you like to pay back?
 			<<set _additiveModifier -= 3>>
 		<</if>>
 		/* Reduce travel time if player has the Star Compass relic. */
-		<<set _additiveModifier -= 5>>
+		<<if $ownedRelics.some(e => e.name === "Star Compass")>>
+			<<set _additiveModifier -= 5>>
+		<</if>>
 <</switch>>
 
 /* If the additive modifier is a time reduction, apply it to the base time. */

--- a/src/global.twee
+++ b/src/global.twee
@@ -7,154 +7,10 @@
 <<if $hiredCompanions.length> 0>>\
 [[Party|Party Sidebar]]
 <</if>>\
-<<if setup.haveNotepad()>>\
+<<if setup.haveNotepad>>\
 [[Layer Notes]]
 <</if>>\
 <br>
-
-
-:: Count Curse Instances [script]
-setup.activeCurseCount = function(name) {
-	return variables().playerCurses.countWith(
-		e => e.name === name
-	);
-}
-setup.takenCurseCount = function(name) {
-	return variables().playerCurses.concat(variables().StoredCurse).countWith(
-		e => e.name === name
-	);
-}
-
-
-:: Calculate Carried Weight [script]
-setup.calcCarriedWeight = function() {
-	return (
-		variables().items.reduce((total, item) => total + item.weight * item.count, 0) +
-		variables().ownedRelics.reduce((total, relic) => total + relic.weight, 0)
-	);
-}
-
-:: Sell or unsell relic [script]
-setup.sellRelic = relicOrNameOrIndex => {
-	const vars = variables();
-	let relic, name, index;
-	switch (typeof relicOrNameOrIndex) {
-		case 'string':
-			name = relicOrNameOrIndex;
-			index = vars.ownedRelics.findIndex(relic => relic.name == name);
-			if (index >= 0) {
-				relic = vars.ownedRelics[index];
-			} else {
-				console.error(`Relic '${name}' not found in $ownedRelics!`);
-			}
-			break;
-		case 'number':
-			index = relicOrNameOrIndex;
-			if (0 <= index && index < vars.ownedRelics.length) {
-				relic = vars.ownedRelics[index];
-				name = relic.name;
-			} else {
-				console.error(`${index} is not a valid index in $ownedRelics!`);
-			}
-			break;
-		default:
-			relic = relicOrNameOrIndex;
-			if (relic) {
-				name = relic.name;
-				index = vars.ownedRelics.findIndex(relic => relic.name == name);
-				if (index < 0) console.error(`Relic '${name}' not found in $ownedRelics!`);
-			} else {
-				console.error('Passed relic was undefined!');
-			}
-	}
-	if (0 <= index && index < vars.ownedRelics.length) vars.ownedRelics.splice(index, 1);
-	if (relic) vars.soldRelics.push(relic);
-};
-setup.unsellRelic = relicOrName => {
-	const vars = variables();
-	let relic, name, index;
-	if (typeof relicOrName == 'string') {
-		name = relicOrName;
-		index = vars.soldRelics.findLastIndex(relic => relic.name == name);
-		if (index >= 0) {
-			relic = vars.soldRelics[index];
-		} else {
-			relic = vars.relics.findLast(relic => relic.name == name);
-		}
-		if (!relic) console.error(`Relic '${name}' does not exist!`);
-	} else {
-		relic = relicOrName;
-		if (relic) {
-			name = relic.name;
-			index = vars.soldRelics.findLastIndex(relic => relic.name == name);
-		} else {
-			console.error('Passed relic was undefined!');
-		}
-	}
-	if (index >= 0) vars.soldRelics.splice(index, 1);
-	if (relic) vars.ownedRelics.push(relic);
-};
-
-:: Check Availability of Cutting Tool [script]
-setup.haveCuttingTool = function() {
-	return variables().cut != 0 || variables().items[14].count > 0 || variables().ownedRelics.some(
-		r => r.name === "Giddy Reaper" || r.name === "Sharing Shears" || r.name === "Sunbeam"
-	);
-}
-
-:: Check Availability of Scuba Gear [script]
-setup.haveScubaGear = function() {
-	return variables().scuba != 0 || variables().items[15].count > 0 || variables().ownedRelics.some(
-		r => r.name === "Pneuma Wisp" 
-	);
-}
-
-:: Smartphone helpers [script]
-Object.defineProperty(setup, 'smartphoneRegular', {
-	get: () => variables().items[17],
-});
-Object.defineProperty(setup, 'haveSmartphoneRegular', {
-	get: () => variables().items[17].count > 0,
-	set: have => { variables().items[17].count = have ? 1 : 0; },
-});
-Object.defineProperty(setup, 'haveSmartphoneAI', {
-	get: () => variables().items[21].count > 0,
-	set: have => { variables().items[21].count = have ? 1 : 0; },
-});
-Object.defineProperty(setup, 'haveSmartphone', {
-	get: () => setup.haveSmartphoneRegular || setup.haveSmartphoneAI,
-});
-
-:: Check Availability of Light Source [script]
-// Light sources that are not going to run out during an expedition.
-setup.haveUnlimitedLightSource = function() {
-	return variables().light != 0 || variables().items[10].count > 0 || setup.haveSmartphone || variables().ownedRelics.some(
-		r => r.name === "Sunbeam" || r.name === "Glare Vantage"|| variables().BDwear
-	);
-}
-// Light sources that either consume supplies or can only be used in short bursts.
-// Use this function to check for Relic reachability.
-setup.havePotentialLightSource = function() {
-	return variables().items[9].count > 0 || variables().ownedRelics.some(
-		r => r.name === "Firmament Pigment"
-	) || setup.haveUnlimitedLightSource();
-}
-// Use this function to check whether a light source is on while traversing the Abyss.
-setup.haveTravelLightSource = function() {
-	return variables().torchUse == 1 
-	|| setup.haveUnlimitedLightSource();
-}
-
-:: Check Availability of notepad [script]
-setup.haveNotepad = function() {
-	return variables().notepad != 0 || setup.haveSmartphone || variables().items[26].count > 0;
-}
-
-:: Check Availability of rope [script]
-setup.haveRope = function() {
-	return variables().rope != 0 || variables().items[11].count > 0 ||  variables().ownedRelics.some(
-		r => r.name === "Orbweaver");
-}
 
 :: Curses [noreturn]
 <<AppearanceCorrect>>\
@@ -247,7 +103,7 @@ The total value of all your Relics is $total_value_relics dubloons.<br><br>
 	Your personal carrying capacity is <<print Math.round($carryWeight)>> kg.<br>
 <</if>>
 Your team has a total carrying capacity of <<print Math.round($totalCarry)>> kg.<br>
-Your team is currently carrying <<print setup.calcCarriedWeight().toFixed(1)>> kg.<br><br>
+Your team is currently carrying <<print setup.carriedWeight.toFixed(1)>> kg.<br><br>
 
 <<back [[$menuReturn]]>>
 <</nobr>>
@@ -1961,12 +1817,12 @@ How many dubloons would you like to pay back?
 <<switch $currentLayer>>
 	<<case 2>>
 		/* Reduce travel time if player has a cutting tool. */
-		<<if setup.haveCuttingTool()>>
+		<<if setup.haveCuttingTool>>
 			<<set _additiveModifier -= 1>>
 		<</if>>
 	<<case 3>>
-		/* Reduce travel time if player has a light source. */
-		<<if setup.haveTravelLightSource()>>
+		/* Reduce travel time if player has an active light source. */
+		<<if setup.haveTravelLightSource>>
 			<<set _additiveModifier -= 1>>
 		<</if>>
 		/* Apply Chlorophyll curse penalty, if any. */
@@ -2123,8 +1979,8 @@ How many dubloons would you like to pay back?
 	<<case 3>>
 		<<set $timeL3 += $tempTime>>
 		<<set $timeL3T1 += $tempTime>>
-		/* Check if player has a light source. */
-		<<if !setup.haveTravelLightSource()>>
+		/* Check if player has an active light source. */
+		<<if !setup.haveTravelLightSource>>
 			<<set $timeL3T2 += $tempTime>>
 		<</if>>
 	<<case 4>>
@@ -3073,7 +2929,7 @@ Which gender will the soul you summon to inhabit the golem possess?<br>
 	Your personal carrying capacity is <<print Math.round($carryWeight)>> kg.
 <</if>><br>
 Your team has a total carrying capacity of <<print Math.round($totalCarry)>> kg.<br>
-Your team is currently carrying <<print setup.calcCarriedWeight().toFixed(1)>> kg.<br>
+Your team is currently carrying <<print setup.carriedWeight.toFixed(1)>> kg.<br>
 
 /*<<if >>
 <</if>> message for item redundancy*/

--- a/src/layer3.twee
+++ b/src/layer3.twee
@@ -275,7 +275,7 @@ In the deeper parts of the layer, a cold breeze occasionally blows through the c
 	<<set $tempTime=1>>
 	<<include "GeneralTimeStats">>	
 /* 		<<set $timeL3T1 += 1>>
-	<<if !setup.haveTravelLightSource()>>
+	<<if !setup.haveTravelLightSource>>
 		<<set $timeL3T2 += 1>>
 	<</if>>
 	<<if $forageWater == 0>>

--- a/src/layer4.twee
+++ b/src/layer4.twee
@@ -867,7 +867,7 @@ As you draw closer, you notice that the air around the Purity Tree feels lighter
 You consider your options carefully, knowing that the wood of the Purity Tree holds untold potential. Harvesting it could grant you the power to purify a significant amount of corruption and craft invaluable items, while leaving it be and merely basking in its cleansing smoke may offer a more temporary reprieve.
 
 What would you like to do with the Purity Tree?
-<<if setup.haveCuttingTool()>>
+<<if setup.haveCuttingTool>>
 You can chop down the dead purity tree and use the 4 pieces to make crude protective gear for a total of +60 corruption immediately.
 [[Chop down the tree and make crude protective gear|Layer4 Hub][$corruption += 60]]
 
@@ -1088,7 +1088,7 @@ You have successfully taken the $relic48.name Relic. Hopefully you can make good
 <<if $layerExit == 0>>
 	<<set $layerExit = 1>>
 
-	<<if setup.haveRope() > 0>>
+	<<if setup.haveRope>>
 		<<set $tempTime = 8>>
 	<<else>>
 		<<set $tempTime = 19>>

--- a/src/layer5.twee
+++ b/src/layer5.twee
@@ -373,10 +373,10 @@ You do not have a medkit to cure your status condition.<br>
 <p>
 <<if _totalRelics.some(e => e.name === _name)>>
 Already taken
-<<elseif _name === "Moonwatcher" && !setup.havePotentialLightSource()>>
+<<elseif _name === "Moonwatcher" && !setup.havePotentialLightSource>>
 @@.unreachable;Located in a dark, sealed chamber with a light-activated lock. Requires a source of light.@@
-<<elseif _name === "Twin Polaris" && setup.calcCarriedWeight() + $hiredCompanions.length * 60 < 90>>
-@@.unreachable;Located in a sealed chamber locked by a pressure switch that must be held down with 90 kg of weight. The weight you and your companions can currently put on the switch is only <<print (setup.calcCarriedWeight() + $hiredCompanions.length * 60).toFixed(1)>> kg.@@
+<<elseif _name === "Twin Polaris" && setup.carriedWeight + $hiredCompanions.length * 60 < 90>>
+@@.unreachable;Located in a sealed chamber locked by a pressure switch that must be held down with 90 kg of weight. The weight you and your companions can currently put on the switch is only <<print (setup.carriedWeight + $hiredCompanions.length * 60).toFixed(1)>> kg.@@
 <<elseif _name === "Empath Coil" && ($items[20].count < 1 || $items[13].count < 1) && $slingshot == 0>>
 @@.unreachable;Located in a sealed chamber locked by a switch on the ceiling, far out of reach. Can be hit with a pistol, using 1 bullet.@@
 <<else>>
@@ -1517,7 +1517,7 @@ The radiant sun empowers your Breathless Exhale Relic, its energy pulsating with
 <<if $layerExit == 0>>
 	<<set $layerExit = 1>>
 
-	<<if setup.haveRope()>>
+	<<if setup.haveRope>>
 		<<set $tempTime = 11>>
 	<<else>>
 		<<set $tempTime = 24>>

--- a/src/layer7.twee
+++ b/src/layer7.twee
@@ -578,7 +578,7 @@ If you choose to place 2 Relics in the Clockwork Forge, along with 4 dubloons, y
 
 <p>Here are all of the items available for you to spend your $dubloons dubloons on in the Vend-o-matic 6900.</p>
 
-<p>Your team is currently carrying <<print setup.calcCarriedWeight().toFixed(1)>> kg and your team has a total carrying capacity of <<print Math.round($totalCarry)>> kg.</p>
+<p>Your team is currently carrying <<print setup.carriedWeight.toFixed(1)>> kg and your team has a total carrying capacity of <<print Math.round($totalCarry)>> kg.</p>
 <div class="cards-grid">
 <<for _item range [
 	setup.itemVendFood, setup.itemVendWater, setup.itemVendFlask,

--- a/src/layer8.twee
+++ b/src/layer8.twee
@@ -1429,7 +1429,6 @@ If you continue your descent in spite of everything, descending past this layer'
 	<<set _curseBonus = 0>>
 	<<set _companionBonus = 0>>
 	<<set _equipmentBonus = 0>>
-	<<set _cutRed = setup.haveCuttingTool() ? 1 : 0>>
 
 <<if $ownedRelics.some(e => e.name === "Lightning Rook")>>
 		Holding the Lightning Rook seems to slow the world down for you, evading your opponents and landing meaningful blows is much easier when you have so much time to react.<br>
@@ -1491,7 +1490,7 @@ If you continue your descent in spite of everything, descending past this layer'
 	<<if $hiredCompanions.some(e => e.name === "Khemia")>>
 		Khemia assumes a fighting stance, dispatching any mimics that finds itself near him. 
 		<<set _companionBonus += 15 * (1+$companionKhemia.HandicapThreat/10)>>
-		<<if _cutRed>>
+		<<if setup.haveCuttingTool>>
 			His sword slashes through them almost as fast as you can blink.
 			<<set _companionBonus += 8 * (1+$companionKhemia.HandicapThreat/10)>>
 			<<if $ownedRelics.some(e => e.name === "Sunbeam") || $joyousSword>>
@@ -1557,7 +1556,7 @@ If you continue your descent in spite of everything, descending past this layer'
 
 	<</if>>
 
-	<<if _cutRed>>
+	<<if setup.haveCuttingTool>>
 		You're glad you brought along a sword to defend yourself.<br>
 		<<set _equipmentBonus += 7>>
 	<</if>>
@@ -1657,7 +1656,6 @@ If you continue your descent in spite of everything, descending past this layer'
 	<<set _curseBonus = 0>>
 	<<set _companionBonus = 0>>
 	<<set _equipmentBonus = 0>>
-	<<set _cutRed = setup.haveCuttingTool() ? 1 : 0>>
 
 	<<if $ownedRelics.some(e => e.name === "Lightning Rook")>>
 		<<set _relicBonus += 10>>
@@ -1706,7 +1704,7 @@ If you continue your descent in spite of everything, descending past this layer'
 
 	<<if $hiredCompanions.some(e => e.name === "Khemia")>>
 		<<set _companionBonus += 15* (1+ $companionKhemia.HandicapThreat/10)>>
-		<<if _cutRed>>
+		<<if setup.haveCuttingTool>>
 			<<set _companionBonus += 8* (1+ $companionKhemia.HandicapThreat/10)>>
 			<<if $ownedRelics.some(e => e.name === "Sunbeam") || $joyousSword>>
 			<<set _companionBonus += 5* (1+ $companionKhemia.HandicapThreat/10)>>
@@ -1759,7 +1757,7 @@ If you continue your descent in spite of everything, descending past this layer'
 		<<set _companionBonus += _twinBonus>>
 	<</if>>
 
-	<<if _cutRed>>
+	<<if setup.haveCuttingTool>>
 		<<set _equipmentBonus += 7>>
 	<</if>>
 

--- a/src/relics.twee
+++ b/src/relics.twee
@@ -1630,33 +1630,33 @@ The one supernatural effect not cancelled is the unbreakability of Eternal Repos
     <p>
     <<if _totalRelics.some(e => e.name === _name)>>
         Already taken
-    <<elseif _name === "Forest's Gift" && !setup.haveCuttingTool()>>
+    <<elseif _name === "Forest's Gift" && !setup.haveCuttingTool>>
         @@.unreachable;Located in a cavern completely covered in hard brambles. You cannot retrieve this Relic unless you find some kind of cutting tool.@@
-    <<elseif _name === "Umbra Trident" && !setup.havePotentialLightSource()>>
+    <<elseif _name === "Umbra Trident" && !setup.havePotentialLightSource>>
         @@.unreachable;Located in a side cavern that is completely unlit. Due to this Relic's properties, it is impossible to move it in complete darkness, and a source of light is required to retrieve it.@@
-    <<elseif _name === "Orbweaver" && !setup.haveRope()>>
+    <<elseif _name === "Orbweaver" && !setup.haveRope>>
         @@.unreachable;Located on top of a large vertical shaft with no footholds. You cannot reach this Relic without some kind of climbing gear, like a rope.@@
-    <<elseif _name === "Acrobatic Accord" && !setup.haveScubaGear() >>
+    <<elseif _name === "Acrobatic Accord" && !setup.haveScubaGear >>
         @@.unreachable;Located in an underwater tunnel (with murky, undrinkable water.) Requires scuba gear to retrieve.@@
-    <<elseif _name === "Gilded Prison" && !setup.haveCuttingTool() && $torchUse == 0>>
+    <<elseif _name === "Gilded Prison" && !setup.haveCuttingTool && $torchUse == 0>>
         @@.unreachable;The entrance to the cave this Relic's located in is completely covered with hard icicles. You can either slash them away with a cutting tool, or spend 1 extra day melting them with a source of heat (doesn't use up an extra torch if you used one reaching the Relic.)@@
     <<elseif _name === "Omoikane Circuit" && setup.haveSmartphoneAI>>
         Already taken
-    <<elseif _name === "Timekeeper's Keepsake" && !setup.haveRope()>>
+    <<elseif _name === "Timekeeper's Keepsake" && !setup.haveRope>>
         @@.unreachable;Located at the bottom of an icy pit, far too slippery on all sides to be climbed by hand. Requires some rope.@@
-    <<elseif _name === "Out of Mind" && !setup.haveRope() && !setup.haveCuttingTool()>>
+    <<elseif _name === "Out of Mind" && !setup.haveRope && !setup.haveCuttingTool>>
         @@.unreachable;Dangling off the tip of a particularly tall and thick &mdash; but thankfully slow and inactive &mdash; tentacle. Requires either a rope to climb up or a cutting implement to slice it down.@@
-    <<elseif _name === "Forbidden Grimoire" && !setup.haveScubaGear()>>
+    <<elseif _name === "Forbidden Grimoire" && !setup.haveScubaGear>>
         @@.unreachable;Found in a chest at the bottom of a very deep pool of...tentacle slime? Gross. You'll need diving gear to breathe long enough to reach it. Don't drink the tentacle slime, please.@@
-    <<elseif _name === "Phoenix Obol" && !setup.havePotentialLightSource()>>
+    <<elseif _name === "Phoenix Obol" && !setup.havePotentialLightSource>>
         @@.unreachable;Located in a sealed, dark vault with a light-activated lock. Requires a source of light.@@
     <<elseif _name === "Blind Divine" && $items[13].count == 0 && $items[20].count < 4 && $slingshot == 0>>
         @@.unreachable;Located in a vault sealed by 4 out-of-reach switches. Can be reached with bullets, expending 4 in the process. Even Cloud can't decrease this count; he can't make a bullet go in two directions at once.@@
-    <<elseif _name === "Granted Granite" && setup.calcCarriedWeight() + $hiredCompanions.length * 60 < 200>>
-        @@.unreachable;Located in a vault sealed by a pressure switch that requires 200 kg to remain pressed. The weight you and your companions can currently put on the switch is only <<print (setup.calcCarriedWeight() + $hiredCompanions.length * 60).toFixed(1)>> kg.@@
-    <<elseif _name === "Absolute Oracle" && !setup.havePotentialLightSource()>>
+    <<elseif _name === "Granted Granite" && setup.carriedWeight + $hiredCompanions.length * 60 < 200>>
+        @@.unreachable;Located in a vault sealed by a pressure switch that requires 200 kg to remain pressed. The weight you and your companions can currently put on the switch is only <<print (setup.carriedWeight + $hiredCompanions.length * 60).toFixed(1)>> kg.@@
+    <<elseif _name === "Absolute Oracle" && !setup.havePotentialLightSource>>
         @@.unreachable;THE ROOM THIS RELIC IS LOCATED IN IS VERY BAD. Pitch black, with light from the outside hallway seemingly refusing to enter altogether. You hear thousands of tiny whispers and chattering teeth inside. Don't go in without a source of light or you'll get eaten by a grue or something. (Whatever's in there won't appear so long as you have one.)@@
-    <<elseif _name === "Drifting Aperture" && !setup.haveRope()>>
+    <<elseif _name === "Drifting Aperture" && !setup.haveRope>>
         @@.unreachable;They're sitting on a ceiling a very long way above you, with no apparent paths that would allow you to walk on that same ceiling. Requires a rope to reach.@@
     <<else>>
         <<print "[[Pick up the " + _name + "]]">>

--- a/src/surface.twee
+++ b/src/surface.twee
@@ -161,7 +161,7 @@ Would you like to go back to before you were in debt without a creditor, like Cl
 :: ShopInventory [nobr]
 <p>Here are the items available for your to spend your $dubloons dubloons on.</p>
 
-<p>Your team is currently carrying <<print setup.calcCarriedWeight().toFixed(1)>> kg and your team has a total carrying capacity of <<print Math.round($totalCarry)>> kg.</p>
+<p>Your team is currently carrying <<print setup.carriedWeight.toFixed(1)>> kg and your team has a total carrying capacity of <<print Math.round($totalCarry)>> kg.</p>
 
 <div class="cards-grid">
 <<for _item range [$item2, $item1, $item3].concat($items.slice(4, 20), $item27, setup.itemMoney)>>
@@ -522,11 +522,11 @@ How many warding braces would you like to buy?
 
 :: Buy Smartphone [item]
 <<set $temp = 1>>
-[img[setup.ImagePath + setup.smartphoneRegular.image]]
+[img[setup.ImagePath + setup.item('Smartphone').image]]
 
 You have bought a smartphone.
 
-[[Confirm|previous()][setup.haveSmartphoneRegular = true, $dubloons -= setup.smartphoneRegular.cost]]
+[[Confirm|previous()][setup.haveSmartphoneRegular = true, $dubloons -= setup.item('Smartphone').cost]]
 <<back>>
 
 :: Buy Inn Room Pass [item]

--- a/src/widgets.twee
+++ b/src/widgets.twee
@@ -2388,7 +2388,7 @@
 	<<set $totalCarry +=$carryWeight>>
 <</if>>
 
-<<set _carriedWeight = setup.calcCarriedWeight()>>
+<<set _carriedWeight = setup.carriedWeight>>
 <<if $totalCarry*1.1 < _carriedWeight >>
 	@@.alert2; You are severely overburdened!@@<br><br>
 <<elseif $totalCarry*1 < _carriedWeight  >>


### PR DESCRIPTION
This is mostly cleanup, although there are some minor fixes in there.

* Moves JS from `global.twee` to `script.js`.
* Makes more use of getters for a slight improvement of readability.
* Introduces some utility functions for getting items/relics/curses by name.
* Adds an optional reward/cost argument to sellRelic/unsellRelic (I didn't update any callers yet).
* Fixes a bug in `haveUnlimitedLightSource` where variable `BDwear` was checked alongside relics.

Edit: Decided to remove the item synchronization thing after noticing `$vaultItems`, which relies on every element being a copy! Still would have worked, but no reason to sync them right now anyway.