### PR TITLE
Fix checks for heat and cold protection with helper functions

### DIFF
--- a/src/global.twee
+++ b/src/global.twee
@@ -142,9 +142,13 @@ Click this if you have found something that can be used as a light source:
 [[I have a Light|Adjustments][$light = 1]]
 [[No Light|Adjustments][$light = 0]]
 
-Click this if you have found something that can be used as a substantial heat source:
-[[I have a source of Heat|Adjustments][$heat = 1]]
-[[No Heat|Adjustments][$heat = 0]]
+Click this if you have found something that can be used to persistently keep you warm:
+[[I have protection from cold|Adjustments][$heatOverride = true]]
+[[No protection from cold|Adjustments][$heatOverride = false]]
+
+Click this if you have found something that can be used to persistently keep from overheating:
+[[I have protection from heat|Adjustments][$coolOverride = true]]
+[[No protection from cold|Adjustments][$coolOverride = false]]
 
 Click this if you have found something that can be used as a climbing rope:
 [[I have something that can be a Rope|Adjustments][$rope = 1]]
@@ -1688,7 +1692,7 @@ You can use the balloon to send requests and Relics back to Outset Town. You can
 	<<if $ownedRelics[$i].name == "Rømer Stones" && $warmCloth == 0 && $coolCloth == 0>>
 	<br>You muse over what you can do with the Rømer Stones, taking advantage over their ability for limitless small-scale heating or cooling.<br><br>
 	You can either buy some winter clothers for 30 dubloons to craft self-warming winter gear, or you could buy some light summer clothing for 25 dubloons to craft some cooling summer clothes.<br>
-		[[Use the Rømer Stones for self-warming winter gear|Balloon Workshop][$ownedRelics.deleteAt($i), $items[22].count = 1, $dubloons -=30,$warmCloth=1]]<br>
+		[[Use the Rømer Stones for self-warming winter gear|Balloon Workshop][$ownedRelics.deleteAt($i), $items[22].count = 1, $dubloons -=30, $warmCloth=1]]<br>
 		[[Use the Rømer Stones for self-cooling summer gear|Balloon Workshop][$ownedRelics.deleteAt($i), $items[23].count = 1, $dubloons -=25, $coolCloth=1]]<br>
 	<</if>>
 	<<if $ownedRelics[$i].name == "Brave Vector" && $slingshot == 0>>
@@ -1788,10 +1792,6 @@ How many dubloons would you like to pay back?
 */
 <<set _inputTime = _args[1]>>
 
-/* Ensure the $heat and $cool variables are set correctly. */
-<<set $heat = $slwear || ($warmCloth && !$dollevent2) ? 1 : 0>>
-<<set $cool = $slwear || ($coolCloth && !$dollevent2) ? 1 : 0>>
-
 /* Start by computing the overall additive modifier. */
 <<set _additiveModifier = _args[3] || 0>>
 
@@ -1801,10 +1801,12 @@ How many dubloons would you like to pay back?
 /* Apply status penalty, if any. */
 <<if $status.duration > 0>>
 	<<set _additiveModifier += $status.penalty>>
-	/* Decrement status duration and remove status penalty if duration is now 0. */
-	<<set $status.duration -= 1>>
-	<<if $status.duration < 1>>
-		<<set $status.penalty = 0>>
+	<<if !_args[2]>>
+		/* Decrement status duration and remove status penalty if duration is now 0. */
+		<<set $status.duration -= 1>>
+		<<if $status.duration < 1>>
+			<<set $status.penalty = 0>>
+		<</if>>
 	<</if>>
 <</if>>
 
@@ -1832,7 +1834,7 @@ How many dubloons would you like to pay back?
 		<</if>>
 	<<case 4>>
 		/* Reduce travel time if player has a heat source. */
-		<<if $heat>>
+		<<if setup.haveColdProtection>>
 			<<set _additiveModifier -= 2>>
 		<<elseif $torchUse == 1 && $items[9].count > 0>>
 			<<set _additiveModifier -= 2>>
@@ -1853,7 +1855,7 @@ How many dubloons would you like to pay back?
 		<</if>>
 	<<case 5 6>>
 		/* Reduce travel time if player has a way to keep from overheating. */
-		<<if $cool>>
+		<<if setup.haveHeatProtection>>
 			<<set _additiveModifier -= 1>>
 		<</if>>
 	<<case 8>>

--- a/src/init.twee
+++ b/src/init.twee
@@ -111,8 +111,8 @@ document.documentElement.setAttribute("lang", "en");
 <<set $riverVisit = 0>>
 <<set $cut = 0>>
 <<set $light = 0>>
-<<set $heat = 0>>
-<<set $cool = 0>>
+<<set $heatOverride = false>>
+<<set $coolOverride = false>>
 <<set $rope = 0>>
 <<set $scuba = 0>>
 <<set $height = "0">>

--- a/src/layer4.twee
+++ b/src/layer4.twee
@@ -47,7 +47,7 @@ She stands at the edge of your peripheral vision, immaterial and seemingly harml
 <<else>>
 	<<set $layerTemp = random(0,20)>>
 <</if>>
-<<if $layerTemp == 1 && $heat == 1>>
+<<if $layerTemp == 1 && setup.haveColdProtection>>
 	As you trudge through the snow, you suddenly feel a gust of wind pick up, and a flurry of snowflakes swirl around you. The miasma-enhanced cold bites at your skin, and you struggle to maintain visibility. You quickly reach for your heat source, igniting it with a flare of heat that temporarily pushes the biting cold away. The storm subsides just as quickly as it began, but you're reminded of the harsh reality of this layer of the Abyss. <br><br>
 <<elseif $layerTemp == 2>>
 	A sudden flurry of Miasma-driven hail pelts down on you, each icy stone biting into your exposed skin. You take shelter behind a nearby glacier, watching as the hailstorm intensifies. Just as you're about to leave your hiding place, you notice a small, crystalline creature darting in and out of the hailstones, seemingly unaffected by the storm. Its delicate, ice-like body refracts the Miasma's light, creating a mesmerizing dance of colors. Once the hailstorm subsides, the creature disappears into the snowy landscape.<br><br>
@@ -79,10 +79,10 @@ She stands at the edge of your peripheral vision, immaterial and seemingly harml
 
 	<</if>>
 
-	<<if $items[9].count > 0 && $heat == 0 && $torchUse == 0>>
+	<<if $items[9].count > 0 && !setup.haveColdProtection && $torchUse == 0>>
 	[[Use torches to reduce travel times on this layer by 2 days each at the cost of 1 torch per travel|Layer4 Hub][$torchUse = 1]]<br><br>
 	<</if>>
-	<<if $torchUse == 1 && $heat == 0>>
+	<<if $torchUse == 1 && !setup.haveColdProtection>>
 	[[Stop using torches to reduce travel time|Layer4 Hub][$torchUse = 0]]<br><br>
 	<</if>>
 

--- a/src/layer5.twee
+++ b/src/layer5.twee
@@ -1781,47 +1781,6 @@ Threats:
 
 <<back>>
 
-:: Layer5Time
-<<nobr>>
-<<if $status.duration > 0>>
-	<<set $status.duration -= 1>>
-	<<else>>
-	<<set $status.penalty = 0>>
-<</if>>
-<<set $tempTime = (Math.max((1+$SizeHandicap)*($tempTime - $timeRed + $status.penalty + (Math.trunc($hexflame / 10)) - $cool), 0))>>
-<<set $timeL5 += $tempTime>>
-<<if ($items[0].count + $items[3].count) > 10>>
-	<<set $timeL5T2 += $tempTime>>
-<</if>>
-<<set $timeL5T1 += $tempTime>>
-<<set $time += $tempTime>>
-<<if $forageFood == 0>>
-	<<set $items[1].count -= $tempTime>>
-	<<else>>
-	<<set $foodL5 += $tempTime>>
-	<<if $abyssKnow == 0>>
-		<<set $crumbleFluid += (5 * $tempTime)>>
-		<<else>>
-		<<set $crumbleFluid += $tempTime>>
-	<</if>>
-<</if>>
-<<for $i = 0; $i < $tempTime; $i++>>
-	<<if $forageWater == 0>>
-		<<if $items[3].count > 0>>
-			<<set $items[3].count -= 1>>
-			<<set $items[2].count += 1>>
-		<<else>>
-			<<set $items[0].count -= 1>>
-		<</if>>
-	<<else>>
-		<<set $waterL5 += 1>>
-	<</if>>
-	<<if $hexflame > 9>>
-		<<set $hexflame -= 1>>
-	<</if>>
-<</for>>
-<</nobr>>
-
 :: Layer5 Camp
 
 <<include 'CampCode'>>

--- a/src/layer6.twee
+++ b/src/layer6.twee
@@ -45,11 +45,9 @@ They grow taller as you proceed, until you're wading through a thicket or navel-
 <</if>>
 
 <<if $coolCloth && !$dollevent2>>
-	<<set $cool=1>>
 	You put on the self-cooling clothes. The romer stones that you incorperated in it feel like small airconditioning units although the clothes are light they still cover you very well and soon you feel them cool your entire body. You feel like you could run a mile in these clothes and still not overheat in this hellish landscape you find yourself. It looks like you'll be able to cover more distance wearing this than you would normally be able to, reducing all travel costs on this layer by 1 day.<br><br>
 
 <<elseif $dollevent2 && $coolCloth>>
-
 	By now you have accepted that you can't take of the tattered pink dress. But when you try to put the self-cooling clothes over your tattered dress you faint, only to wake up with the summer clothes off and neatly folded in your hands again. Looking at the doll you swear you can see it grinning at you. It seems you are stuck sweating it out in this worn down dress. If only it would be little hoter so that acursed doll would go up in flames..<br><br>
 
 <<elseif $dollevent2 && !$coolCloth>>

--- a/src/script.js
+++ b/src/script.js
@@ -369,6 +369,20 @@ Object.defineProperties(setup, {
 	haveRope: {
 		get: () => checkAvailability(['Rope'], ['Orbweaver'], ['rope']),
 	},
+	// Check whether the player has protection from cold.
+	haveColdProtection: {
+		get: () => {
+			const vars = variables();
+			return Boolean(vars.heatOverride || vars.slwear || (vars.warmCloth && !vars.dollevent2));
+		},
+	},
+	// Check whether the player has protection from heat.
+	haveHeatProtection: {
+		get: () => {
+			const vars = variables();
+			return Boolean(vars.coolOverride || vars.slwear || (vars.coolCloth && !vars.dollevent2));
+		},
+	},
 	// Sell a relic (dubloon reward optional).
 	sellRelic: {
 		value: (relicOrNameOrIndex, dubloonReward) => {

--- a/src/surface.twee
+++ b/src/surface.twee
@@ -746,7 +746,7 @@ You step into the Relic Workshop of Outset Town. The air is thick with the smell
 	<br>You muse over what you can do with the Rømer Stones, taking advantage over their ability for limitless small-scale heating or cooling.<br><br>
 	You can either craft self-warming winter gear using winter clothes available, or you could use some light summer clothing to craft some self-cooling summer gear. Either one of these will require using all of the Rømer stones to craft.<br>
 		<<if $warmCloth == 0>>
-		[[Use the Rømer Stones for self-warming winter gear|Surface Workshop][setup.sellRelic($i), $items[22].count = 1,$warmCloth=1]]<br>
+		[[Use the Rømer Stones for self-warming winter gear|Surface Workshop][setup.sellRelic($i), $items[22].count = 1, $warmCloth=1]]<br>
 		<</if>>
 		<<if $coolCloth == 0>>
 		[[Use the Rømer Stones for self-cooling summer gear|Surface Workshop][setup.sellRelic($i), $items[23].count = 1, $coolCloth=1]]<br>

--- a/src/widgets.twee
+++ b/src/widgets.twee
@@ -3011,10 +3011,7 @@
 <<capture _relic>>
 	<<set _relic = _args[0]>>
 	<<set $ownedRelics.push(_relic)>>
-	<<if _relic.time - $SibylBuff > 0>>
-		<<set $tempTime = _relic.time - $SibylBuff>>
-		<<AdjustedTravelTime "$tempTime" $tempTime>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
-	<</if>>
+	<<AdjustedTravelTime "$tempTime" _relic.time false `-$SibylBuff`>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 	<<set $corruption -= Math.max(_relic.corr - $corRed + ($currentLayer != 6 ? 5 * Math.trunc($hexflame / 10) : 0), 0)>>
 	<<if _relic.pic>>
 		[img[setup.ImagePath + _relic.pic]]<br>


### PR DESCRIPTION
This adds an override for protection from heat and makes the override for protection from cold actually useful (it was being overwritten every time you traveled). Checks for this now use helper functions.

I also noticed another oversight in `<<AdjustedTravelTime>>`: The status effect time was being decremented even when the macro was used for prediction in the relic grid.