### PR TITLE
Fix companion swap after object identity changes

### DIFF
--- a/src/layer2.twee
+++ b/src/layer2.twee
@@ -578,61 +578,63 @@ Whose body do you find yourself in?
 <<AdjustedTravelTime "$tempTime" 3>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
 <<set $hiredCompanions[$swapComp].carry = $temp2>>
 <<CarryAdjust>>
+<<set _companionSwapHandle = $hiredCompanions[$swapComp]>>
 <</nobr>>
-You've woken up in the body of $hiredCompanions[$swapComp].name! And $hiredCompanions[$swapComp].name has woken up in your body!
+You've woken up in the body of _companionSwapHandle.name! And _companionSwapHandle.name has woken up in your body!
 
 How do you feel? Did you ask your companion before the switch? Be prepared for your relationship to change if they didn't want this.
 
 <<nobr>>
+/* Make a shallow copy of the companion. */
+<<set _copy = Object.assign({}, _companionSwapHandle)>>
 
-<<if $hiredCompanions[$swapComp].name == $companionTwin.name >>
-	<<set _tempName = "Twin">>
-<<else>>
-	<<set _tempName = $hiredCompanions[$swapComp].name>>
-<</if>>
-<<print "<<set _handle  = $companion"+ _tempName +" >>">>
+<<set _companionSwapHandle.age = $app.age>>
+<<set _companionSwapHandle.osex = $app.osex>>
+<<set _companionSwapHandle.obreasts = $app.obreasts>>
+<<set _companionSwapHandle.openis = $app.openis>>
+<<set _companionSwapHandle.ogender = $app.ogender>>
+<<set _companionSwapHandle.oheight = $app.oheight>>
+<<set _companionSwapHandle.ohair = $app.ohair>>
+<<set _companionSwapHandle.oskinColor = $app.oskinColor>>
+<<set _companionSwapHandle.oeyeColor = $app.oeyeColor>>
+<<set _companionSwapHandle.switch = true>>
 
-<<set _handle.osex = $app.osex>>
-<<set _handle.obreasts = $app.obreasts>>
-<<set _handle.openis = $app.openis>>
-<<set _handle.ogender = $app.ogender>>
-<<set _handle.oheight = $app.oheight>>
-<<set _handle.age = $app.age>>
-<<set _handle.ohair = $app.ohair>>
-<<set _handle.oskinColor = $app.oskinColor>>
-<<set _handle.oeyeColor = $app.oeyeColor>>
+<<set $app.age = _copy.age>>
+<<set $app.osex = _copy.osex>>
+<<set $app.obreasts = _copy.obreasts>>
+<<set $app.openis = _copy.openis>>
+<<set $app.ogender = _copy.ogender>>
+<<set $app.oheight = _copy.oheight>>
+<<set $app.ohair = _copy.ohair>>
+<<set $app.oskinColor = _copy.oskinColor>>
+<<set $app.oeyeColor = _copy.oeyeColor>>
+<<set $app.switch = true>>
 
-<<set $app.osex = $hiredCompanions[$swapComp].osex>>
-<<set $app.obreasts = $hiredCompanions[$swapComp].obreasts>>
-<<set $app.openis = $hiredCompanions[$swapComp].openis>>
-<<set $app.ogender = $hiredCompanions[$swapComp].ogender>>
-<<set $app.oheight = $hiredCompanions[$swapComp].oheight>>
-<<set $app.age = $hiredCompanions[$swapComp].age>>
-<<set $app.ohair = $hiredCompanions[$swapComp].ohair>>
-<<set $app.oskinColor = $hiredCompanions[$swapComp].oskinColor>>
-<<set $app.oeyeColor = $hiredCompanions[$swapComp].oeyeColor>>
-<<set $app.desc += $hiredCompanions[$swapComp].appDesc>>
+<<set $app.desc += _copy.appDesc>>
 
-<<if $hiredCompanions[$swapComp].name == $companionTwin.name>>
+<<if _companionSwapHandle.name == $companionTwin.name>>
 	<<set $companionSwitched = "Twin">>
 <<else>>
-	<<set $companionSwitched = $hiredCompanions[$swapComp].name>>
+	<<set $companionSwitched = _companionSwapHandle.name>>
 <</if>>
-<<set _handle.switch=true>>
-<<set $app.switch=true>>
+
 <<CarryAdjust>>
 <<Update_MC_Speech>>
-<<if $hiredCompanions[$swapComp].name=="Maru">>
-	<<set $companionMaru.genderVoice = $companionMaru.gender>>
-	<<set $mc.imageIcon=$hiredCompanions[$swapComp].imageIcon>>
-	<<if $companionMaru.sex=='male'>>
-		<<set $companionMaru.imageIcon="Player Icons/playerM.png">>
-	<<else>>
-		<<set $companionMaru.imageIcon="Player Icons/playerF.png">>
-	<</if>>
-	<<set $companionMaru.affec -= (7-$hsswear)>>
-	<<set $companionMaru.swap = true>>
 
+<<set _companionSwapHandle.genderVoice = _companionSwapHandle.gender>>
+<<set $mc.imageIcon = _companionSwapHandle.imageIcon>>
+<<if _companionSwapHandle.sex == "male">>
+	<<set _companionSwapHandle.image = "Player Icons/playerM.png">>
+	<<set _companionSwapHandle.imageIcon = "Player Icons/playerM.png">>
+	<<if $app.sex == "female">><<set $menCycleT = $time - 7>><</if>>
+<<else>>
+	<<set _companionSwapHandle.image = "Player Icons/playerF.png">>
+	<<set _companionSwapHandle.imageIcon = "Player Icons/playerF.png">>
+<</if>>
+<<set _companionSwapHandle.swap = true>>
+
+<<if _companionSwapHandle.name == "Maru">>
+	<<set $companionMaru.affec -= (7-$hsswear)>>
 	<<say $companionMaru>> Huh? what happened to me? Why do I feel so strange? And why am I also standing right there?<</say>><br>
 	Your old body points at you, a look of confusion across their face.<br><br>
 	<<say $mc>> I'm sorry Maru, I had to do this. Trust me, it's better for the whole expedition in the long run.<</say>><br>
@@ -641,18 +643,9 @@ How do you feel? Did you ask your companion before the switch? Be prepared for y
 	<<say $mc>> Please stop crying, we might even be able to reverse this eventually with another wonder!<</say>><br>
 	<<say $companionMaru>> You think? Do you promise to change me back if we do?<</say>><br>
 	<<say $mc>> Absolutely! <</say>><br>
-<<elseif $hiredCompanions[$swapComp].name=="Lily">>
-	<<set $companionLily.genderVoice = $companionLily.gender>>
-	<<set $mc.imageIcon=$hiredCompanions[$swapComp].imageIcon>>
-	<<if $companionLily.sex=='male'>>
-		<<set $companionLily.imageIcon="Player Icons/playerM.png">>
-		<<set $menCycleT = $time - 7>>
-	<<else>>
-		<<set $companionLily.imageIcon="Player Icons/playerF.png">>
-	<</if>>
+<<elseif _companionSwapHandle.name == "Lily">>
 	<<set $companionLily.affec -= (7-$hsswear)>>
-	<<set $companionLily.swap = true>>
-		<<say $companionLily>> What the hell? Why do I see myself over there?<</say>><br>
+	<<say $companionLily>> What the hell? Why do I see myself over there?<</say>><br>
 	Your old body points towards you accusingly.<br><br>
 	<<say $mc>> I'm sorry Lily, I had to do this. Trust me it's better for the whole expedition in the long run<</say>><br>
 	As Lily looks down she notices she is not in her own body anymore.<br><br>
@@ -678,16 +671,8 @@ How do you feel? Did you ask your companion before the switch? Be prepared for y
 		<<say $companionLily>> IF? you better pray for your own sake that there is a way!<</say>><br>
 		You gulp. You have never seen her so angry. Apparently she valued her own body even more than you thought.<br><br>
 	<</if>>
-<<elseif $hiredCompanions[$swapComp].name=="Khemia">>
-	<<set $companionKhemia.genderVoice = $companionKhemia.gender>>
-	<<set $mc.imageIcon=$hiredCompanions[$swapComp].imageIcon>>
-	<<if $companionKhemia.sex=='male'>>
-		<<set $companionKhemia.imageIcon="Player Icons/playerM.png">>
-	<<else>>
-		<<set $companionKhemia.imageIcon="Player Icons/playerF.png">>
-	<</if>>
+<<elseif _companionSwapHandle.name == "Khemia">>
 	<<set $companionKhemia.affec -= (7-$hsswear)>>
-	<<set $companionKhemia.swap = true>>
 	<<say $companionKhemia>> I feel weird, $mc.name. Why do I feel so sluggish?<</say>><br>
 	<<say $mc>> I'm sorry Khemia, I had to do this. Trust me it's better for the whole expedition in the long run.<</say>><br>
 	It seems he only just now notices that he is looking at his own former body.<br><br>
@@ -709,18 +694,8 @@ How do you feel? Did you ask your companion before the switch? Be prepared for y
 		<<say $mc>> Look, it might not even be permanent, who knows?<</say>><br>
 		<<say $companionKhemia>> For your sake, it better not be... I guess I'll keep you safe for now, since you are holding my body hostage.<</say>><br>
 	<</if>>
-
-<<elseif $hiredCompanions[$swapComp].name=="Cherry">>
-	<<set $companionCherry.genderVoice = $companionCherry.gender>>
-	<<set $mc.imageIcon=$hiredCompanions[$swapComp].imageIcon>>
-	<<if $companionCherry.sex=='male'>>
-		<<set $companionCherry.imageIcon="Player Icons/playerM.png">>
-		<<set $menCycleT = $time - 7>>
-	<<else>>
-		<<set $companionCherry.imageIcon="Player Icons/playerF.png">>
-	<</if>>
+<<elseif _companionSwapHandle.name == "Cherry">>
 	<<set $companionCherry.affec -= (5-$hsswear)>>
-	<<set $companionCherry.swap = true>>
 	<<say $companionCherry>> Huh? What happened? Why am I looking at myself?<</say>><br>
 	<<say $mc>> I'm sorry Cherry, I had to do this. Trust me, it's better for the whole expedition in the long run.<</say>><br>
 	<<say $companionCherry>> You switched bodies with me?<</say>><br>
@@ -729,16 +704,8 @@ How do you feel? Did you ask your companion before the switch? Be prepared for y
 	<<say $companionCherry>> I don't know... I thought after all this time I really stopped caring... But if that's true, why do I still feel sad now?<</say>><br>
 	<<say $mc>> Ah, again, sorry I had to do this. If I can find a way to reverse this I absolutely will.<</say>><br>
 	<<say $companionCherry>> You saying that makes me a little less sad, I think.<</say>><br>
-<<elseif $hiredCompanions[$swapComp].name=="Cloud">>
-	<<set $companionCloud.genderVoice = $companionCloud.gender>>
-	<<set $mc.imageIcon=$hiredCompanions[$swapComp].imageIcon>>
-	<<if $companionCloud.sex=='male'>>
-		<<set $companionCloud.imageIcon="Player Icons/playerM.png">>
-	<<else>>
-		<<set $companionCloud.imageIcon="Player Icons/playerF.png">>
-	<</if>>
+<<elseif _companionSwapHandle.name == "Cloud">>
 	<<set $companionCloud.affec -= (7-$hsswear)>>
-	<<set $companionCloud.swap = true>>
 	<<say $companionCloud>> There's something wrong...<</say>><br>
 	He immediately sticks two fingers in his throat and starts to throw up.<br>
 	<<say $companionCloud>> Quick, water, somebody! I think I've been poisoned, I'm hallucinating and I feel wrong.<</say>><br>
@@ -750,17 +717,8 @@ How do you feel? Did you ask your companion before the switch? Be prepared for y
 	You gulp<br><br>
 	<<say $mc>> Yes, sir!<</say>><br>
 	<<say $companionCloud>> And after this expedition's over, you're coming with me, because I can't really show up to some people looking like this...<</say>><br>
-<<elseif $hiredCompanions[$swapComp].name=="Saeko">>
-	<<set $companionSaeko.genderVoice = $companionSaeko.gender>>
-	<<set $mc.imageIcon=$hiredCompanions[$swapComp].imageIcon>>
-	<<if $companionSaeko.sex=='male'>>
-		<<set $companionSaeko.imageIcon="Player Icons/playerM.png">>
-		<<set $menCycleT = $time - 7>>
-	<<else>>
-		<<set $companionSaeko.imageIcon="Player Icons/playerF.png">>
-	<</if>>
+<<elseif _companionSwapHandle.name == "Saeko">>
 	<<set $companionSaeko.affec -= (7-$hsswear)>>
-	<<set $companionSaeko.swap = true>>
 	<<say $companionSaeko>> Huh? What is...<</say>><br>
 	She inspects her own body and than looks up at her former body. You see her eyes go wide in sudden realization.<br><br>
 	<<say $companionSaeko>> Tell me you didn't use the Fate Crossing Star pond to switch our bodies?<</say>><br>
@@ -777,18 +735,7 @@ How do you feel? Did you ask your companion before the switch? Be prepared for y
 	<<say $mc>> Great! Where is it?<</say>><br>
 	<<say $companionSaeko>> You're either an idiot or cruel, and I honestly can't tell which right now.<</say>><br>
 	She walks off with your body, still clearly very much annoyed.
-<<elseif $hiredCompanions[$swapComp].name==$companionTwin>>
-	<<set $companionTwin.genderVoice = $companionTwin.gender>>
-	<<set $mc.imageIcon=$hiredCompanions[$swapComp].imageIcon>>
-	<<if $companionTwin.sex=='male'>>
-		<<set $companionTwin.imageIcon="Player Icons/playerM.png">>
-		<<if $curse111.variation2 == "inverted">>
-			<<set $menCycleT = $time - 7>>
-		<</if>>
-	<<else>>
-		<<set $companionTwin.imageIcon="Player Icons/playerF.png">>
-	<</if>>
-	<<set $companionTwin.swap = true>>
+<<elseif _companionSwapHandle.name == $companionTwin>>
 	<<say $companionTwin>> Hmm? What something feels off. Wait a second...<</say>><br>
 	<<if $companionTwin.osex=="male">>He <<else>>She <</if>>looks at you intensenly.<br><br>
 	<<if $companionTwin.osex==$app.osex>>
@@ -813,29 +760,29 @@ How do you feel? Did you ask your companion before the switch? Be prepared for y
 	<</if>>
 <</if>>
 
-<<if $hiredCompanions.length>1 & $companionTwin.swap !== true>>
-The rest of your companions are clearly not aproving of your action as well<br><br>
-<<if $hiredCompanions.some(e => e.name === "Maru") && $companionMaru.swap==false>>
+<<if $hiredCompanions.length > 1 && !$companionTwin.swap>>
+	The rest of your companions are clearly not aproving of your action as well<br><br>
+<<if $hiredCompanions.some(e => e.name === "Maru") && !$companionMaru.swap>>
 	<<set $companionMaru.affec -= (3-$hsswear)>>
 	<<say $companionMaru>> That's not nice... <</say>><br>
 <</if>>
-<<if $hiredCompanions.some(e => e.name === "Lily") && $companionLily.swap==false>>
+<<if $hiredCompanions.some(e => e.name === "Lily") && !$companionLily.swap>>
 	<<set $companionLily.affec -= (3-$hsswear)>>
 	<<say $companionLily>> How could you?! <</say>><br>
 <</if>>
-<<if $hiredCompanions.some(e => e.name === "Khemia") && $companionKhemia.swap==false>>
+<<if $hiredCompanions.some(e => e.name === "Khemia") && !$companionKhemia.swap>>
 	<<set $companionKhemia.affec -= (3-$hsswear)>>
 	<<say $companionKhemia>> Not cool! Why would you do that? <</say>><br>
 <</if>>
-<<if $hiredCompanions.some(e => e.name === "Cherry") && $companionCherry.swap==false>>
+<<if $hiredCompanions.some(e => e.name === "Cherry") && !$companionCherry.swap>>
 	<<set $companionCherry.affec -= (3-$hsswear)>>
 	<<say $companionCherry>> I thought you were different... <</say>><br>
 <</if>>
-<<if $hiredCompanions.some(e => e.name === "Cloud") && $companionCloud.swap==false>>
+<<if $hiredCompanions.some(e => e.name === "Cloud") && !$companionCloud.swap>>
 	<<set $companionCloud.affec -= (3-$hsswear)>>
 	<<say $companionCloud>> Tsk. Untrustworthy... <</say>><br>
 <</if>>
-<<if $hiredCompanions.some(e => e.name === "Saeko") && $companionSaeko.swap==false>>
+<<if $hiredCompanions.some(e => e.name === "Saeko") && !$companionSaeko.swap>>
 	<<set $companionSaeko.affec -= (3-$hsswear)>>
 	<<say $companionSaeko>> Your modus operandi has been noted... <</say>><br>
 <</if>>

--- a/src/widgets.twee
+++ b/src/widgets.twee
@@ -1644,6 +1644,13 @@
 		<<set $companionTwin.ogender = 1>>
 		<<set $companionTwin.oheight = $app.oheight +0.01525*$app.oheight*5>>
 	<</if>>
+	<<if $app.sex=="male">>
+		<<set $companionTwin.sex = "female">>
+	<<elseif $app.sex=="female">>
+		<<set $companionTwin.sex = "male">>
+	<<else>>
+		<<set $companionTwin.sex = "doll-like">>
+	<</if>>
 
 	<<if $app.appGender<=5 >>
 		<<set $companionTwin.imageIcon="Player Icons/playerF.png">>


### PR DESCRIPTION
I think this is already broken in v0.9.7.1 due to the earlier change I made, but it was certainly broken by the object identity stuff. This fixes it to create a shallow copy, and also avoid using `_handle` as it's used in the macros called by this passage.