### PR TITLE
Clean up code for selling or losing relics

### DIFF
--- a/src/companionConversations.twee
+++ b/src/companionConversations.twee
@@ -6449,7 +6449,7 @@ There's a hearty laugh in his words, even as he sidesteps a stray glob of goo on
 
 A faint crunch echoes with every footstep you take as you walk through the fourth floor, the new weight and balance from the appendage at your back making your walk a bit more deliberate.
 
-<<say $companionKhemia>>Well, aren't you a sight? Looks like the Abyss has really given you a souvenir."<</say>>
+<<say $companionKhemia>>Well, aren't you a sight? Looks like the Abyss has really given you a souvenir.<</say>>
 Khemia's voice rumbles, warm and reassuring against the biting cold. The grin on his face, despite the treacherous conditions, holds no mockery, only open fascination and a spark of excitement.
 
 A sweeping gust of wind cuts your response short, and you pull the edges of your cloak tighter, the new scales on your tail instinctively bristling against the cold. You can't help but feel the Abyss staring at your new form, a keen observer as always.

--- a/src/global.twee
+++ b/src/global.twee
@@ -716,6 +716,7 @@ Using your balloon, you're able to send up any Relics you want to sell and get b
 
 
 :: Balloon Sell1 [balloon nobr]
+<<CarryAdjust>>
 Here you can permanently sell any of your collected Relics for a nice haul of dubloons. You can use this to fund further expeditions, pay off your debt, or just get a nice payday at the end of your expedition.<br><br>
 <<if $ownedRelics.length < 1>>
 You have no relics to sell.<br>
@@ -733,14 +734,6 @@ Choose the Relic you would like to sell:<br>
 				<<else>>
 					[[_linkText|Balloon Sell1][setup.sellRelic(_relic)]]
 				<</if>>
-			<<case "Chain of Lorelei">>
-				[[_linkText|Balloon Sell1][setup.sellRelic(_relic), $colwear = 0]]
-			<<case "Heart-stealing Stole">>
-				[[_linkText|Balloon Sell1][setup.sellRelic(_relic), $hsswear = 0]]
-			<<case "Solace Lace">>
-				[[_linkText|Balloon Sell1][setup.sellRelic(_relic), $slwear = 0]]
-			<<case "Sibyl Blend">>
-				[[_linkText|Balloon Sell1][setup.sellRelic(_relic), $SibylBuff = 0]]
 			<<case "World Stone">>
 				<<if $LilyPromise>>
 					[[_linkText|Balloon Sell1][setup.sellRelic(_relic), setup.modAffection('Lily', -5)]]
@@ -754,14 +747,6 @@ Choose the Relic you would like to sell:<br>
 				<<else>>
 					You need to empty the Everheavea to sell it (have at least two empty flasks in your inventory).
 				<</if>>
-			<<case "Brave Vector">>
-				[[_linkText|Balloon Sell1][setup.sellRelic(_relic), $slingshot = 0]]
-			<<case "Daedalus Mechanism">>
-				[[_linkText|Balloon Sell1][setup.sellRelic(_relic), $DaedalusEquip = false, $DaedalusFly = false]]
-			<<case "Blind Divine">>
-				[[_linkText|Balloon Sell1][setup.sellRelic(_relic), $BDwear = false]]
-			<<case "Heavy is the Head">>
-				[[_linkText|Balloon Sell1][setup.sellRelic(_relic), $HeavyHeadwear = false]]
 			<<case "Moonwatcher">>
 				<<if $BionicEye>>
 					_relic.name: You can't sell Relics that have become part of your body.

--- a/src/global.twee
+++ b/src/global.twee
@@ -715,39 +715,72 @@ Using your balloon, you're able to send up any Relics you want to sell and get b
 [[Finish using balloon to trade|$layerReturn]]
 
 
-:: Balloon Sell1 [balloon]
-Here you can permanently sell any of your collected Relics for a nice haul of dubloons. You can use this to fund further expeditions, pay off your debt, or just get a nice payday at the end of your expedition.
-
-Choose the Relic you would like to sell:
-<<nobr>>
-<<for $i = 0; $i < $ownedRelics.length; $i++>>
-	<<capture $i>>
-		<<if $ownedRelics[$i].name=="Creepy Doll" && $creepydoll.affec > 5>>
-			You can't seem to part ways with the Creepy Doll<br>
-		<<elseif $ownedRelics[$i].name=="Chain of Lorelei">>
-			<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Balloon Sell1][$colwear=0,$dubloons += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
-		<<elseif $ownedRelics[$i].name=="Heart-stealing Stole">>
-			<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Balloon Sell1][$hsswear=0,$dubloons += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
-		<<elseif $ownedRelics[$i].name=="Solace Lace">>
-			<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Balloon Sell1][$slwear=0,$dubloons += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
-		<<elseif $ownedRelics[$i].name=="Sibyl Blend">>
-			<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Balloon Sell1][$SibylBuff=0,$dubloons += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
-		<<elseif $ownedRelics[$i].name=="World Stone" && $LilyPromise>>
-			<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Balloon Sell1][$dubloons += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i), $companionLily.affec -= (5 - $hsswear)]]">>
-			You promised Lily she could use the World Stone, selling it now will surely dissapoint her greatly.<br>
-		<<elseif $ownedRelics[$i].name=="Everhevea">>
-			<<if $items[2].count >= 2>>
-				<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Balloon Sell1][$dubloons += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i), $items[2].count -= 2]]">>
-			<<else>>
-				You need to empty the Everheavea to sell it (have at least two empty flasks in your inventory) <br>
-			<</if>>
-		<<else>>
-			<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Balloon Sell1][$dubloons += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
-		<</if>>
+:: Balloon Sell1 [balloon nobr]
+Here you can permanently sell any of your collected Relics for a nice haul of dubloons. You can use this to fund further expeditions, pay off your debt, or just get a nice payday at the end of your expedition.<br><br>
+<<if $ownedRelics.length < 1>>
+You have no relics to sell.<br>
+<<else>>
+Choose the Relic you would like to sell:<br>
+<</if>>
+<<for _relic range $ownedRelics>>
+	<<capture _relic>>
+		<<set _linkText = `Sell ${_relic.name} for ${setup.sellValue(_relic)} dubloons`>>
+		/* Add a bit of indentation: */ &nbsp;
+		<<switch _relic.name>>
+			<<case "Creepy Doll">>
+				<<if $creepydoll.affec > 5>>
+					You can't seem to part ways with the Creepy Doll...
+				<<else>>
+					[[_linkText|Balloon Sell1][setup.sellRelic(_relic)]]
+				<</if>>
+			<<case "Chain of Lorelei">>
+				[[_linkText|Balloon Sell1][setup.sellRelic(_relic), $colwear = 0]]
+			<<case "Heart-stealing Stole">>
+				[[_linkText|Balloon Sell1][setup.sellRelic(_relic), $hsswear = 0]]
+			<<case "Solace Lace">>
+				[[_linkText|Balloon Sell1][setup.sellRelic(_relic), $slwear = 0]]
+			<<case "Sibyl Blend">>
+				[[_linkText|Balloon Sell1][setup.sellRelic(_relic), $SibylBuff = 0]]
+			<<case "World Stone">>
+				<<if $LilyPromise>>
+					[[_linkText|Balloon Sell1][setup.sellRelic(_relic), setup.modAffection('Lily', -5)]]
+					You promised Lily she could use the World Stone at the end of your journey. Selling it now will surely dissapoint her greatly.
+				<<else>>
+					[[_linkText|Balloon Sell1][setup.sellRelic(_relic)]]<br>
+				<</if>>
+			<<case "Everhevea">>
+				<<if setup.item('Empty Flask').count >= 2>>
+					[[_linkText|Balloon Sell1][setup.sellRelic(_relic), setup.item('Empty Flask').count -= 2]]
+				<<else>>
+					You need to empty the Everheavea to sell it (have at least two empty flasks in your inventory).
+				<</if>>
+			<<case "Brave Vector">>
+				[[_linkText|Balloon Sell1][setup.sellRelic(_relic), $slingshot = 0]]
+			<<case "Daedalus Mechanism">>
+				[[_linkText|Balloon Sell1][setup.sellRelic(_relic), $DaedalusEquip = false, $DaedalusFly = false]]
+			<<case "Blind Divine">>
+				[[_linkText|Balloon Sell1][setup.sellRelic(_relic), $BDwear = false]]
+			<<case "Heavy is the Head">>
+				[[_linkText|Balloon Sell1][setup.sellRelic(_relic), $HeavyHeadwear = false]]
+			<<case "Moonwatcher">>
+				<<if $BionicEye>>
+					_relic.name: You can't sell Relics that have become part of your body.
+				<<else>>
+					[[_linkText|Balloon Sell1][setup.sellRelic(_relic)]]
+				<</if>>
+			<<case "Glory's Grasp">>
+				<<if $BionicArm>>
+					_relic.name: You can't sell Relics that have become part of your body.
+				<<else>>
+					[[_linkText|Balloon Sell1][setup.sellRelic(_relic)]]
+				<</if>>
+			<<default>>
+				[[_linkText|Balloon Sell1][setup.sellRelic(_relic)]]
+		<</switch>>
+		<br>
 	<</capture>>
 <</for>>
-<</nobr>>
-
+<br>
 [[Continue using the commerce balloon|Commerce Balloon]]
 
 
@@ -824,7 +857,6 @@ Helpful people on the surface managed to find your items safely, retrieving all 
 <h1 class="gameover">You Are Dead</h1>\
 \
 <<if $ownedRelics.some(e => e.name === "Phoenix Obol")>>
-	<<set _string = "Layer" + $currentLayer + " Hub">>
 	The Abyss has proven to much for you. You feel your life fade as you close your eyes for a final time.
 
 	But suddenly, you startle awake again! You look around at your surroundings, and see that you're utterly alone and completely naked in an otherworldy white void that extends in every direction as you can see. The glow is not overly bright, but seems to pierce you in a way which is both unique and hard to describe. As if the light permeated your essense, rather than just illuminating your view. But before you have a chance to think too deeply about the situation, you feel a warm sensation in your clenched hand.
@@ -835,24 +867,24 @@ Helpful people on the surface managed to find your items safely, retrieving all 
 
 	Then you recover and find yourself once again in a new place. But this is one that you've been to before.
 
-	<<for _i = 0; _i < $ownedRelics.length; _i++>>
-		<<capture _i>>
-			<<if $ownedRelics[_i].name=="Phoenix Obol">>
-				[[Open your eyes to find yourself back in the Abyss, your hand clutching a scorched coin, now devoid of its sigil|_string][setup.sellRelic(_i),$starving=0,$dehydrated=0,$SemenDemonBalance=0,$gameOver=false]]
-			<</if>>
-		<</capture>>
-	<</for>>
+	<<link 'Open your eyes to find yourself back in the Abyss, your hand clutching a scorched coin, now devoid of its sigil' `"Layer" + $currentLayer + " Hub"`>>
+		<<set setup.loseRelic('Phoenix Obol')>>
+		<<set $starving = 0>>
+		<<set $dehydrated = 0>>
+		<<set $SemenDemonBalance = 0>>
+		<<set $gameOver = false>>
+	<</link>>
 <<elseif $starving > 5>>
-You have avoided eating for a few days, but eventually starved to death. If you didn't realize what had happened, you can avoid this fate by pressing the back arrow in the top left until you reach the main part of a layer. Once you are there, you can take the habitation option for the current layer to avoid death.
+	You have avoided eating for a few days, but eventually starved to death. If you didn't realize what had happened, you can avoid this fate by pressing the back arrow in the top left until you reach the main part of a layer. Once you are there, you can take the habitation option for the current layer to avoid death.
 <<elseif $dehydrated > 2>>
-You managed to survive without water for a few days, but eventually died of dehydration. If you didn't realize what had happened, you can avoid this fate by pressing the back arrow in the top left until you reach the main part of a layer. Once you are there, you can take the habitation option for the current layer to avoid death.
-<<elseif $SemenDemonBalance<-14>>
-Your hunger for sexual fluids was not without risks in the end. You couldn't keep up the amount of fluids your body was now requiring and in the end you collapsed. If you didn't realize what had happened, you can avoid this fate by pressing the back arrow in the top left until you reach the main part of a layer. Once you are there, you can take the habitation option for the current layer to avoid death.
+	You managed to survive without water for a few days, but eventually died of dehydration. If you didn't realize what had happened, you can avoid this fate by pressing the back arrow in the top left until you reach the main part of a layer. Once you are there, you can take the habitation option for the current layer to avoid death.
+<<elseif $SemenDemonBalance < -14>>
+	Your hunger for sexual fluids was not without risks in the end. You couldn't keep up the amount of fluids your body was now requiring and in the end you collapsed. If you didn't realize what had happened, you can avoid this fate by pressing the back arrow in the top left until you reach the main part of a layer. Once you are there, you can take the habitation option for the current layer to avoid death.
 <<else>>
-The horrors of the Abyss were simply too much for you. Perhaps better equipement, different companions, or a totally new approach to the encounter that ended your life could have saved you.
-<</if>><<if $corruption < 0>>
-
-Due to your negative corruption, you are unable to accept a habitation option at this time. However, you can go back to the main part of the layer, then take Curses until you have reached a corruption above 0 to survive. This is highly reccomended if you wish to avoid death.
+	The horrors of the Abyss were simply too much for you. Perhaps better equipement, different companions, or a totally new approach to the encounter that ended your life could have saved you.
+<</if>>
+<<if $corruption < 0>>
+	Due to your negative corruption, you are unable to accept a habitation option at this time. However, you can go back to the main part of the layer, then take Curses until you have reached a corruption above 0 to survive. This is highly reccomended if you wish to avoid death.
 <</if>>
 
 :: Labor Scene
@@ -1647,7 +1679,7 @@ The current total value of Relics you have copied is $relic38.copiedValue dubloo
 		<</if>>
 	<</for>>
 <<else>>
-	<<set setup.sellRelic("Kin Shifter")>>
+	<<set setup.loseRelic('Kin Shifter')>>
 	As you touched the final Relic to the Kin Shifter, the last of the goo was used up and your Relic was copied. The cute eyes faded as the slime transmuted into the new Relic you chose.<br><br>
 
 	Now that you have become better equipped, you can continue your journey.<br>

--- a/src/global.twee
+++ b/src/global.twee
@@ -2243,7 +2243,7 @@ How many dubloons would you like to pay back?
 				<<set $hexflame -= 1>>
 			<</if>>
 		<<elseif !$forageWater>>
-			<<include "Drinking code">>
+			<<include "Drinking code">><<if !_drank>><<break>><</if>>
 		<<elseif !$abyssKnow>>
 			<<switch $currentLayer>>
 				<<case 1>>
@@ -2253,19 +2253,19 @@ How many dubloons would you like to pay back?
 					<<set $waterL2 += 1>>
 					<<set $bewitchBabies += 1>>
 				<<case 3>>
-					<<include "Drinking code">>
+					<<include "Drinking code">><<if !_drank>><<break>><</if>>
 				<<case 4>>
 					<<set $waterL4 += 1>>
 					<<set $algalSize += 1>>
 				<<case 5>>
-					<<include "Drinking code">>
+					<<include "Drinking code">><<if !_drank>><<break>><</if>>
 				<<case 6>>
 					<<set $waterL6 += 1>>
 					<<if !($hiredCompanions.some(e => e.name === "Saeko") && setup.haveSmartphone)>>
 						<<set $hexflame += 1>>
 					<</if>>
 				<<case 7>>
-					<<include "Drinking code">>
+					<<include "Drinking code">><<if !_drank>><<break>><</if>>
 				<<case 8>>
 					<<set $waterL8 += 1>>
 					<<set $IQdrop += 0.5>>
@@ -2277,18 +2277,18 @@ How many dubloons would you like to pay back?
 				<<case 2>>
 					<<set $waterL2 += 1>>
 				<<case 3>>
-					<<include "Drinking code">>
+					<<include "Drinking code">><<if !_drank>><<break>><</if>>
 				<<case 4>>
 					<<set $waterL4 += 1>>
 				<<case 5>>
-					<<include "Drinking code">>
+					<<include "Drinking code">><<if !_drank>><<break>><</if>>
 				<<case 6>>
 					<<set $waterL6 += 1>>
 					<<if !($hiredCompanions.some(e => e.name === "Saeko") && setup.haveSmartphone)>>
 						<<set $hexflame += 1>>
 					<</if>>
 				<<case 7>>
-					<<include "Drinking code">>
+					<<include "Drinking code">><<if !_drank>><<break>><</if>>
 				<<case 8>>
 					<<set $waterL8 += 1>>
 					<<if !($hiredCompanions.some(e => e.name === "Saeko") && setup.haveSmartphone)>>
@@ -2360,13 +2360,15 @@ How many dubloons would you like to pay back?
 			<<set $corruption -= 1>>
 		<</if>>
 	<</if>>
+	<<set _drank = true>>
 <<elseif $items[25].count >= _consumptionPerDay>>
 	<<set $items[25].count -= _consumptionPerDay>>
 	<<if $hexflame > 9>>
 		<<set $hexflame -= 1>>
 	<</if>>
+	<<set _drank = true>>
 <<else>>
-	<<break>>
+	<<set _drank = false>>
 <</if>>
 
 :: Water drop code[nobr]

--- a/src/layer1.twee
+++ b/src/layer1.twee
@@ -1064,6 +1064,7 @@ Use the following option only if you have specifically considered your inventory
 
 
 :: Relic Surrender [layer1]
+<<CarryAdjust>>\
 [img[setup.ImagePath+'Threats/opportunisticbandits.png']]
 
 Nervously, you begin going trough your bag, attempting to decide which Relics to surrender and which to keep.
@@ -1087,14 +1088,6 @@ Choose the Relic you would like to hand over to the bandits:
 				<<else>>
 					[[_linkText|Relic Surrender][setup.loseRelic(_relic), $surrVal += setup.sellValue(_relic)]]
 				<</if>>
-			<<case "Chain of Lorelei">>
-				[[_linkText|Relic Surrender][setup.loseRelic(_relic), $surrVal += setup.sellValue(_relic), $colwear = 0]]
-			<<case "Heart-stealing Stole">>
-				[[_linkText|Relic Surrender][setup.loseRelic(_relic), $surrVal += setup.sellValue(_relic), $hsswear = 0]]
-			<<case "Solace Lace">>
-				[[_linkText|Relic Surrender][setup.loseRelic(_relic), $surrVal += setup.sellValue(_relic), $slwear = 0]]
-			<<case "Sibyl Blend">>
-				[[_linkText|Relic Surrender][setup.loseRelic(_relic), $surrVal += setup.sellValue(_relic), $SibylBuff = 0]]
 			<<case "World Stone">>
 				<<if $LilyPromise>>
 					[[_linkText|Relic Surrender][setup.loseRelic(_relic), $surrVal += setup.sellValue(_relic), setup.modAffection('Lily', -3)]]
@@ -1108,14 +1101,6 @@ Choose the Relic you would like to hand over to the bandits:
 				<<else>>
 					You need to empty the Everheavea to hand it over (have at least two empty flasks in your inventory).
 				<</if>>
-			<<case "Brave Vector">>
-				[[_linkText|Relic Surrender][setup.loseRelic(_relic), $surrVal += setup.sellValue(_relic), $slingshot = 0]]
-			<<case "Daedalus Mechanism">>
-				[[_linkText|Relic Surrender][setup.loseRelic(_relic), $surrVal += setup.sellValue(_relic), $DaedalusEquip = false, $DaedalusFly = false]]
-			<<case "Blind Divine">>
-				[[_linkText|Relic Surrender][setup.loseRelic(_relic), $surrVal += setup.sellValue(_relic), $BDwear = false]]
-			<<case "Heavy is the Head">>
-				[[_linkText|Relic Surrender][setup.loseRelic(_relic), $surrVal += setup.sellValue(_relic), $HeavyHeadwear = false]]
 			<<case "Moonwatcher">>
 				<<if $BionicEye>>
 					_relic.name: You can't give away Relics that have become part of your body.

--- a/src/layer1.twee
+++ b/src/layer1.twee
@@ -1076,40 +1076,62 @@ Nervously, you begin going trough your bag, attempting to decide which Relics to
 <<if $surrVal < _temp>>
 Choose the Relic you would like to hand over to the bandits:
 <<nobr>>
-<<for $i = 0; $i < $ownedRelics.length; $i++>>
-	<<capture $i>>
-		<<if $ownedRelics[$i].name=="Creepy Doll" && $creepydoll.affec > 5>>
-			You would never hand over your Dolly... Uh, the Creepy Doll, you mean.<br>
-		<<elseif $ownedRelics[$i].name=="Chain of Lorelei">>
-			<<print $ownedRelics[$i].name>><<print " worth ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Hand over|Relic Surrender][$colwear=0, $surrVal += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
-
-		<<elseif $ownedRelics[$i].name=="Heart-stealing Stole">>
-			<<print $ownedRelics[$i].name>><<print " worth ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Hand over|Relic Surrender][$hsswear=0, $surrVal += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
-
-		<<elseif $ownedRelics[$i].name=="Sibyl Blend">>
-			<<print $ownedRelics[$i].name>><<print " worth ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Hand over|Relic Surrender][$SibylBuff=0,$surrVal += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
-		<<elseif $ownedRelics[$i].name=="World Stone" && $LilyPromise>>
-			<<print $ownedRelics[$i].name>><<print " worth ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Hand over|Relic Surrender][$surrVal += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i), $companionLily.affec -= (3-$hsswear)]]">> 
-			<br>You promised Lily she could use the World Stone. Although you are not exactly selling it, you feel she would still be dissapointed if you gave it away.<br>
-		<<elseif $ownedRelics[$i].name=="Everhevea">>
-			<<if $items[2].count >= 2>>
-				<<print $ownedRelics[$i].name>><<print " worth ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Hand over|Relic Surrender][$surrVal += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i), $items[2].count -= 2]]">>
-			<<else>>
-				You need to empty the Everheavea to hand it over (have at least two empty flasks in your inventory) <br>
-			<</if>>
-		<<elseif $ownedRelics[$i].name=="Daedalus Mechanism">>
-			<<print $ownedRelics[$i].name>><<print " worth ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Hand over|Relic Surrender][$DaedalusEquip = false, $DaedalusFly = false, $surrVal += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
-		<<elseif $ownedRelics[$i].name=="Blind Divine">>
-			<<print $ownedRelics[$i].name>><<print " worth ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Hand over|Relic Surrender][$BDwear = false, $surrVal += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
-		<<elseif $ownedRelics[$i].name=="Heavy is the Head">>
-			<<print $ownedRelics[$i].name>><<print " worth ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Hand over|Relic Surrender][$HeavyHeadwear= false, $surrVal += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
-		<<elseif $ownedRelics[$i].name=="Moonwatcher" & $BionicEye >>
-			<<print $ownedRelics[$i].name>> You can't give away Relics that have become part of your body.<br>
-		<<elseif $ownedRelics[$i].name=="Glory's Grasp" & $BionicArm >>
-			<<print $ownedRelics[$i].name>> You can't give away Relics that have become part of your body.<br>
-		<<else>>
-			<<print $ownedRelics[$i].name>><<print " worth ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Hand over|Relic Surrender][$surrVal += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
-		<</if>>
+<<for _relic range $ownedRelics>>
+	<<capture _relic>>
+		<<set _linkText = `Hand over ${_relic.name} worth ${setup.sellValue(_relic)} dubloons`>>
+		/* Add a bit of indentation: */ &nbsp;
+		<<switch _relic.name>>
+			<<case "Creepy Doll">>
+				<<if $creepydoll.affec > 5>>
+					You would never hand over your Dolly... Uh, the Creepy Doll, you mean.
+				<<else>>
+					[[_linkText|Relic Surrender][setup.loseRelic(_relic), $surrVal += setup.sellValue(_relic)]]
+				<</if>>
+			<<case "Chain of Lorelei">>
+				[[_linkText|Relic Surrender][setup.loseRelic(_relic), $surrVal += setup.sellValue(_relic), $colwear = 0]]
+			<<case "Heart-stealing Stole">>
+				[[_linkText|Relic Surrender][setup.loseRelic(_relic), $surrVal += setup.sellValue(_relic), $hsswear = 0]]
+			<<case "Solace Lace">>
+				[[_linkText|Relic Surrender][setup.loseRelic(_relic), $surrVal += setup.sellValue(_relic), $slwear = 0]]
+			<<case "Sibyl Blend">>
+				[[_linkText|Relic Surrender][setup.loseRelic(_relic), $surrVal += setup.sellValue(_relic), $SibylBuff = 0]]
+			<<case "World Stone">>
+				<<if $LilyPromise>>
+					[[_linkText|Relic Surrender][setup.loseRelic(_relic), $surrVal += setup.sellValue(_relic), setup.modAffection('Lily', -3)]]
+					You promised Lily she could use the World Stone at the end of your journey. Although you are not exactly selling it, you feel she would still be dissapointed if you gave it away.
+				<<else>>
+					[[_linkText|Relic Surrender][setup.loseRelic(_relic), $surrVal += setup.sellValue(_relic)]]<br>
+				<</if>>
+			<<case "Everhevea">>
+				<<if setup.item('Empty Flask').count >= 2>>
+					[[_linkText|Relic Surrender][setup.loseRelic(_relic), $surrVal += setup.sellValue(_relic), setup.item('Empty Flask').count -= 2]]
+				<<else>>
+					You need to empty the Everheavea to hand it over (have at least two empty flasks in your inventory).
+				<</if>>
+			<<case "Brave Vector">>
+				[[_linkText|Relic Surrender][setup.loseRelic(_relic), $surrVal += setup.sellValue(_relic), $slingshot = 0]]
+			<<case "Daedalus Mechanism">>
+				[[_linkText|Relic Surrender][setup.loseRelic(_relic), $surrVal += setup.sellValue(_relic), $DaedalusEquip = false, $DaedalusFly = false]]
+			<<case "Blind Divine">>
+				[[_linkText|Relic Surrender][setup.loseRelic(_relic), $surrVal += setup.sellValue(_relic), $BDwear = false]]
+			<<case "Heavy is the Head">>
+				[[_linkText|Relic Surrender][setup.loseRelic(_relic), $surrVal += setup.sellValue(_relic), $HeavyHeadwear = false]]
+			<<case "Moonwatcher">>
+				<<if $BionicEye>>
+					_relic.name: You can't give away Relics that have become part of your body.
+				<<else>>
+					[[_linkText|Relic Surrender][setup.loseRelic(_relic), $surrVal += setup.sellValue(_relic)]]
+				<</if>>
+			<<case "Glory's Grasp">>
+				<<if $BionicArm>>
+					_relic.name: You can't give away Relics that have become part of your body.
+				<<else>>
+					[[_linkText|Relic Surrender][setup.loseRelic(_relic), $surrVal += setup.sellValue(_relic)]]
+				<</if>>
+			<<default>>
+				[[_linkText|Relic Surrender][setup.loseRelic(_relic), $surrVal += setup.sellValue(_relic)]]
+		<</switch>>
+		<br>
 	<</capture>>
 <</for>>
 <</nobr>>
@@ -1249,19 +1271,8 @@ Finally the nauseous feeling passes but is replaced by a brief sense of terror a
 [img[setup.ImagePath+'Clipped-Fin/Abyss Diver Page 2-threats.png']]
 
 Finally, the vision fades, leaving you standing once again where you were before, with only a brief sense of motion sickness as you orient yourself back to your physical body. As you look at the Gleam Dazer once again, you notice the Relic is cracked and broken.
-<<nobr>>
-<<if $ownedRelics.length==1>>
-	<<set $temp=0>>
-<<else>>
-	<<for $i = 0; $i < $ownedRelics.length && !$endloop; $i++>>
-		<<if $ownedRelics[$i].name=="Gleam Dazer" >>
-			<<set $temp=$i>>
-			<<set $endloop=false>>
-		<</if>>
-	<</for>>
-<</if>>
-<</nobr>>
-[[Return|$previewReturn][setup.sellRelic($temp), $endloop=false]]
+
+[[Return|$previewReturn][setup.loseRelic('Gleam Dazer')]]
 
 :: Layer1 notes [image layer1 noreturn]
 

--- a/src/layer2.twee
+++ b/src/layer2.twee
@@ -1687,19 +1687,8 @@ Finally the nauseous feeling passes but is replaced by a brief sense of terror a
 [img[setup.ImagePath+'Clipped-Fin/Abyss Diver Page 3-threats.png']]
 
 Finally, the vision fades, leaving you standing once again where you were before, with only a brief sense of motion sickness as you orient yourself back to your physical body. As you look at the Gleam Dazer once again, you notice the Relic is cracked and broken.
-<<nobr>>
-<<if $ownedRelics.length==1>>
-	<<set $temp=0>>
-<<else>>
-	<<for $i = 0; $i < $ownedRelics.length && !$endloop; $i++>>
-		<<if $ownedRelics[$i].name=="Gleam Dazer" >>
-			<<set $temp=$i>>
-			<<set $endloop=false>>
-		<</if>>
-	<</for>>
-<</if>>
-<</nobr>>
-[[Return|$previewReturn][setup.sellRelic($temp), $endloop=false]]
+
+[[Return|$previewReturn][setup.loseRelic('Gleam Dazer')]]
 
 :: Layer2 notes [image layer2 noreturn]
 

--- a/src/layer3.twee
+++ b/src/layer3.twee
@@ -1723,19 +1723,8 @@ Finally the nauseous feeling passes but is replaced by a brief sense of terror a
 [img[setup.ImagePath+'Clipped-Fin/Abyss Diver Page 4-threats.png']]
 
 Finally, the vision fades, leaving you standing once again where you were before, with only a brief sense of motion sickness as you orient yourself back to your physical body. As you look at the Gleam Dazer once again, you notice the Relic is cracked and broken.
-<<nobr>>
-<<if $ownedRelics.length==1>>
-	<<set $temp=0>>
-<<else>>
-	<<for _i = 0; _i < $ownedRelics.length && !$endloop; _i++>>
-		<<if $ownedRelics[_i].name=="Gleam Dazer" >>
-			<<set $temp=_i>>
-			<<set $endloop=false>>
-		<</if>>
-	<</for>>
-<</if>>
-<</nobr>>
-[[Return|$previewReturn][setup.sellRelic($temp), $endloop=false]]
+
+[[Return|$previewReturn][setup.loseRelic('Gleam Dazer')]]
 
 :: Layer3 notes [image layer3 noreturn]
 

--- a/src/layer4.twee
+++ b/src/layer4.twee
@@ -1516,19 +1516,8 @@ Finally the nauseous feeling passes but is replaced by a brief sense of terror a
 [img[setup.ImagePath+'Clipped-Fin/Abyss Diver Page 5-threats.png']]
 
 Finally, the vision fades, leaving you standing once again where you were before, with only a brief sense of motion sickness as you orient yourself back to your physical body. As you look at the Gleam Dazer once again, you notice the Relic is cracked and broken.
-<<nobr>>
-<<if $ownedRelics.length==1>>
-	<<set $temp=0>>
-<<else>>
-	<<for $i = 0; $i < $ownedRelics.length && !$endloop; $i++>>
-		<<if $ownedRelics[$i].name=="Gleam Dazer" >>
-			<<set $temp=$i>>
-			<<set $endloop=false>>
-		<</if>>
-	<</for>>
-<</if>>
-<</nobr>>
-[[Return|$previewReturn][setup.sellRelic($temp), $endloop=false]]
+
+[[Return|$previewReturn][setup.loseRelic('Gleam Dazer')]]
 
 :: Layer4 notes [image layer4 noreturn]
 

--- a/src/layer5.twee
+++ b/src/layer5.twee
@@ -1218,8 +1218,7 @@ The Relics you have found with Cherry's Chaotic Luck are $relics[$temp1].name an
 		<<set $ownedRelics.deleteAt($ownedRelics.length-1)>>
 		<<set $corruption += Math.floor(Math.max(($relics[$temp2].corr / 2) - $corRed, 0))>>
 
-		<<set _temp = $ownedRelics.findIndex(e=> e.name==="Devil's Own")>>
-		<<set setup.sellRelic(_temp)>>
+		<<set setup.loseRelic("Devil's Own")>>
 	<</link>>
 
 <</if>>
@@ -1310,8 +1309,7 @@ Please enter your new exoskeleton color:
 		<</if>>
 		<<RemoveCurse $curses[$temp2]>>
 
-		<<set _temp = $ownedRelics.findIndex(e=> e.name==="Devil's Own")>>
-		<<set setup.sellRelic(_temp)>>
+		<<set setup.loseRelic("Devil's Own")>>
 	<</link>>
 
 <</if>>
@@ -1392,8 +1390,7 @@ Please enter your new exoskeleton color:
 			<</if>>
 		<</if>>
 		<<RemoveCurse $curses[$temp2]>>
-		<<set _temp = $ownedRelics.findIndex(e=> e.name==="Devil's Own")>>
-		<<set setup.sellRelic(_temp)>>
+		<<set setup.loseRelic("Devil's Own")>>
 	<</link>>
 
 <</if>>
@@ -1747,19 +1744,8 @@ Finally the nauseous feeling passes but is replaced by a brief sense of terror a
 [img[setup.ImagePath+'Clipped-Fin/Abyss Diver Page 6-threats.png']]
 
 Finally, the vision fades, leaving you standing once again where you were before, with only a brief sense of motion sickness as you orient yourself back to your physical body. As you look at the Gleam Dazer once again, you notice the Relic is cracked and broken.
-<<nobr>>
-<<if $ownedRelics.length==1>>
-	<<set $temp=0>>
-<<else>>
-	<<for $i = 0; $i < $ownedRelics.length && !$endloop; $i++>>
-		<<if $ownedRelics[$i].name=="Gleam Dazer" >>
-			<<set $temp=$i>>
-			<<set $endloop=false>>
-		<</if>>
-	<</for>>
-<</if>>
-<</nobr>>
-[[Return|$previewReturn][setup.sellRelic($temp), $endloop=false]]
+
+[[Return|$previewReturn][setup.loseRelic('Gleam Dazer')]]
 
 :: Layer5 notes [image layer5 noreturn]
 

--- a/src/layer6.twee
+++ b/src/layer6.twee
@@ -964,8 +964,7 @@ The Relics you have found with Cherry's Chaotic Luck are $relics[$temp1].name an
 		<<set $ownedRelics.deleteAt($ownedRelics.length-1)>>
 		<<set $corruption += Math.floor(Math.max(($relics[$temp2].corr / 2) - $corRed, 0))>>
 
-		<<set _temp = $ownedRelics.findIndex(e=> e.name==="Devil's Own")>>
-		<<set setup.sellRelic(_temp)>>
+		<<set setup.loseRelic("Devil's Own")>>
 	<</link>>
 
 <</if>>
@@ -1028,8 +1027,7 @@ The Curses you have obtained with Cherry's Chaotic Luck are $curses[$temp1].name
 			<</if>>
 		<</if>>
 		<<RemoveCurse $curses[$temp2]>>
-		<<set _temp = $ownedRelics.findIndex(e=> e.name==="Devil's Own")>>
-		<<set setup.sellRelic(_temp)>>
+		<<set setup.loseRelic("Devil's Own")>>
 	<</link>>
 
 <</if>>
@@ -1081,8 +1079,7 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 			<</if>>
 		<</if>>
 		<<RemoveCurse $curses[$temp2]>>
-		<<set _temp = $ownedRelics.findIndex(e=> e.name==="Devil's Own")>>
-		<<set setup.sellRelic(_temp)>>
+		<<set setup.loseRelic("Devil's Own")>>
 	<</link>>
 
 <</if>>
@@ -1483,19 +1480,8 @@ Finally the nauseous feeling passes but is replaced by a brief sense of terror a
 [img[setup.ImagePath+'Clipped-Fin/Abyss Diver Page 7-threats.png']]
 
 Finally, the vision fades, leaving you standing once again where you were before, with only a brief sense of motion sickness as you orient yourself back to your physical body. As you look at the Gleam Dazer once again, you notice the Relic is cracked and broken.
-<<nobr>>
-<<if $ownedRelics.length==1>>
-	<<set $temp=0>>
-<<else>>
-	<<for $i = 0; $i < $ownedRelics.length && !$endloop; $i++>>
-		<<if $ownedRelics[$i].name=="Gleam Dazer" >>
-			<<set $temp=$i>>
-			<<set $endloop=false>>
-		<</if>>
-	<</for>>
-<</if>>
-<</nobr>>
-[[Return|$previewReturn][setup.sellRelic($temp), $endloop=false]]
+
+[[Return|$previewReturn][setup.loseRelic('Gleam Dazer')]]
 
 :: Layer6 notes [image layer6 noreturn]
 

--- a/src/layer7.twee
+++ b/src/layer7.twee
@@ -45,19 +45,8 @@ Finally the nauseous feeling passes but is replaced by a brief sense of terror a
 [img[setup.ImagePath+'Clipped-Fin/Abyss Diver Page 8-threats.png']]
 
 Finally, the vision fades, leaving you standing once again where you were before, with only a brief sense of motion sickness as you orient yourself back to your physical body. As you look at the Gleam Dazer once again, you notice the Relic is cracked and broken.
-<<nobr>>
-<<if $ownedRelics.length==1>>
-	<<set $temp=0>>
-<<else>>
-	<<for $i = 0; $i < $ownedRelics.length && !$endloop; $i++>>
-		<<if $ownedRelics[$i].name=="Gleam Dazer" >>
-			<<set $temp=$i>>
-			<<set $endloop=false>>
-		<</if>>
-	<</for>>
-<</if>>
-<</nobr>>
-[[Return|$previewReturn][setup.sellRelic($temp), $endloop=false]]
+
+[[Return|$previewReturn][setup.loseRelic('Gleam Dazer')]]
 
 :: Layer7 notes [image layer7 noreturn]
 
@@ -634,38 +623,63 @@ Here you can permanently recycle any of your collected Relics for a nice haul of
 
 Choose the Relic you would like to sell:
 <<nobr>>
-<<for $i = 0; $i < $ownedRelics.length; $i++>>
-	<<capture $i>>
-		<<if $ownedRelics[$i].name=="Creepy Doll" && $creepydoll.affec > 5>>
-			You can't seem to part ways with the Creepy Doll<br>
-		<<elseif $ownedRelics[$i].name=="Chain of Lorelei">>
-			<<print $ownedRelics[$i].name>><<print " for ">><<print (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2)))>><<print " dubloons ">><<print "[[Sell|Layer7 Recycle][$colwear=0,$dubloons += (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2))), setup.sellRelic($i)]]">><br>
-		<<elseif $ownedRelics[$i].name=="Heart-stealing Stole">>
-			<<print $ownedRelics[$i].name>><<print " for ">><<print (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2)))>><<print " dubloons ">><<print "[[Sell|Layer7 Recycle][$hsswear=0,$dubloons += (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2))), setup.sellRelic($i)]]">><br>
-		<<elseif $ownedRelics[$i].name=="Sibyl Blend">>
-			<<print $ownedRelics[$i].name>><<print " for ">><<print (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2)))>><<print " dubloons ">><<print "[[Sell|Layer7 Recycle][$SibylBuff=0,$dubloons += (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2))), setup.sellRelic($i)]]">><br>
-		<<elseif $ownedRelics[$i].name=="World Stone" && $LilyPromise>>
-			<<print $ownedRelics[$i].name>><<print " for ">><<print (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2)))>><<print " dubloons ">><<print "[[Sell|Layer7 Recycle][$dubloons += (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2))), setup.sellRelic($i), $companionLily.affec -= (5 - $hsswear)]]">>
-			You promised Lily she could use the World Stone at the end of your journey, recycling it now will surely disappoint her quite a lot. <br>
-		<<elseif $ownedRelics[$i].name=="Everhevea">>
-			<<if $items[2].count >= 2>>
-				<<print $ownedRelics[$i].name>><<print " for ">><<print (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2)))>><<print " dubloons ">><<print "[[Sell|Layer7 Recycle][$dubloons += (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2))), setup.sellRelic($i), $items[2].count -= 2]]">>
-			<<else>>
-				You need to empty the Everheavea to recycle it (have at least two empty flasks in your inventory) <br>
-			<</if>>
-		<<elseif $ownedRelics[$i].name=="Daedalus Mechanism">>
-			<<print $ownedRelics[$i].name>><<print " for ">><<print (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2)))>><<print " dubloons ">><<print "[[Sell|Layer7 Recycle][$DaedalusEquip = false, $DaedalusFly = false, $dubloons += (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2))), setup.sellRelic($i)]]">><br>
-		<<elseif $ownedRelics[$i].name=="Blind Divine">>
-			<<print $ownedRelics[$i].name>><<print " for ">><<print (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2)))>><<print " dubloons ">><<print "[[Sell|Layer7 Recycle][$BDwear = false, $dubloons += (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2))), setup.sellRelic($i)]]">><br>
-		<<elseif $ownedRelics[$i].name=="Heavy is the Head">>
-			<<print $ownedRelics[$i].name>><<print " for ">><<print (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2)))>><<print " dubloons ">><<print "[[Sell|Layer7 Recycle][$HeavyHeadwear= false, $dubloons += (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2))), setup.sellRelic($i)]]">><br>
-		<<elseif $ownedRelics[$i].name=="Moonwatcher" & $BionicEye >>
-			<<print $ownedRelics[$i].name>> You can't sell Relics that have become part of your body.<br>
-		<<elseif $ownedRelics[$i].name=="Glory's Grasp" & $BionicArm >>
-			<<print $ownedRelics[$i].name>> You can't sell Relics that have become part of your body.<br>		
-		<<else>>
-			<<print $ownedRelics[$i].name>><<print " for ">><<print (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2)))>><<print " dubloons ">><<print "[[Sell|Layer7 Recycle][$dubloons += (Math.max($ownedRelics[$i].value - 15 + ($sellAdd / 2))), setup.sellRelic($i)]]">><br>
-		<</if>>
+<<set _callback = v => v - 15 + $sellAdd / 2>>
+<<for _relic range $ownedRelics>>
+	<<capture _callback, _relic>>
+		<<set _linkText = `Sell ${_relic.name} for ${Math.max(_callback(_relic.value), 0)} dubloons`>>
+		/* Add a bit of indentation: */ &nbsp;
+		<<switch _relic.name>>
+			<<case "Creepy Doll">>
+				<<if $creepydoll.affec > 5>>
+					You can't seem to part ways with the Creepy Doll...
+				<<else>>
+					[[_linkText|Layer7 Recycle][setup.sellRelic(_relic, _callback)]]
+				<</if>>
+			<<case "Chain of Lorelei">>
+				[[_linkText|Layer7 Recycle][setup.sellRelic(_relic, _callback), $colwear = 0]]
+			<<case "Heart-stealing Stole">>
+				[[_linkText|Layer7 Recycle][setup.sellRelic(_relic, _callback), $hsswear = 0]]
+			<<case "Solace Lace">>
+				[[_linkText|Layer7 Recycle][setup.sellRelic(_relic, _callback), $slwear = 0]]
+			<<case "Sibyl Blend">>
+				[[_linkText|Layer7 Recycle][setup.sellRelic(_relic, _callback), $SibylBuff = 0]]
+			<<case "World Stone">>
+				<<if $LilyPromise>>
+					[[_linkText|Layer7 Recycle][setup.sellRelic(_relic, _callback), setup.modAffection('Lily', -5)]]
+					You promised Lily she could use the World Stone at the end of your journey. Recycling it now will surely dissapoint her quite a lot.
+				<<else>>
+					[[_linkText|Layer7 Recycle][setup.sellRelic(_relic, _callback)]]<br>
+				<</if>>
+			<<case "Everhevea">>
+				<<if setup.item('Empty Flask').count >= 2>>
+					[[_linkText|Layer7 Recycle][setup.sellRelic(_relic, _callback), setup.item('Empty Flask').count -= 2]]
+				<<else>>
+					You need to empty the Everheavea to sell it (have at least two empty flasks in your inventory).
+				<</if>>
+			<<case "Brave Vector">>
+				[[_linkText|Layer7 Recycle][setup.sellRelic(_relic, _callback), $slingshot = 0]]
+			<<case "Daedalus Mechanism">>
+				[[_linkText|Layer7 Recycle][setup.sellRelic(_relic, _callback), $DaedalusEquip = false, $DaedalusFly = false]]
+			<<case "Blind Divine">>
+				[[_linkText|Layer7 Recycle][setup.sellRelic(_relic, _callback), $BDwear = false]]
+			<<case "Heavy is the Head">>
+				[[_linkText|Layer7 Recycle][setup.sellRelic(_relic, _callback), $HeavyHeadwear = false]]
+			<<case "Moonwatcher">>
+				<<if $BionicEye>>
+					_relic.name: You can't sell Relics that have become part of your body.
+				<<else>>
+					[[_linkText|Layer7 Recycle][setup.sellRelic(_relic, _callback)]]
+				<</if>>
+			<<case "Glory's Grasp">>
+				<<if $BionicArm>>
+					_relic.name: You can't sell Relics that have become part of your body.
+				<<else>>
+					[[_linkText|Layer7 Recycle][setup.sellRelic(_relic, _callback)]]
+				<</if>>
+			<<default>>
+				[[_linkText|Layer7 Recycle][setup.sellRelic(_relic, _callback)]]
+		<</switch>>
+		<br>
 	<</capture>>
 <</for>>
 <</nobr>>
@@ -1213,8 +1227,7 @@ The Relics you have found with Cherry's Chaotic Luck are $relics[$temp1].name an
 		<<set $ownedRelics.deleteAt($ownedRelics.length-1)>>
 		<<set $corruption += Math.floor(Math.max(($relics[$temp2].corr / 2) - $corRed, 0))>>
 
-		<<set _temp = $ownedRelics.findIndex(e=> e.name==="Devil's Own")>>
-		<<set setup.sellRelic(_temp)>>
+		<<set setup.loseRelic("Devil's Own")>>
 	<</link>>
 
 <</if>>
@@ -1285,8 +1298,7 @@ The Curses you have obtained with Cherry's Chaotic Luck are $curses[$temp1].name
 		<</if>>
 		<<RemoveCurse $curses[$temp2]>>
 
-		<<set _temp = $ownedRelics.findIndex(e=> e.name==="Devil's Own")>>
-		<<set setup.sellRelic(_temp)>>
+		<<set setup.loseRelic("Devil's Own")>>
 	<</link>>
 
 <</if>>
@@ -1350,8 +1362,7 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 			<</if>>
 		<</if>>
 		<<RemoveCurse $curses[$temp2]>>
-		<<set _temp = $ownedRelics.findIndex(e=> e.name==="Devil's Own")>>
-		<<set setup.sellRelic(_temp)>>
+		<<set setup.loseRelic("Devil's Own")>>
 	<</link>>
 
 <</if>>

--- a/src/layer7.twee
+++ b/src/layer7.twee
@@ -615,6 +615,7 @@ You have refilled $temp flasks with the cool, refreshing, and surprisingly pure 
 [[Continue exploring the seventh layer|Layer7 Hub]]
 
 :: Layer7 Recycle [layer7]
+<<CarryAdjust>>\
 Suddenly, your eyes are drawn to a pulse of light from a nearby structure. As you move closer, the distinct scent of hot metal and the occasional metallic crunch breaks the city's monotonous hum. This is the Recycling Center, a hulking machine of steel that stands stark against the neon skyline, casting long shadows on the cobble of metal beneath.
 
 Your eyes trace up to the chutes, each one aglow with a heat source that dances with colors of azure and crimson. The hypnotic pulsing seems to beckon you, promising riches in exchange for the Relics you've amassed. The robots gliding around the area are as silent as wraiths, their lights twinkling like distant stars against their metallic frames.
@@ -635,14 +636,6 @@ Choose the Relic you would like to sell:
 				<<else>>
 					[[_linkText|Layer7 Recycle][setup.sellRelic(_relic, _callback)]]
 				<</if>>
-			<<case "Chain of Lorelei">>
-				[[_linkText|Layer7 Recycle][setup.sellRelic(_relic, _callback), $colwear = 0]]
-			<<case "Heart-stealing Stole">>
-				[[_linkText|Layer7 Recycle][setup.sellRelic(_relic, _callback), $hsswear = 0]]
-			<<case "Solace Lace">>
-				[[_linkText|Layer7 Recycle][setup.sellRelic(_relic, _callback), $slwear = 0]]
-			<<case "Sibyl Blend">>
-				[[_linkText|Layer7 Recycle][setup.sellRelic(_relic, _callback), $SibylBuff = 0]]
 			<<case "World Stone">>
 				<<if $LilyPromise>>
 					[[_linkText|Layer7 Recycle][setup.sellRelic(_relic, _callback), setup.modAffection('Lily', -5)]]
@@ -656,14 +649,6 @@ Choose the Relic you would like to sell:
 				<<else>>
 					You need to empty the Everheavea to sell it (have at least two empty flasks in your inventory).
 				<</if>>
-			<<case "Brave Vector">>
-				[[_linkText|Layer7 Recycle][setup.sellRelic(_relic, _callback), $slingshot = 0]]
-			<<case "Daedalus Mechanism">>
-				[[_linkText|Layer7 Recycle][setup.sellRelic(_relic, _callback), $DaedalusEquip = false, $DaedalusFly = false]]
-			<<case "Blind Divine">>
-				[[_linkText|Layer7 Recycle][setup.sellRelic(_relic, _callback), $BDwear = false]]
-			<<case "Heavy is the Head">>
-				[[_linkText|Layer7 Recycle][setup.sellRelic(_relic, _callback), $HeavyHeadwear = false]]
 			<<case "Moonwatcher">>
 				<<if $BionicEye>>
 					_relic.name: You can't sell Relics that have become part of your body.

--- a/src/layer8.twee
+++ b/src/layer8.twee
@@ -58,19 +58,8 @@ Finally the nauseous feeling passes but is replaced by a brief sense of terror a
 [img[setup.ImagePath+'Clipped-Fin/Abyss Diver Page 9-threats.png']]
 
 Finally, the vision fades, leaving you standing once again where you were before, with only a brief sense of motion sickness as you orient yourself back to your physical body. As you look at the Gleam Dazer once again, you notice the Relic is cracked and broken.
-<<nobr>>
-<<if $ownedRelics.length==1>>
-	<<set $temp=0>>
-<<else>>
-	<<for $i = 0; $i < $ownedRelics.length && !$endloop; $i++>>
-		<<if $ownedRelics[$i].name=="Gleam Dazer" >>
-			<<set $temp=$i>>
-			<<set $endloop=false>>
-		<</if>>
-	<</for>>
-<</if>>
-<</nobr>>
-[[Return|$previewReturn][setup.sellRelic($temp), $endloop=false]]
+
+[[Return|$previewReturn][setup.loseRelic('Gleam Dazer')]]
 
 :: Layer8 notes [image layer8 noreturn]
 
@@ -270,12 +259,12 @@ After using it, the orbs and circles will fade, leaving you unable to ever use E
 Choose a Relic to temporally limit-break:
 
 <<nobr>>
-<<for _i = 0; _i < $ownedRelics.length; _i++>>
-	<<capture _i>>
-		<<if $ownedRelics[_i].name == "Aeonglass">>
-			<<print "[[$ownedRelics[_i].name|Layer8 Time][$timeUsed = 1, setup.sellRelic(_i), $ownedRelics.push($relic70_ET), $timeRelic = $relic70_ET.name]]">><br>
-		<<elseif $spaceRelic != $ownedRelics[_i].name>>
-			<<print "[[$ownedRelics[_i].name|Layer8 Time][$timeUsed = 1, $timeRelic = $ownedRelics[_i].name]]">><br>
+<<for _relic range $ownedRelics>>
+	<<capture _relic>>
+		<<if _relic.name == "Aeonglass">>
+			[[_relic.name|Layer8 Time][$timeUsed = 1, setup.loseRelic(_relic), $ownedRelics.push($relic70_ET), $timeRelic = $relic70_ET.name]]<br>
+		<<elseif _relic.name != $spaceRelic>>
+			[[_relic.name|Layer8 Time][$timeUsed = 1, $timeRelic = _relic.name]]<br>
 		<</if>>
 	<</capture>>
 <</for>>
@@ -1109,8 +1098,7 @@ The Relics you have found with Cherry's Chaotic Luck are $relics[$temp1].name an
 		<<set $ownedRelics.deleteAt($ownedRelics.length-1)>>
 		<<set $corruption += Math.floor(Math.max(($relics[$temp2].corr / 2) - $corRed, 0))>>
 
-		<<set _temp = $ownedRelics.findIndex(e=> e.name==="Devil's Own")>>
-		<<set setup.sellRelic(_temp)>>
+		<<set setup.loseRelic("Devil's Own")>>
 	<</link>>
 
 <</if>>
@@ -1201,8 +1189,7 @@ The Curses you have obtained with Cherry's Chaotic Luck are $curses[$temp1].name
 		<</if>>
 		<<RemoveCurse $curses[$temp2]>>
 
-		<<set _temp = $ownedRelics.findIndex(e=> e.name === "Devil's Own")>>
-		<<set setup.sellRelic(_temp)>>
+		<<set setup.loseRelic("Devil's Own")>>
 	<</link>>
 
 <</if>>
@@ -1286,8 +1273,7 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 			<</if>>
 		<</if>>
 		<<RemoveCurse $curses[$temp2]>>
-		<<set _temp = $ownedRelics.findIndex(e=> e.name === "Devil's Own")>>
-		<<set setup.sellRelic(_temp)>>
+		<<set setup.loseRelic("Devil's Own")>>
 	<</link>>
 
 <</if>>

--- a/src/surface.twee
+++ b/src/surface.twee
@@ -641,7 +641,7 @@ Cashing out, really? Where is your sense of adventure?
 <</nobr>>
 
 :: Surface Sell 1 [surface]
-<<Inhuman>>\
+<<CarryAdjust>><<Inhuman>>\
 <<if $visitL1 == 0>>
 	Stepping into the shop, you're immediately greeted by a spectacle of Relics, in varying stages of packaging, ready to be shipped off to unknown buyers across the globe.
 
@@ -686,14 +686,6 @@ Cashing out, really? Where is your sense of adventure?
 				<<else>>
 					[[_linkText|Surface Sell 1][setup.sellRelic(_relic)]]
 				<</if>>
-			<<case "Chain of Lorelei">>
-				[[_linkText|Surface Sell 1][setup.sellRelic(_relic), $colwear = 0]]
-			<<case "Heart-stealing Stole">>
-				[[_linkText|Surface Sell 1][setup.sellRelic(_relic), $hsswear = 0]]
-			<<case "Solace Lace">>
-				[[_linkText|Surface Sell 1][setup.sellRelic(_relic), $slwear = 0]]
-			<<case "Sibyl Blend">>
-				[[_linkText|Surface Sell 1][setup.sellRelic(_relic), $SibylBuff = 0]]
 			<<case "World Stone">>
 				<<if $LilyPromise>>
 					[[_linkText|Surface Sell 1][setup.sellRelic(_relic), setup.modAffection('Lily', -5)]]
@@ -707,14 +699,6 @@ Cashing out, really? Where is your sense of adventure?
 				<<else>>
 					You need to empty the Everheavea to sell it (have at least two empty flasks in your inventory).
 				<</if>>
-			<<case "Brave Vector">>
-				[[_linkText|Surface Sell 1][setup.sellRelic(_relic), $slingshot = 0]]
-			<<case "Daedalus Mechanism">>
-				[[_linkText|Surface Sell 1][setup.sellRelic(_relic), $DaedalusEquip = false, $DaedalusFly = false]]
-			<<case "Blind Divine">>
-				[[_linkText|Surface Sell 1][setup.sellRelic(_relic), $BDwear = false]]
-			<<case "Heavy is the Head">>
-				[[_linkText|Surface Sell 1][setup.sellRelic(_relic), $HeavyHeadwear = false]]
 			<<case "Moonwatcher">>
 				<<if $BionicEye>>
 					_relic.name: You can't sell Relics that have become part of your body.
@@ -1197,6 +1181,7 @@ You want to throw the doll away, but your body simply refuses. At the moment it 
 
 
 :: Inn Storage [nobr]
+<<CarryAdjust>>
 
 <<if $innDubloons > 0>>
 	You can retrieve all of the dubloons you have stored in your inn room. You currently have $innDubloons stored.<br>
@@ -1235,28 +1220,12 @@ You want to throw the doll away, but your body simply refuses. At the moment it 
 					<<else>>
 						[[_linkText|passage()][$innRelics.push(_relic), setup.loseRelic(_relic)]]
 					<</if>>
-				<<case "Chain of Lorelei">>
-					[[_linkText|passage()][$innRelics.push(_relic), setup.loseRelic(_relic), $colwear = 0]]
-				<<case "Heart-stealing Stole">>
-					[[_linkText|passage()][$innRelics.push(_relic), setup.loseRelic(_relic), $hsswear = 0]]
-				<<case "Solace Lace">>
-					[[_linkText|passage()][$innRelics.push(_relic), setup.loseRelic(_relic), $slwear = 0]]
-				<<case "Sibyl Blend">>
-					[[_linkText|passage()][$innRelics.push(_relic), setup.loseRelic(_relic), $SibylBuff = 0]]
 				<<case "Everhevea">>
 					<<if setup.item('Empty Flask').count >= 2>>
 						[[_linkText|passage()][$innRelics.push(_relic), setup.loseRelic(_relic), setup.item('Empty Flask').count -= 2]]
 					<<else>>
 						You need to empty the Everheavea to store it (have at least two empty flasks in your inventory).
 					<</if>>
-				<<case "Brave Vector">>
-					[[_linkText|passage()][$innRelics.push(_relic), setup.loseRelic(_relic), $slingshot = 0]]
-				<<case "Daedalus Mechanism">>
-					[[_linkText|passage()][$innRelics.push(_relic), setup.loseRelic(_relic), $DaedalusEquip = false, $DaedalusFly = false]]
-				<<case "Blind Divine">>
-					[[_linkText|passage()][$innRelics.push(_relic), setup.loseRelic(_relic), $BDwear = false]]
-				<<case "Heavy is the Head">>
-					[[_linkText|passage()][$innRelics.push(_relic), setup.loseRelic(_relic), $HeavyHeadwear = false]]
 				<<case "Moonwatcher">>
 					<<if $BionicEye>>
 						_relic.name: You can't store Relics that have become part of your body.

--- a/src/surface.twee
+++ b/src/surface.twee
@@ -675,44 +675,64 @@ Cashing out, really? Where is your sense of adventure?
 
 	Choose the Relic you would like to sell:
 	<<nobr>>
-	<<for $i = 0; $i < $ownedRelics.length; $i++>>
-		<<capture $i>>
-			<<if $ownedRelics[$i].name=="Creepy Doll" && $creepydoll.affec > 5>>
-				You can't seem to part ways with the Creepy Doll<br>
-			<<elseif $ownedRelics[$i].name=="Chain of Lorelei">>
-				<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Surface Sell 1][$colwear=0, $dubloons += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
-			<<elseif $ownedRelics[$i].name=="Heart-stealing Stole">>
-				<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Surface Sell 1][$hsswear=0, $dubloons += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
-			<<elseif $ownedRelics[$i].name=="Solace Lace">>
-				<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Surface Sell 1][$slwear=0, $dubloons += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
-			<<elseif $ownedRelics[$i].name=="Sibyl Blend">>
-				<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Surface Sell 1][$SibylBuff=0, $dubloons += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
-			<<elseif $ownedRelics[$i].name=="World Stone" && $LilyPromise>>
-				<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Surface Sell 1][$dubloons += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i), $companionLily.affec -= (5 - $hsswear)]]">>
-				You promised Lily she could use the World Stone at the end of your journey, selling it now will surely disappoint her greatly. <br>
-			<<elseif $ownedRelics[$i].name=="Everhevea">>
-				<<if $items[2].count >= 2>>
-					<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Surface Sell 1][$dubloons += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i), $items[2].count -= 2]]">><br>
+<<for _relic range $ownedRelics>>
+	<<capture _relic>>
+		<<set _linkText = `Sell ${_relic.name} for ${setup.sellValue(_relic)} dubloons`>>
+		/* Add a bit of indentation: */ &nbsp;
+		<<switch _relic.name>>
+			<<case "Creepy Doll">>
+				<<if $creepydoll.affec > 5>>
+					You can't seem to part ways with the Creepy Doll...
 				<<else>>
-					You need to empty the Everheavea to sell it (have at least two empty flasks in your inventory) <br>
+					[[_linkText|Surface Sell 1][setup.sellRelic(_relic)]]
 				<</if>>
-			<<elseif $ownedRelics[$i].name=="Daedalus Mechanism">>
-				<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Surface Sell 1][$DaedalusEquip = false, $DaedalusFly = false, $dubloons += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
-			<<elseif $ownedRelics[$i].name=="Blind Divine">>
-				<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Surface Sell 1][$BDwear = false, $dubloons += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
-			<<elseif $ownedRelics[$i].name=="Heavy is the Head">>
-				<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Surface Sell 1][$HeavyHeadwear= false, $dubloons += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
-			<<elseif $ownedRelics[$i].name=="Brave Vector">>
-				<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Surface Sell 1][$dubloons += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i), $slingshot = 0]]">><br>
-			<<elseif $ownedRelics[$i].name=="Moonwatcher" & $BionicEye >>
-				<<print $ownedRelics[$i].name>> You can not sell Relics that have become part of your body.<br>
-			<<elseif $ownedRelics[$i].name=="Glory's Grasp" & $BionicArm >>
-				<<print $ownedRelics[$i].name>> You can not sell Relics that have become part of your body.<br>
-			<<else>>
-				<<print $ownedRelics[$i].name>><<print " for ">><<print ($ownedRelics[$i].value + $sellAdd)>><<print " dubloons ">><<print "[[Sell|Surface Sell 1][$dubloons += ($ownedRelics[$i].value + $sellAdd), setup.sellRelic($i)]]">><br>
-			<</if>>
-		<</capture>>
-	<</for>>
+			<<case "Chain of Lorelei">>
+				[[_linkText|Surface Sell 1][setup.sellRelic(_relic), $colwear = 0]]
+			<<case "Heart-stealing Stole">>
+				[[_linkText|Surface Sell 1][setup.sellRelic(_relic), $hsswear = 0]]
+			<<case "Solace Lace">>
+				[[_linkText|Surface Sell 1][setup.sellRelic(_relic), $slwear = 0]]
+			<<case "Sibyl Blend">>
+				[[_linkText|Surface Sell 1][setup.sellRelic(_relic), $SibylBuff = 0]]
+			<<case "World Stone">>
+				<<if $LilyPromise>>
+					[[_linkText|Surface Sell 1][setup.sellRelic(_relic), setup.modAffection('Lily', -5)]]
+					You promised Lily she could use the World Stone at the end of your journey. Selling it now will surely dissapoint her greatly.
+				<<else>>
+					[[_linkText|Surface Sell 1][setup.sellRelic(_relic)]]<br>
+				<</if>>
+			<<case "Everhevea">>
+				<<if setup.item('Empty Flask').count >= 2>>
+					[[_linkText|Surface Sell 1][setup.sellRelic(_relic), setup.item('Empty Flask').count -= 2]]
+				<<else>>
+					You need to empty the Everheavea to sell it (have at least two empty flasks in your inventory).
+				<</if>>
+			<<case "Brave Vector">>
+				[[_linkText|Surface Sell 1][setup.sellRelic(_relic), $slingshot = 0]]
+			<<case "Daedalus Mechanism">>
+				[[_linkText|Surface Sell 1][setup.sellRelic(_relic), $DaedalusEquip = false, $DaedalusFly = false]]
+			<<case "Blind Divine">>
+				[[_linkText|Surface Sell 1][setup.sellRelic(_relic), $BDwear = false]]
+			<<case "Heavy is the Head">>
+				[[_linkText|Surface Sell 1][setup.sellRelic(_relic), $HeavyHeadwear = false]]
+			<<case "Moonwatcher">>
+				<<if $BionicEye>>
+					_relic.name: You can't sell Relics that have become part of your body.
+				<<else>>
+					[[_linkText|Surface Sell 1][setup.sellRelic(_relic)]]
+				<</if>>
+			<<case "Glory's Grasp">>
+				<<if $BionicArm>>
+					_relic.name: You can't sell Relics that have become part of your body.
+				<<else>>
+					[[_linkText|Surface Sell 1][setup.sellRelic(_relic)]]
+				<</if>>
+			<<default>>
+				[[_linkText|Surface Sell 1][setup.sellRelic(_relic)]]
+		<</switch>>
+		<br>
+	<</capture>>
+<</for>>
 	<</nobr>>
 <</if>>\
 
@@ -733,54 +753,45 @@ The Relic $ownedRelics[$temp].name has been successfully sold and you've gotten 
 You step into the Relic Workshop of Outset Town. The air is thick with the smell of glue, sawdust, and molten metal. You see a couple of other adventurers tinkering away at Relics they found themselves. You approach one of the free workbenches and decide what you want to do.
 
 <<nobr>>
-<<for $i = 0; $i < $ownedRelics.length; $i++>>
-	<<capture $i>>
-	<<if $ownedRelics[$i].name == "Purity Tree Plank">>
-
-		<br>Would you like to fashion your Purity Wood Planks into protective gear for a value of +25 corruption each?<br>
-
-		[[Use Purity Wood Plank|Surface Workshop][$ownedRelics.deleteAt($i), $corruption += 25]]<br>
-	<</if>>
-
-	<<if $ownedRelics[$i].name == "Rømer Stones">>
-	<br>You muse over what you can do with the Rømer Stones, taking advantage over their ability for limitless small-scale heating or cooling.<br><br>
-	You can either craft self-warming winter gear using winter clothes available, or you could use some light summer clothing to craft some self-cooling summer gear. Either one of these will require using all of the Rømer stones to craft.<br>
-		<<if $warmCloth == 0>>
-		[[Use the Rømer Stones for self-warming winter gear|Surface Workshop][setup.sellRelic($i), $items[22].count = 1, $warmCloth=1]]<br>
-		<</if>>
-		<<if $coolCloth == 0>>
-		[[Use the Rømer Stones for self-cooling summer gear|Surface Workshop][setup.sellRelic($i), $items[23].count = 1, $coolCloth=1]]<br>
-		<</if>>
-	<</if>>
-	<<if $ownedRelics[$i].name == "Creepy Doll" && $dollevent==false>>
-		<br>You are intrigued by the doll and its warm yet creepy aura. Perhaps you want to take a peek inside and see whether it truly is a doll or if its something different entirely that merely takes on the appearance of a doll.<br>
-		[[Use scizzors to cut open the doll|Doll event]]<br>
-	<</if>>
-	<<if $ownedRelics[$i].name == "Brave Vector" && $slingshot == 0>>
-		<br>The Brave Vector seems like it should have some application as a weapon, but it turns out that it is exceedingly difficult to use a bent pipe like that as a gun substitute. Luckily, with the help of the resident Relic experts, you can change the form of the Brave Vector to a much more useful one. They seem to recommend a sort of metal slingshot design, which should be able to function like a gun, but will be able to use anything of approximately the correct size as ammo.<br>
-		[[Reshape the Brave Vector into a powerful slingshot|Surface Workshop][$slingshot = 1]]<br>
-	<</if>>
-	<<if $ownedRelics[$i].name == "Joyous Sunder" && $joyousSword == 0>>
-		<br>The Joyous Sunder is an incredibly powerful offensive tool, but it is limited by its form as a small knife. Luckily, with the help of the local Relic Engineers, you can reshape this Relic into a true sword that an expert swordsman would feel comfortable using. A weapon like that would be literally unstoppable by any enemy that can be defeated by physical attacks and does not disable the user before they can get close enough to use it. This would be most useful in the hands of someone like Khemia, letting him defeat powerful beasts from the depths of the Abyss without fear of injury himself. <br>
-		[[Reshape the Joyous Sunder into a true sword|Surface Workshop][$joyousSword = 1]]<br>
-	<</if>>
-	<<if $ownedRelics[$i].name == "Moonwatcher" && $BionicEye == false>>
-		<br>As you contemplate the potential benefits of the Moonwatcher serving as a bionic eye, an almost electric thrill runs through you. The thought of gaining night vision and the ability to see through objects seems incredibly appealing. Here, at the Relic Workshop, they can safely perform the installation for you.<br>
-		[[Opt to have the Moonwatcher installed as your bionic eye|Surface Workshop][$light = 1, $BionicEye=true]]<br>
-	<</if>>
-	<<if $ownedRelics[$i].name == "Glory's Grasp" && $BionicArm == false>>
-		<br>The allure of Glory's Grasp replacing your organic arm with a bionic one is not lost on you. The notion carries with it a certain charm and intrigue. Here, in the Relic Workshop, they can ensure a secure and proficient installation.<br>
-		[[Proceed with the installation of Glory's Grasp as your bionic arm|Surface Workshop][$BionicArm=true]]<br>
-	<</if>>
-	<<if $ownedRelics[$i].name == "Omoikane Circuit" && setup.haveSmartphoneRegular>>
-		<br>The Omoikane Circuit, you've heard, is a Relic specifically designed for integration with your phone. Why not seize this opportunity to upgrade your device right here in the safety of the Relic Workshop?<br>
-		[[It's time to revolutionize your phone!|AI ConvoIn][setup.haveSmartphoneRegular = false, setup.haveSmartphoneAI = true, setup.sellRelic($i) ]]<br>
-	<</if>>
+<<for _relic range $ownedRelics>>
+	<<capture _relic>>
+		<<switch _relic.name>>
+			<<case "Purity Tree Plank">>
+				<br>Would you like to fashion your Purity Wood Planks into protective gear for a value of +25 corruption each?<br>
+				[[Use Purity Wood Plank|Surface Workshop][setup.loseRelic(_relic), $corruption += 25]]<br>
+			<<case "Rømer Stones">>
+				<br>You muse over what you can do with the Rømer Stones, taking advantage over their ability for limitless small-scale heating or cooling.<br>
+				<br>You can either craft self-warming winter gear using winter clothes available, or you could use some light summer clothing to craft some self-cooling summer gear. Either one of these will require using all of the Rømer stones to craft.<br>
+				<<if $warmCloth == 0>>
+					[[Use the Rømer Stones for self-warming winter gear|Surface Workshop][setup.loseRelic(_relic), setup.item('Self-Warming Clothes').count = 1, $warmCloth = 1]]<br>
+				<</if>>
+				<<if $coolCloth == 0>>
+					[[Use the Rømer Stones for self-cooling summer gear|Surface Workshop][setup.loseRelic(_relic), setup.item('Self-Cooling Clothes').count = 1, $coolCloth = 1]]<br>
+				<</if>>
+			<<case "Creepy Doll" && $dollevent==false>>
+				<br>You are intrigued by the doll and its warm yet creepy aura. Perhaps you want to take a peek inside and see whether it truly is a doll or if its something different entirely that merely takes on the appearance of a doll.<br>
+				[[Use scizzors to cut open the doll|Doll event]]<br>
+			<<case "Brave Vector" && $slingshot == 0>>
+				<br>The Brave Vector seems like it should have some application as a weapon, but it turns out that it is exceedingly difficult to use a bent pipe like that as a gun substitute. Luckily, with the help of the resident Relic experts, you can change the form of the Brave Vector to a much more useful one. They seem to recommend a sort of metal slingshot design, which should be able to function like a gun, but will be able to use anything of approximately the correct size as ammo.<br>
+				[[Reshape the Brave Vector into a powerful slingshot|Surface Workshop][$slingshot = 1]]<br>
+			<<case "Joyous Sunder" && $joyousSword == 0>>
+				<br>The Joyous Sunder is an incredibly powerful offensive tool, but it is limited by its form as a small knife. Luckily, with the help of the local Relic Engineers, you can reshape this Relic into a true sword that an expert swordsman would feel comfortable using. A weapon like that would be literally unstoppable by any enemy that can be defeated by physical attacks and does not disable the user before they can get close enough to use it. This would be most useful in the hands of someone like Khemia, letting him defeat powerful beasts from the depths of the Abyss without fear of injury himself. <br>
+				[[Reshape the Joyous Sunder into a true sword|Surface Workshop][$joyousSword = 1]]<br>
+			<<case "Moonwatcher" && $BionicEye == false>>
+				<br>As you contemplate the potential benefits of the Moonwatcher serving as a bionic eye, an almost electric thrill runs through you. The thought of gaining night vision and the ability to see through objects seems incredibly appealing. Here, at the Relic Workshop, they can safely perform the installation for you.<br>
+				[[Opt to have the Moonwatcher installed as your bionic eye|Surface Workshop][$light = 1, $BionicEye = true]]<br>
+			<<case "Glory's Grasp" && $BionicArm == false>>
+				<br>The allure of Glory's Grasp replacing your organic arm with a bionic one is not lost on you. The notion carries with it a certain charm and intrigue. Here, in the Relic Workshop, they can ensure a secure and proficient installation.<br>
+				[[Proceed with the installation of Glory's Grasp as your bionic arm|Surface Workshop][$BionicArm = true]]<br>
+			<<case "Omoikane Circuit" && setup.haveSmartphoneRegular>>
+				<br>The Omoikane Circuit, you've heard, is a Relic specifically designed for integration with your phone. Why not seize this opportunity to upgrade your device right here in the safety of the Relic Workshop?<br>
+				[[It's time to revolutionize your phone!|AI ConvoIn][setup.haveSmartphoneRegular = false, setup.haveSmartphoneAI = true, setup.loseRelic(_relic) ]]<br>
+		<</switch>>
 	<</capture>>
 <</for>>
 <<if setup.haveSmartphoneAI>>
 	<br>Is listening to that snarky AI worth the spec upgrade to the Omoikone Smartphone?<br>
-	[[Hell no, time for a downgrade|AI ConvoOut][setup.haveSmartphoneRegular = true, setup.haveSmartphoneAI = false, setup.unsellRelic("Omoikane Circuit")]]<br>
+	[[Hell no, time for a downgrade|AI ConvoOut][setup.haveSmartphoneRegular = true, setup.haveSmartphoneAI = false, setup.unsellRelic('Omoikane Circuit')]]<br>
 <</if>>
 <</nobr>>
 
@@ -1202,9 +1213,9 @@ You want to throw the doll away, but your body simply refuses. At the moment it 
 
 <<if $innRelics.length > 0>>
 	You can pick up any of the Relics you've previously stored in your inn room:<br>
-	<<for $i = 0; $i < $innRelics.length; $i++>>
-		<<capture $i>>
-			<<print $innRelics[$i].name + " [[Retrieve|passage()][setup.unsellRelic($innRelics[$i]), $innRelics.deleteAt($i)]]">><br>
+	<<for _i, _relic range $innRelics>>
+		<<capture _i _relic>>
+			[[`Retrieve ${_relic.name}`|passage()][setup.unsellRelic(_relic), $innRelics.deleteAt(_i)]]<br>
 		<</capture>>
 	<</for>>
 	<br>
@@ -1213,25 +1224,55 @@ You want to throw the doll away, but your body simply refuses. At the moment it 
 <<if $ownedRelics.length > 0>>
 	You can store any Relics you're holding here for safe keeping or if you just want to reduce the weight you're holding.
 	Choose a Relic you would like to store here at the inn:<br>
-	<<for $i = 0; $i < $ownedRelics.length; $i++>>
-		<<capture $i>>
-			<<if $ownedRelics[$i].name=="Creepy Doll" && $creepydoll.affec > 5>>
-				You can't seem to part ways with the Creepy Doll<br>
-			<<elseif $ownedRelics[$i].name=="Chain of Lorelei">>
-				<<print $ownedRelics[$i].name>><<print " [[Store|passage()][$innRelics.push($ownedRelics[$i]), setup.sellRelic($i), $colwear = 0]]">><br>
-			<<elseif $ownedRelics[$i].name=="Heart-stealing Stole">>
-				<<print $ownedRelics[$i].name>><<print " [[Store|passage()][$innRelics.push($ownedRelics[$i]), setup.sellRelic($i), $hsswear = 0]]">><br>
-			<<elseif $ownedRelics[$i].name=="Solace Lace">>
-				<<print $ownedRelics[$i].name>><<print " [[Store|passage()][$innRelics.push($ownedRelics[$i]), setup.sellRelic($i), $slwear = 0]]">><br>
-			<<elseif $ownedRelics[$i].name=="Sibyl Blend">>
-				<<print $ownedRelics[$i].name>><<print " [[Store|passage()][$innRelics.push($ownedRelics[$i]), setup.sellRelic($i), $SibylBuff = 0]]">><br>
-			<<elseif $ownedRelics[$i].name=="Everhevea">>
-				<<print $ownedRelics[$i].name>><<print " [[Store|passage()][$innRelics.push($ownedRelics[$i]), setup.sellRelic($i), $items[2].count -= 2]]">><br>
-			<<elseif $ownedRelics[$i].name=="Brave Vector">>
-				<<print $ownedRelics[$i].name>><<print " [[Store|passage()][$innRelics.push($ownedRelics[$i]), setup.sellRelic($i), $slingshot = 0]]">><br>
-			<<else>>
-				<<print $ownedRelics[$i].name>><<print " [[Store|passage()][$innRelics.push($ownedRelics[$i]), setup.sellRelic($i)]]">><br>
-			<</if>>
+	<<for _relic range $ownedRelics>>
+		<<capture _relic>>
+			<<set _linkText = `Store ${_relic.name}`>>
+			/* Add a bit of indentation: */ &nbsp;
+			<<switch _relic.name>>
+				<<case "Creepy Doll">>
+					<<if $creepydoll.affec > 5>>
+						You can't seem to part ways with the Creepy Doll...
+					<<else>>
+						[[_linkText|passage()][$innRelics.push(_relic), setup.loseRelic(_relic)]]
+					<</if>>
+				<<case "Chain of Lorelei">>
+					[[_linkText|passage()][$innRelics.push(_relic), setup.loseRelic(_relic), $colwear = 0]]
+				<<case "Heart-stealing Stole">>
+					[[_linkText|passage()][$innRelics.push(_relic), setup.loseRelic(_relic), $hsswear = 0]]
+				<<case "Solace Lace">>
+					[[_linkText|passage()][$innRelics.push(_relic), setup.loseRelic(_relic), $slwear = 0]]
+				<<case "Sibyl Blend">>
+					[[_linkText|passage()][$innRelics.push(_relic), setup.loseRelic(_relic), $SibylBuff = 0]]
+				<<case "Everhevea">>
+					<<if setup.item('Empty Flask').count >= 2>>
+						[[_linkText|passage()][$innRelics.push(_relic), setup.loseRelic(_relic), setup.item('Empty Flask').count -= 2]]
+					<<else>>
+						You need to empty the Everheavea to store it (have at least two empty flasks in your inventory).
+					<</if>>
+				<<case "Brave Vector">>
+					[[_linkText|passage()][$innRelics.push(_relic), setup.loseRelic(_relic), $slingshot = 0]]
+				<<case "Daedalus Mechanism">>
+					[[_linkText|passage()][$innRelics.push(_relic), setup.loseRelic(_relic), $DaedalusEquip = false, $DaedalusFly = false]]
+				<<case "Blind Divine">>
+					[[_linkText|passage()][$innRelics.push(_relic), setup.loseRelic(_relic), $BDwear = false]]
+				<<case "Heavy is the Head">>
+					[[_linkText|passage()][$innRelics.push(_relic), setup.loseRelic(_relic), $HeavyHeadwear = false]]
+				<<case "Moonwatcher">>
+					<<if $BionicEye>>
+						_relic.name: You can't store Relics that have become part of your body.
+					<<else>>
+						[[_linkText|passage()][$innRelics.push(_relic), setup.loseRelic(_relic)]]
+					<</if>>
+				<<case "Glory's Grasp">>
+					<<if $BionicArm>>
+						_relic.name: You can't store Relics that have become part of your body.
+					<<else>>
+						[[_linkText|passage()][$innRelics.push(_relic), setup.loseRelic(_relic)]]
+					<</if>>
+				<<default>>
+					[[_linkText|passage()][$innRelics.push(_relic), setup.loseRelic(_relic)]]
+			<</switch>>
+			<br>
 		<</capture>>
 	<</for>>
 	<br>

--- a/src/widgets.twee
+++ b/src/widgets.twee
@@ -3064,6 +3064,10 @@
 	<<set $SibylBuff = 0>>
 <</if>>
 
+<<if !$ownedRelics.some(e => e.name === "Brave Vector")>>
+	<<set $slingshot = 0>>
+<</if>>
+
 <<if !$ownedRelics.some(e => e.name === "Daedalus Mechanism")>>
 	<<set $DaedalusEquip = false>>
 	<<set $DaedalusFly = false>>

--- a/src/widgets.twee
+++ b/src/widgets.twee
@@ -824,10 +824,10 @@
 <</for>>
 
 <<set $SemenDemonBalance += (_contributions-$curse82.variation1)*_args[0]>>/* */
-<<if $SemenDemonBalance <-14 >>
+<<if $SemenDemonBalance < -14>>
 	<<set $gameOver=true>>
-<<elseif $SemenDemonBalance >14 >>
-	<<set $SemenDemonBalance = 14>>/* */
+<<elseif $SemenDemonBalance > 14>>
+	<<set $SemenDemonBalance = 14>>
 <</if>>
 <</widget>>
 


### PR DESCRIPTION
This cleans up all the loops for selling, recycling or handing over relics to the bandits.
* I generalized some utility functions and added a couple of new ones to do it.
* I also adjusted every other place where you lose a relic (which I previously updated to use `sellRelic`).
* Losing a relic currently still places it in `$soldRelics`, it just doesn't give you money for it (`sellRelic` now gives you money automatically). We can add `$lostRelics` or similar later.
* I significantly simplified all the "Gleam Dazer" checks and slightly simplified the "Devil's Own" checks.
* All the loops now have the same relic exceptions (they weren't very consistent), with the exception of storing the "World Stone" at the inn (since Lily doesn't mind you storing it).
* I used a callback for setting the sell value on layer 7 since it's different from the sell value everywhere else. Ended up pretty clean :)