### PR TITLE
Pass time widget for layer exit

### DIFF
--- a/src/global.twee
+++ b/src/global.twee
@@ -1801,6 +1801,7 @@ How many dubloons would you like to pay back?
 
 :: Widgets for the passage of time [widget nobr]
 <<widget "AdjustedTravelTime">>
+<<capture _additiveModifier _consumptionPerDay _forPreview _inputTime _multiplicativeModifier>>
 /*
 	_args[0]: string       = the variable to write to, as a string (e.g. "$tempTime")
 	_args[1]: var|number   = the raw, unadjusted travel time
@@ -1808,6 +1809,7 @@ How many dubloons would you like to pay back?
 	_args[3]: [var|number] = initial additive modifier (optional, can be negative)
 */
 <<set _inputTime = _args[1]>>
+<<set _forPreview = _args[2]>>
 
 /* Start by computing the overall additive modifier. */
 <<set _additiveModifier = _args[3] || 0>>
@@ -1818,7 +1820,7 @@ How many dubloons would you like to pay back?
 /* Apply status penalty, if any. */
 <<if $status.duration > 0>>
 	<<set _additiveModifier += $status.penalty>>
-	<<if !_args[2]>>
+	<<if !_forPreview>>
 		/* Decrement status duration and remove status penalty if duration is now 0. */
 		<<set $status.duration -= 1>>
 		<<if $status.duration < 1>>
@@ -1855,7 +1857,7 @@ How many dubloons would you like to pay back?
 			<<set _additiveModifier -= 2>>
 		<<elseif $torchUse == 1 && $items[9].count > 0>>
 			<<set _additiveModifier -= 2>>
-			<<if !_args[2]>>
+			<<if !_forPreview>>
 				/* Decrement number of torches and stop using torches if the count is now 0. */
 				<<set $items[9].count -= 1>>
 				<<if $items[9].count < 1>>
@@ -1910,10 +1912,7 @@ How many dubloons would you like to pay back?
 		Your exceptional physical condition is reducing your travel time.<br>
 		<<set _multiplicativeModifier /= 1 + $app.HandicapMovement / 10>>
 	<</if>>
-	/* Print a message if the Aeonglass with Endless Time relic is causing time dilation, but don't handle it here. */
-	<<if $EndlessAeonglass>>
-		The enhanced Aeonglass, shimmering with a timeless aura, grants you the remarkable ability to reduce your travel time by half.<br>
-	<</if>>
+
 	/* Apply the multiplicative modifiers. */
 	<<set _inputTime *= _multiplicativeModifier>>
 	/* Adjust the travel time if the player is using energy rations. */
@@ -1930,7 +1929,7 @@ How many dubloons would you like to pay back?
 		<<set _daysOfEnergyRations = Math.min(_inputTime / 2, $items[24].count / _consumptionPerDay)>>
 		/* Every day with an energy ration counts for twice as much. */
 		<<set _inputTime -= _daysOfEnergyRations>>
-		<<if !_args[2]>>
+		<<if !_forPreview>>
 			/* Round up the number of days of energy rations to a whole number, as GeneralTimeStats iterates per day. */
 			<<set _daysOfEnergyRations = Math.ceil(_daysOfEnergyRations)>>
 			/* If we used up all the energy rations we had, stop using them. */
@@ -1946,13 +1945,19 @@ How many dubloons would you like to pay back?
 	<<set _inputTime += _additiveModifier>>
 <</if>>
 
+/* Print a message about the Aeonglass with Endless Time relic, but only apply the bonus if we're in preview mode. */
+<<if $EndlessAeonglass>>
+	The enhanced Aeonglass, shimmering with a timeless aura, grants you the remarkable ability to reduce your travel time by half.<br>
+	<<if _forPreview>><<set _inputTime /= 2>><</if>>
+<</if>>
+
 /* Don't allow travel time to become negative. */
 <<if _inputTime < 0>><<set _inputTime = 0>><</if>>
 
 /* Round travel time to a whole number of days. */
 <<set _inputTime = Math.round(_inputTime)>>
 
-<<if !_args[2]>>
+<<if !_forPreview>>
 	<<if _daysOfEnergyRations && _daysOfEnergyRations > _inputTime>>
 		/* Ensure all days of energy rations end up used. */
 		<<set $items[24].count -= _consumptionPerDay * (_daysOfEnergyRations - _inputTime)>>
@@ -1963,6 +1968,7 @@ How many dubloons would you like to pay back?
 /* Write to the output variable. */
 <<print `<<set ${_args[0]} = ${_inputTime}>>`>>
 
+<</capture>>
 <</widget>>
 
 <<widget "PassTime">>

--- a/src/global.twee
+++ b/src/global.twee
@@ -1965,8 +1965,9 @@ How many dubloons would you like to pay back?
 <</widget>>
 
 <<widget "PassTime">>
-<<capture _i _days>>
+<<capture _consumptionPerDay _day _days _i _random _threshold _timeDilation>>
 <<set _days = _args[0]>>
+<<set _timeDilation = 1>>
 
 /* Check for wetting events. */
 <<if $WettingSolution == 0>>
@@ -1989,69 +1990,6 @@ How many dubloons would you like to pay back?
 	<<SemenDemonCalc _days>>
 <</if>>
 
-<<switch $currentLayer>>
-	<<case 1>>
-		<<set $timeL1 += _days>>
-	<<case 2>>
-		<<set $timeL2 += _days>>
-		/* Check if player has 10+ food rations. */
-		<<if $items[1].count >= 10>>
-			<<set $timeL2T1 += _days>>
-		<</if>>
-	<<case 3>>
-		<<set $timeL3 += _days>>
-		<<set $timeL3T1 += _days>>
-		/* Check if player has an active light source. */
-		<<if !setup.haveTravelLightSource>>
-			<<set $timeL3T2 += _days>>
-		<</if>>
-	<<case 4>>
-		<<set $timeL4 += _days>>
-		<<set $timeL4T1 += _days>>
-	<<case 5>>
-		<<set $timeL5 += _days>>
-		/* Check if player has 10+ water or filled flasks. */
-		<<if ($items[0].count + $items[3].count) >= 10>>
-			<<set $timeL5T2 += _days>>
-		<</if>>
-		<<set $timeL5T1 += _days>>
-	<<case 6>>
-		<<set $timeL6 += _days>>
-		/* Check if player has 200+ dubloons. */
-		<<if $dubloons >= 200>>
-			<<set $timeL6T2 += _days>>
-		<</if>>
-		<<set $timeL6T1 += _days>>
-		/* Add a jinxed flame counter for every day unless the player is flying. */
-		<<if !$DaedalusFly>>
-			<<set $hexflame += _days>>
-		<</if>>
-	<<case 7>>
-		<<set $timeL7 += _days>>
-		/* Check if the player has fewer than 500 dubloons. */
-		<<if $dubloons < 500>>
-			<<set $timeL7T2 += _days>>
-		<</if>>
-		/* Subtract dubloons for every day spent on this layer. */
-		<<for _i = 0; _i < _days; ++_i>>
-			<<if $dubloons >= 300>>
-				<<set $dubloons -= 1>>
-			<<elseif $dubloons >= 100>>
-				<<set $dubloons -= 2>>
-			<<else>>
-				<<set $dubloons -= 3>>
-			<</if>>
-		<</for>>
-	<<case 8>>
-		<<set $timeL8 += _days>>
-		<<set $timeL8T2a += _days>>
-		<<set $timeL8T2b += _days>>
-		/* Trigger an Inanis Ego event (once per trip). */
-		<<if !$L8loopLim>>
-			<<include "Layer 8 Threat 1a">>
-		<</if>>
-<</switch>>
-
 /* Calculate the amount of food and drink that needs to be consumed per day. */
 <<set _consumptionPerDay = 1>>
 <<if $hiredCompanions.some(e => e.name === $companionTwin.name)>>
@@ -2061,13 +1999,85 @@ How many dubloons would you like to pay back?
 	<<set _consumptionPerDay /= 4>> /* You eat and drink a lot less than normal (your twin shares your curses). */
 <</if>>
 
-<<for _i = 0; _i < _days; ++_i>>
+<<for _i = 0, _day = 0; _i < _days; ++_i>>
+	/* Check whether we need to be foraging for food to avoid dying of starvation. */
 	<<if !$forageFood && $starving > 4 && $currentLayer != 7 && $items[1].count + $items[24].count < _consumptionPerDay>>
 		@@.alert2; In order to avoid death by starvation, you are currently foraging for food on this layer, no matter the consequences.<br>
 		<<set $forageFood = 1>>
 	<</if>>
-	<<for ++$starving; $starving > 0; --$starving>>
-		<<if _daysOfEnergyRations>>
+	/* Check whether we need to be foraging for water to avoid dying of dehydration. */
+	<<if !$forageWater && $dehydrated > 1 && $currentLayer != 3 && $currentLayer != 5 && $items[0].count + $items[3].count + $items[25].count < _consumptionPerDay>>
+		@@.alert2; In order to avoid death by dehydration, you are currently foraging for water on this layer, no matter the consequences.<br>
+		<<set $forageWater = 1>>
+	<</if>>
+	/* Starvation and dehydration go up by 1 every day. If the player is starving */
+	/* or dehydrated, assume that they will stop to forage until they are sated. */
+	<<for ++$starving, ++$dehydrated; $starving > 0 || $dehydrated > 0; --$starving, --$dehydrated, ++_day>>
+		/* Adjust layer-specific state. */
+		<<if (_day % _timeDilation) == 0>>
+			<<switch $currentLayer>>
+				<<case 1>>
+					<<set $timeL1 += 1>>
+				<<case 2>>
+					<<set $timeL2 += 1>>
+					/* Check if player has 10+ food rations. */
+					<<if $items[1].count >= 10>>
+						<<set $timeL2T1 += 1>>
+					<</if>>
+				<<case 3>>
+					<<set $timeL3 += 1>>
+					<<set $timeL3T1 += 1>>
+					/* Check if player has an active light source. */
+					<<if !setup.haveTravelLightSource>>
+						<<set $timeL3T2 += 1>>
+					<</if>>
+				<<case 4>>
+					<<set $timeL4 += 1>>
+					<<set $timeL4T1 += 1>>
+				<<case 5>>
+					<<set $timeL5 += 1>>
+					/* Check if player has 10+ water or filled flasks. */
+					<<if ($items[0].count + $items[3].count) >= 10>>
+						<<set $timeL5T2 += 1>>
+					<</if>>
+					<<set $timeL5T1 += 1>>
+				<<case 6>>
+					<<set $timeL6 += 1>>
+					/* Check if player has 200+ dubloons. */
+					<<if $dubloons >= 200>>
+						<<set $timeL6T2 += 1>>
+					<</if>>
+					<<set $timeL6T1 += 1>>
+					/* Add a jinxed flame counter for every day unless the player is flying. */
+					<<if !$DaedalusFly>>
+						<<set $hexflame += 1>>
+					<</if>>
+				<<case 7>>
+					<<set $timeL7 += 1>>
+					/* Check if the player has fewer than 500 dubloons. */
+					<<if $dubloons < 500>>
+						<<set $timeL7T2 += 1>>
+					<</if>>
+					/* Subtract dubloons for every day spent on this layer. */
+					<<if $dubloons >= 300>>
+						<<set $dubloons -= 1>>
+					<<elseif $dubloons >= 100>>
+						<<set $dubloons -= 2>>
+					<<else>>
+						<<set $dubloons -= 3>>
+					<</if>>
+				<<case 8>>
+					<<set $timeL8 += 1>>
+					<<set $timeL8T2a += 1>>
+					<<set $timeL8T2b += 1>>
+					/* Trigger an Inanis Ego event (once per trip). */
+					<<if !$L8loopLim>>
+						<<include "Layer 8 Threat 1a">>
+					<</if>>
+			<</switch>>
+		<</if>>
+		/* Try to eat. */
+		<<if _daysOfEnergyRations > 0>>
 			/* If we used energy rations to speed up travel, use those first (regardless of foraging settings). */
 			<<set $items[24].count -= _consumptionPerDay>>
 			<<set _daysOfEnergyRations -= 1>>
@@ -2166,10 +2176,10 @@ How many dubloons would you like to pay back?
 						<<elseif $items[13].count && $items[20].count >= 1>>
 							<<set $items[20].count -= 1>>
 						<<else>>
-							<<set $lastFlan = $time + _i>>
+							<<set $lastFlan = $time + Math.round(_day / _timeDilation)>>
 						<</if>>
 					<<else>>
-						<<set $lastFlan = $time + _i>>
+						<<set $lastFlan = $time + Math.round(_day / _timeDilation)>>
 					<</if>>
 				<<case 3>>
 					<<set $foodL3 += 1>>
@@ -2228,17 +2238,9 @@ How many dubloons would you like to pay back?
 					<<set $LibidoLog.push($ForageFoodMinor)>>
 			<</switch>>
 		<</if>>
-	<</for>>
-<</for>>
-
-<<for _i = 0; _i < _days; ++_i>>
-	<<if !$forageWater && $dehydrated > 1 && $currentLayer != 3 && $currentLayer != 5 && $items[0].count + $items[3].count + $items[25].count < _consumptionPerDay>>
-		@@.alert2; In order to avoid death by dehydration, you are currently foraging for water on this layer, no matter the consequences.<br>
-		<<set $forageWater = 1>>
-	<</if>>
-	<<for ++$dehydrated; $dehydrated > 0; --$dehydrated>>
-		/* First check if we're drinking ward water. */
+		/* Try to drink. */
 		<<if $items[25].count >= _consumptionPerDay && ($wardWaterDrink == 1 || ($wardWaterDrink == 2 && $hexflame > 9))>>
+			/* If we're drinking ward water, use that first (regardless of foraging settings). */
 			<<set $items[25].count -= _consumptionPerDay>>
 			<<if $hexflame > 9>>
 				<<set $hexflame -= 1>>
@@ -2299,15 +2301,15 @@ How many dubloons would you like to pay back?
 					<</if>>
 			<</switch>>
 		<</if>>
+		/* Decrease the jinxed flame counter if not on layer 6. */
+		<<if $currentLayer != 6 && $hexflame > 9>>
+			<<set $hexflame -= 1>>
+		<</if>>
 	<</for>>
-	/* Decrease the jinxed flame counter if not on layer 6. */
-	<<if $currentLayer != 6 && $hexflame > 9>>
-		<<set $hexflame -= 1>>
-	<</if>>
 <</for>>
 
 /* Increase the elapsed time. */
-<<set $time += _days>>
+<<set $time += Math.round(_day / _timeDilation)>>
 
 <</capture>>
 <</widget>>

--- a/src/global.twee
+++ b/src/global.twee
@@ -1776,7 +1776,7 @@ How many dubloons would you like to pay back?
 
 :: Curse removal widget [widget nobr]
 <<widget "RemoveCurse">>
-<<capture _i, _j, _logName, _logVar, _targetCurse>>
+<<capture _i _j _logName _logVar _targetCurse>>
 
 <<set _targetCurse = _args[0]>>
 <<for _i = 0; _i < $playerCurses.length; ++_i>>
@@ -1960,7 +1960,7 @@ How many dubloons would you like to pay back?
 <</if>>
 
 /* Write to the output variable. */
-<<print "<<set " + _args[0] + " = " + _inputTime + ">>">>
+<<print `<<set ${_args[0]} = ${_inputTime}>>`>>
 
 <</widget>>
 

--- a/src/global.twee
+++ b/src/global.twee
@@ -668,7 +668,7 @@ This will also consume food/water/etc. as necessary based on your current layer.
 :: Adjust time2 [noreturn]
 <<nobr>>
 <<set _tempTime = parseInt($temp)>>
-/*<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>*/
+/*<<PassTime _tempTime>><<include "GeneralTimeFinal">>*/
 <<set $time += _tempTime>>
 <</nobr>>
 
@@ -961,7 +961,7 @@ It emits of a brigth flash of light that forces you to close your eyes, and you 
 	You have pushed yourself quite a bit, which hampers your recovery. So it takes 7 days until you feel fit enough to begin your journey once again. And your weakened condition will increase your next 3 travel times by 1 day each.
 	<<set $status.duration += 3>>\
 	<<set $status.penalty += 1>>\
-	<<set $tempTime=7>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>\
+	<<PassTime 7>><<include "GeneralTimeFinal">>\
 <<elseif $hiredCompanions.length==1>>\
 	You spend the next few days with $hiredCompanions[0].name at your side recovering, both emotionally as well as physically. $hiredCompanions[0].name helps you a lot and after a few days you start walking around a little bit again.
 	It takes 7 days until you feel fit enough to begin your journey once again.
@@ -972,7 +972,7 @@ It emits of a brigth flash of light that forces you to close your eyes, and you 
 		<<set $status.duration += 3>>\
 		<<set $status.penalty += 1>>\
 	<</if>>
-	<<set $tempTime=4>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>\
+	<<PassTime 4>><<include "GeneralTimeFinal">>\
 <<elseif $hiredCompanions.length>1>>\
 	You spend the next few days with $hiredCompanions[0].name at your side recovering, both emotionally as well as physically. Your companions help you a lot and after a few days you start walking around a little bit again.
 	It takes 7 days until you feel fit enough to begin your journey once again.
@@ -983,7 +983,7 @@ It emits of a brigth flash of light that forces you to close your eyes, and you 
 		<<set $status.duration += 3>>\
 		<<set $status.penalty += 1>>\
 	<</if>>
-	<<set $tempTime=4>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>\
+	<<PassTime 4>><<include "GeneralTimeFinal">>\
 <</if>>\
 
 [[You cast your eyes once more on the path ahead, it's time to get moving once again|_string]]
@@ -1040,7 +1040,7 @@ Cherry's medical expertise greatly aids $hiredCompanions[_temp1].name in her rec
 In the end, you don't truly resume your travels in earnest until after 7 days.
 <<set $tempTime=7>>
 <</if>>
-<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>\
+<<PassTime $tempTime>><<include "GeneralTimeFinal">>\
 
 [[You cast your eyes once more on the central location of this layer, ready to get moving again|_string]]
 
@@ -1799,7 +1799,7 @@ How many dubloons would you like to pay back?
 <</capture>>
 <</widget>>
 
-:: AdjustedTravelTime widget [widget nobr]
+:: Widgets for the passage of time [widget nobr]
 <<widget "AdjustedTravelTime">>
 /*
 	_args[0]: string       = the variable to write to, as a string (e.g. "$tempTime")
@@ -1964,18 +1964,19 @@ How many dubloons would you like to pay back?
 
 <</widget>>
 
-:: GeneralTimeStats [nobr]
-<<capture _i>>
+<<widget "PassTime">>
+<<capture _i _days>>
+<<set _days = _args[0]>>
 
 /* Check for wetting events. */
 <<if $WettingSolution == 0>>
 	<<if $playerCurses.some(e => e.name === "Urine Reamplification A") || $playerCurses.some(e => e.name === "Urine Reamplification B")>>
 		<<if $playerCurses.some(e => e.name === "Urine Reamplification A") && $playerCurses.some(e => e.name === "Urine Reamplification B")>>
-			<<set _random = random(1, Math.pow(3, $tempTime))>>
-			<<set _threshold = Math.pow(3, $tempTime) - Math.pow(2, $tempTime)>>
+			<<set _random = random(1, Math.pow(3, _days))>>
+			<<set _threshold = Math.pow(3, _days) - Math.pow(2, _days)>>
 		<<else>>
-			<<set _random = random(1, Math.pow(15, $tempTime))>>
-			<<set _threshold = Math.pow(15, $tempTime) - Math.pow(14, $tempTime)>>
+			<<set _random = random(1, Math.pow(15, _days))>>
+			<<set _threshold = Math.pow(15, _days) - Math.pow(14, _days)>>
 		<</if>>
 		<<if _random <= _threshold>>
 			<<include "Wetting Events">>
@@ -1985,54 +1986,54 @@ How many dubloons would you like to pay back?
 
 /* Check for Semen Demon events. */
 <<if $playerCurses.some(e => e.name === "Semen Demon")>>
-	<<SemenDemonCalc $tempTime>>
+	<<SemenDemonCalc _days>>
 <</if>>
 
 <<switch $currentLayer>>
 	<<case 1>>
-		<<set $timeL1 += $tempTime>>
+		<<set $timeL1 += _days>>
 	<<case 2>>
-		<<set $timeL2 += $tempTime>>
+		<<set $timeL2 += _days>>
 		/* Check if player has 10+ food rations. */
 		<<if $items[1].count >= 10>>
-			<<set $timeL2T1 += $tempTime>>
+			<<set $timeL2T1 += _days>>
 		<</if>>
 	<<case 3>>
-		<<set $timeL3 += $tempTime>>
-		<<set $timeL3T1 += $tempTime>>
+		<<set $timeL3 += _days>>
+		<<set $timeL3T1 += _days>>
 		/* Check if player has an active light source. */
 		<<if !setup.haveTravelLightSource>>
-			<<set $timeL3T2 += $tempTime>>
+			<<set $timeL3T2 += _days>>
 		<</if>>
 	<<case 4>>
-		<<set $timeL4 += $tempTime>>
-		<<set $timeL4T1 += $tempTime>>
+		<<set $timeL4 += _days>>
+		<<set $timeL4T1 += _days>>
 	<<case 5>>
-		<<set $timeL5 += $tempTime>>
+		<<set $timeL5 += _days>>
 		/* Check if player has 10+ water or filled flasks. */
 		<<if ($items[0].count + $items[3].count) >= 10>>
-			<<set $timeL5T2 += $tempTime>>
+			<<set $timeL5T2 += _days>>
 		<</if>>
-		<<set $timeL5T1 += $tempTime>>
+		<<set $timeL5T1 += _days>>
 	<<case 6>>
-		<<set $timeL6 += $tempTime>>
+		<<set $timeL6 += _days>>
 		/* Check if player has 200+ dubloons. */
 		<<if $dubloons >= 200>>
-			<<set $timeL6T2 += $tempTime>>
+			<<set $timeL6T2 += _days>>
 		<</if>>
-		<<set $timeL6T1 += $tempTime>>
+		<<set $timeL6T1 += _days>>
 		/* Add a jinxed flame counter for every day unless the player is flying. */
 		<<if !$DaedalusFly>>
-			<<set $hexflame += $tempTime>>
+			<<set $hexflame += _days>>
 		<</if>>
 	<<case 7>>
-		<<set $timeL7 += $tempTime>>
+		<<set $timeL7 += _days>>
 		/* Check if the player has fewer than 500 dubloons. */
 		<<if $dubloons < 500>>
-			<<set $timeL7T2 += $tempTime>>
+			<<set $timeL7T2 += _days>>
 		<</if>>
 		/* Subtract dubloons for every day spent on this layer. */
-		<<for _i = 0; _i < $tempTime; ++_i>>
+		<<for _i = 0; _i < _days; ++_i>>
 			<<if $dubloons >= 300>>
 				<<set $dubloons -= 1>>
 			<<elseif $dubloons >= 100>>
@@ -2042,9 +2043,9 @@ How many dubloons would you like to pay back?
 			<</if>>
 		<</for>>
 	<<case 8>>
-		<<set $timeL8 += $tempTime>>
-		<<set $timeL8T2a += $tempTime>>
-		<<set $timeL8T2b += $tempTime>>
+		<<set $timeL8 += _days>>
+		<<set $timeL8T2a += _days>>
+		<<set $timeL8T2b += _days>>
 		/* Trigger an Inanis Ego event (once per trip). */
 		<<if !$L8loopLim>>
 			<<include "Layer 8 Threat 1a">>
@@ -2060,7 +2061,7 @@ How many dubloons would you like to pay back?
 	<<set _consumptionPerDay /= 4>> /* You eat and drink a lot less than normal (your twin shares your curses). */
 <</if>>
 
-<<for _i = 0; _i < $tempTime; ++_i>>
+<<for _i = 0; _i < _days; ++_i>>
 	<<if !$forageFood && $starving > 4 && $currentLayer != 7 && $items[1].count + $items[24].count < _consumptionPerDay>>
 		@@.alert2; In order to avoid death by starvation, you are currently foraging for food on this layer, no matter the consequences.<br>
 		<<set $forageFood = 1>>
@@ -2230,7 +2231,7 @@ How many dubloons would you like to pay back?
 	<</for>>
 <</for>>
 
-<<for _i = 0; _i < $tempTime; ++_i>>
+<<for _i = 0; _i < _days; ++_i>>
 	<<if !$forageWater && $dehydrated > 1 && $currentLayer != 3 && $currentLayer != 5 && $items[0].count + $items[3].count + $items[25].count < _consumptionPerDay>>
 		@@.alert2; In order to avoid death by dehydration, you are currently foraging for water on this layer, no matter the consequences.<br>
 		<<set $forageWater = 1>>
@@ -2306,9 +2307,10 @@ How many dubloons would you like to pay back?
 <</for>>
 
 /* Increase the elapsed time. */
-<<set $time += $tempTime>>
+<<set $time += _days>>
 
 <</capture>>
+<</widget>>
 
 :: GeneralTimeFinal [nobr]
 /* Ensure that _daysOfEnergyRations is now 0. */
@@ -2429,8 +2431,7 @@ How many days would you like to rest here?
 	<<set _tempTimeWait = parseInt(_temp)>>
 
 	<<for _tempTimeWait; _tempTimeWait >0; _tempTimeWait-->>
-		<<set $tempTime = 1>>
-		<<include "GeneralTimeStats">>
+		<<PassTime 1>>
 	<</for>>
 	<<include "GeneralTimeFinal">>
 

--- a/src/global.twee
+++ b/src/global.twee
@@ -668,7 +668,7 @@ This will also consume food/water/etc. as necessary based on your current layer.
 :: Adjust time2 [noreturn]
 <<nobr>>
 <<set _tempTime = parseInt($temp)>>
-/*<<PassTime _tempTime>><<include "GeneralTimeFinal">>*/
+/*<<PassTime _tempTime>>*/
 <<set $time += _tempTime>>
 <</nobr>>
 
@@ -961,7 +961,7 @@ It emits of a brigth flash of light that forces you to close your eyes, and you 
 	You have pushed yourself quite a bit, which hampers your recovery. So it takes 7 days until you feel fit enough to begin your journey once again. And your weakened condition will increase your next 3 travel times by 1 day each.
 	<<set $status.duration += 3>>\
 	<<set $status.penalty += 1>>\
-	<<PassTime 7>><<include "GeneralTimeFinal">>\
+	<<PassTime 7>>\
 <<elseif $hiredCompanions.length==1>>\
 	You spend the next few days with $hiredCompanions[0].name at your side recovering, both emotionally as well as physically. $hiredCompanions[0].name helps you a lot and after a few days you start walking around a little bit again.
 	It takes 7 days until you feel fit enough to begin your journey once again.
@@ -972,7 +972,7 @@ It emits of a brigth flash of light that forces you to close your eyes, and you 
 		<<set $status.duration += 3>>\
 		<<set $status.penalty += 1>>\
 	<</if>>
-	<<PassTime 4>><<include "GeneralTimeFinal">>\
+	<<PassTime 4>>\
 <<elseif $hiredCompanions.length>1>>\
 	You spend the next few days with $hiredCompanions[0].name at your side recovering, both emotionally as well as physically. Your companions help you a lot and after a few days you start walking around a little bit again.
 	It takes 7 days until you feel fit enough to begin your journey once again.
@@ -983,7 +983,7 @@ It emits of a brigth flash of light that forces you to close your eyes, and you 
 		<<set $status.duration += 3>>\
 		<<set $status.penalty += 1>>\
 	<</if>>
-	<<PassTime 4>><<include "GeneralTimeFinal">>\
+	<<PassTime 4>>\
 <</if>>\
 
 [[You cast your eyes once more on the path ahead, it's time to get moving once again|_string]]
@@ -1040,7 +1040,7 @@ Cherry's medical expertise greatly aids $hiredCompanions[_temp1].name in her rec
 In the end, you don't truly resume your travels in earnest until after 7 days.
 <<set $tempTime=7>>
 <</if>>
-<<PassTime $tempTime>><<include "GeneralTimeFinal">>\
+<<PassTime $tempTime>>\
 
 [[You cast your eyes once more on the central location of this layer, ready to get moving again|_string]]
 
@@ -1855,10 +1855,12 @@ How many dubloons would you like to pay back?
 			<<set _additiveModifier -= 2>>
 		<<elseif $torchUse == 1 && $items[9].count > 0>>
 			<<set _additiveModifier -= 2>>
-			/* Decrement number of torches and stop using torches if the count is now 0. */
-			<<set $items[9].count -= 1>>
-			<<if $items[9].count < 1>>
-				<<set $torchUse = 0>>
+			<<if !_args[2]>>
+				/* Decrement number of torches and stop using torches if the count is now 0. */
+				<<set $items[9].count -= 1>>
+				<<if $items[9].count < 1>>
+					<<set $torchUse = 0>>
+				<</if>>
 			<</if>>
 		<<elseif $playerCurses.some(e => e.name === "Cold Blooded")>>
 			/* Apply Cold Blooded curse penalty. */
@@ -1908,10 +1910,9 @@ How many dubloons would you like to pay back?
 		Your exceptional physical condition is reducing your travel time.<br>
 		<<set _multiplicativeModifier /= 1 + $app.HandicapMovement / 10>>
 	<</if>>
-	/* Halve travel time if player has the Aeonglass with Endless Time relic active. */
+	/* Print a message if the Aeonglass with Endless Time relic is causing time dilation, but don't handle it here. */
 	<<if $EndlessAeonglass>>
 		The enhanced Aeonglass, shimmering with a timeless aura, grants you the remarkable ability to reduce your travel time by half.<br>
-		<<set _multiplicativeModifier /= 2>>
 	<</if>>
 	/* Apply the multiplicative modifiers. */
 	<<set _inputTime *= _multiplicativeModifier>>
@@ -1965,29 +1966,52 @@ How many dubloons would you like to pay back?
 <</widget>>
 
 <<widget "PassTime">>
-<<capture _consumptionPerDay _day _days _i _random _threshold _timeDilation>>
-<<set _days = _args[0]>>
-<<set _timeDilation = 1>>
+<<capture _consumptionPerDay _doneVar _passage _random _state _threshold _timeWeight _triggers>>
+<<set _triggers = _args[1] ?? {}>> /* The event triggers, if any. */
+<<set _doneVar = _args[2]>> /* The variable to write to if we don't break early. */
 
-/* Check for wetting events. */
-<<if $WettingSolution == 0>>
-	<<if $playerCurses.some(e => e.name === "Urine Reamplification A") || $playerCurses.some(e => e.name === "Urine Reamplification B")>>
-		<<if $playerCurses.some(e => e.name === "Urine Reamplification A") && $playerCurses.some(e => e.name === "Urine Reamplification B")>>
-			<<set _random = random(1, Math.pow(3, _days))>>
-			<<set _threshold = Math.pow(3, _days) - Math.pow(2, _days)>>
-		<<else>>
-			<<set _random = random(1, Math.pow(15, _days))>>
-			<<set _threshold = Math.pow(15, _days) - Math.pow(14, _days)>>
-		<</if>>
-		<<if _random <= _threshold>>
-			<<include "Wetting Events">>
+/* Let the caller know that we aren't done. */
+<<if _doneVar>><<print `<<set ${_doneVar} = false>>`>><</if>>
+
+/* Get the persistent state. */
+<<set _passage = passage()>>
+<<set $passTimeState ??= new Map()>>
+<<if $passTimeState.has(_passage)>>
+	/* We already have state for this passage, so use it. */
+	<<set _state = $passTimeState.get(_passage)>>
+<<else>>
+	/* Add new state for this passage. */
+	<<set _state = {
+		expectedDays: _args[0], /* The number of days of time to pass, modulo the time weight. */
+		unweightedDayIndex: 0,
+		weightedDayIndex: 0,
+		unweightedDay: 0,
+		weightedDay: 0,
+		nextRealDay: 0,
+		energy: _daysOfEnergyRations ?? 0,
+	}>>
+	<<set $passTimeState.set(_passage, _state)>>
+
+	/* Check for wetting events. */
+	<<if $WettingSolution == 0>>
+		<<if $playerCurses.some(e => e.name === "Urine Reamplification A") || $playerCurses.some(e => e.name === "Urine Reamplification B")>>
+			<<if $playerCurses.some(e => e.name === "Urine Reamplification A") && $playerCurses.some(e => e.name === "Urine Reamplification B")>>
+				<<set _random = random(1, Math.pow(3, _days))>>
+				<<set _threshold = Math.pow(3, _days) - Math.pow(2, _days)>>
+			<<else>>
+				<<set _random = random(1, Math.pow(15, _days))>>
+				<<set _threshold = Math.pow(15, _days) - Math.pow(14, _days)>>
+			<</if>>
+			<<if _random <= _threshold>>
+				<<include "Wetting Events">>
+			<</if>>
 		<</if>>
 	<</if>>
-<</if>>
 
-/* Check for Semen Demon events. */
-<<if $playerCurses.some(e => e.name === "Semen Demon")>>
-	<<SemenDemonCalc _days>>
+	/* Check for Semen Demon events. */
+	<<if $playerCurses.some(e => e.name === "Semen Demon")>>
+		<<SemenDemonCalc _days>>
+	<</if>>
 <</if>>
 
 /* Calculate the amount of food and drink that needs to be consumed per day. */
@@ -1999,7 +2023,15 @@ How many dubloons would you like to pay back?
 	<<set _consumptionPerDay /= 4>> /* You eat and drink a lot less than normal (your twin shares your curses). */
 <</if>>
 
-<<for _i = 0, _day = 0; _i < _days; ++_i>>
+/* Set time weight to 1/2 if the Aeonglass with Endless Time relic is active. */
+<<set _timeWeight = $EndlessAeonglass ? 1/2 : 1>>
+
+<<set _breakForEvent = false>>
+<<for _state.unweightedDayIndex < _state.expectedDays>>
+	/* Increment the day index. We only break out of the inner loop because we're sated, can't eat/drink or */
+	/* because an event is about to happen. An event might interrupt our attempts to decrease starvation or */
+	/* dehydration, but that's okay - we'll try again during the next trip. */
+	<<set _state.unweightedDayIndex += 1, _state.weightedDayIndex += _timeWeight>>
 	/* Check whether we need to be foraging for food to avoid dying of starvation. */
 	<<if !$forageFood && $starving > 4 && $currentLayer != 7 && $items[1].count + $items[24].count < _consumptionPerDay>>
 		@@.alert2; In order to avoid death by starvation, you are currently foraging for food on this layer, no matter the consequences.<br>
@@ -2012,9 +2044,15 @@ How many dubloons would you like to pay back?
 	<</if>>
 	/* Starvation and dehydration go up by 1 every day. If the player is starving */
 	/* or dehydrated, assume that they will stop to forage until they are sated. */
-	<<for ++$starving, ++$dehydrated; $starving > 0 || $dehydrated > 0; --$starving, --$dehydrated, ++_day>>
-		/* Adjust layer-specific state. */
-		<<if (_day % _timeDilation) == 0>>
+	<<set $starving += 1, $dehydrated += 1>>
+	<<for $starving > 0 || $dehydrated > 0>>
+		/* Increment the actual day. */
+		<<set _state.unweightedDay += 1, _state.weightedDay += _timeWeight>>
+		/* Check if a real day passed. */
+		<<if _state.weightedDay >= _state.nextRealDay>>
+			/* Adjust the overall time. */
+			<<set $time += 1>>
+			/* Adjust layer-specific state. */
 			<<switch $currentLayer>>
 				<<case 1>>
 					<<set $timeL1 += 1>>
@@ -2070,17 +2108,19 @@ How many dubloons would you like to pay back?
 					<<set $timeL8 += 1>>
 					<<set $timeL8T2a += 1>>
 					<<set $timeL8T2b += 1>>
-					/* Trigger an Inanis Ego event (once per trip). */
+					/* Trigger an Inanis Ego event (once per event trigger). */
 					<<if !$L8loopLim>>
 						<<include "Layer 8 Threat 1a">>
+						<<set $L8loopLim = true>>
 					<</if>>
 			<</switch>>
 		<</if>>
 		/* Try to eat. */
-		<<if _daysOfEnergyRations > 0>>
+		<<set _ate = true>>
+		<<if _state.energy > 0>>
 			/* If we used energy rations to speed up travel, use those first (regardless of foraging settings). */
 			<<set $items[24].count -= _consumptionPerDay>>
-			<<set _daysOfEnergyRations -= 1>>
+			<<set _state.energy -= 1>>
 		<<elseif !$forageFood>>
 			<<if $items[1].count >= _consumptionPerDay>>
 				<<set $items[1].count -= _consumptionPerDay>>
@@ -2088,7 +2128,7 @@ How many dubloons would you like to pay back?
 				<<set $items[24].count -= _consumptionPerDay - $items[1].count>>
 				<<set $items[1].count = 0>>
 			<<else>>
-				<<break>>
+				<<set _ate = false>>
 			<</if>>
 		<<elseif !$abyssKnow>>
 			<<switch $currentLayer>>
@@ -2127,7 +2167,7 @@ How many dubloons would you like to pay back?
 							<<set $items[24].count -= _consumptionPerDay - $items[1].count>>
 							<<set $items[1].count = 0>>
 						<<else>>
-							<<break>>
+							<<set _ate = false>>
 						<</if>>
 					<</if>>
 				<<case 5>>
@@ -2147,7 +2187,7 @@ How many dubloons would you like to pay back?
 							<<set $items[24].count -= _consumptionPerDay - $items[1].count>>
 							<<set $items[1].count = 0>>
 						<<else>>
-							<<break>>
+							<<set _ate = false>>
 						<</if>>
 					<</if>>
 				<<case 7>>
@@ -2158,7 +2198,7 @@ How many dubloons would you like to pay back?
 						<<set $items[24].count -= _consumptionPerDay - $items[1].count>>
 						<<set $items[1].count = 0>>
 					<<else>>
-						<<break>>
+						<<set _ate = false>>
 					<</if>>
 				<<case 8>>
 					<<set $foodL8 += 1>>
@@ -2176,10 +2216,10 @@ How many dubloons would you like to pay back?
 						<<elseif $items[13].count && $items[20].count >= 1>>
 							<<set $items[20].count -= 1>>
 						<<else>>
-							<<set $lastFlan = $time + Math.round(_day / _timeDilation)>>
+							<<set $lastFlan = $time>>
 						<</if>>
 					<<else>>
-						<<set $lastFlan = $time + Math.round(_day / _timeDilation)>>
+						<<set $lastFlan = $time>>
 					<</if>>
 				<<case 3>>
 					<<set $foodL3 += 1>>
@@ -2200,7 +2240,7 @@ How many dubloons would you like to pay back?
 							<<set $items[24].count -= _consumptionPerDay - $items[1].count>>
 							<<set $items[1].count = 0>>
 						<<else>>
-							<<break>>
+							<<set _ate = false>>
 						<</if>>
 					<</if>>
 				<<case 5>>
@@ -2220,7 +2260,7 @@ How many dubloons would you like to pay back?
 							<<set $items[24].count -= _consumptionPerDay - $items[1].count>>
 							<<set $items[1].count = 0>>
 						<<else>>
-							<<break>>
+							<<set _ate = false>>
 						<</if>>
 					<</if>>
 				<<case 7>>
@@ -2231,14 +2271,16 @@ How many dubloons would you like to pay back?
 						<<set $items[24].count -= _consumptionPerDay - $items[1].count>>
 						<<set $items[1].count = 0>>
 					<<else>>
-						<<break>>
+						<<set _ate = false>>
 					<</if>>
 				<<case 8>>
 					<<set $foodL8 += 1>>
 					<<set $LibidoLog.push($ForageFoodMinor)>>
 			<</switch>>
 		<</if>>
+		<<if _ate>><<set $starving -= 1>><</if>>
 		/* Try to drink. */
+		<<set _drank = true>>
 		<<if $items[25].count >= _consumptionPerDay && ($wardWaterDrink == 1 || ($wardWaterDrink == 2 && $hexflame > 9))>>
 			/* If we're drinking ward water, use that first (regardless of foraging settings). */
 			<<set $items[25].count -= _consumptionPerDay>>
@@ -2246,7 +2288,7 @@ How many dubloons would you like to pay back?
 				<<set $hexflame -= 1>>
 			<</if>>
 		<<elseif !$forageWater>>
-			<<include "Drinking code">><<if !_drank>><<break>><</if>>
+			<<include "Drinking code">>
 		<<elseif !$abyssKnow>>
 			<<switch $currentLayer>>
 				<<case 1>>
@@ -2256,19 +2298,19 @@ How many dubloons would you like to pay back?
 					<<set $waterL2 += 1>>
 					<<set $bewitchBabies += 1>>
 				<<case 3>>
-					<<include "Drinking code">><<if !_drank>><<break>><</if>>
+					<<include "Drinking code">>
 				<<case 4>>
 					<<set $waterL4 += 1>>
 					<<set $algalSize += 1>>
 				<<case 5>>
-					<<include "Drinking code">><<if !_drank>><<break>><</if>>
+					<<include "Drinking code">>
 				<<case 6>>
 					<<set $waterL6 += 1>>
 					<<if !($hiredCompanions.some(e => e.name === "Saeko") && setup.haveSmartphone)>>
 						<<set $hexflame += 1>>
 					<</if>>
 				<<case 7>>
-					<<include "Drinking code">><<if !_drank>><<break>><</if>>
+					<<include "Drinking code">>
 				<<case 8>>
 					<<set $waterL8 += 1>>
 					<<set $IQdrop += 0.5>>
@@ -2280,18 +2322,18 @@ How many dubloons would you like to pay back?
 				<<case 2>>
 					<<set $waterL2 += 1>>
 				<<case 3>>
-					<<include "Drinking code">><<if !_drank>><<break>><</if>>
+					<<include "Drinking code">>
 				<<case 4>>
 					<<set $waterL4 += 1>>
 				<<case 5>>
-					<<include "Drinking code">><<if !_drank>><<break>><</if>>
+					<<include "Drinking code">>
 				<<case 6>>
 					<<set $waterL6 += 1>>
 					<<if !($hiredCompanions.some(e => e.name === "Saeko") && setup.haveSmartphone)>>
 						<<set $hexflame += 1>>
 					<</if>>
 				<<case 7>>
-					<<include "Drinking code">><<if !_drank>><<break>><</if>>
+					<<include "Drinking code">>
 				<<case 8>>
 					<<set $waterL8 += 1>>
 					<<if !($hiredCompanions.some(e => e.name === "Saeko") && setup.haveSmartphone)>>
@@ -2301,35 +2343,58 @@ How many dubloons would you like to pay back?
 					<</if>>
 			<</switch>>
 		<</if>>
+		<<if _drank>><<set $dehydrated -= 1>><</if>>
 		/* Decrease the jinxed flame counter if not on layer 6. */
 		<<if $currentLayer != 6 && $hexflame > 9>>
 			<<set $hexflame -= 1>>
 		<</if>>
+		<<if _state.weightedDay >= _state.nextRealDay>>
+			/* Increment the next real day. */
+			<<set _state.nextRealDay += 1>>
+			/* Check event triggers. */
+			<<if Object.values(_triggers).some(trigger => trigger())>>
+				<<set _breakForEvent = true>>
+			<</if>>
+		<</if>>
+		<<if !_drank || !_ate || _breakForEvent>><<break>><</if>>
 	<</for>>
+	/* Check if we need to stop to let an event happen. */
+	<<if _breakForEvent>><<break>><</if>>
 <</for>>
 
-/* Increase the elapsed time. */
-<<set $time += Math.round(_day / _timeDilation)>>
+<<if !_breakForEvent>>
+	/* Remove the persistent state for this passage. */
+	<<set $passTimeState.delete(_passage)>>
+
+	/* Let the caller know that we're done. */
+	<<if _doneVar>><<print `<<set ${_doneVar} = true>>`>><</if>>
+
+	/* Print a notice if travel time was longer than predicted due to starvation or dehydration. */
+	<<if Math.round(_state.weightedDay) > Math.round(_state.weightedDayIndex)>>
+		Desperate to stave off starvation and dehydration, you spent an extra
+		<<print Math.round(_state.weightedDay) - Math.round(_state.weightedDayIndex)>>
+		days foraging, extending the time spent to <<print Math.round(_state.weightedDay)>> days!
+	<</if>>
+
+	/* If we ended on a fractional day that should be rounded up, increment the time. */
+	<<if Math.round(_state.weightedDay) > _state.weightedDay>><<set $time += 1>><</if>>
+
+	/* Ensure that we aren't left with a fractional number of rations. */
+	<<set $items[1].count = Math.floor($items[1].count)>>
+	<<set $items[24].count = Math.floor($items[24].count)>>
+
+	/* Ensure that we aren't left with a fractional amount of water. */
+	<<set $items[0].count = Math.floor($items[0].count)>>
+	<<set $items[2].count = Math.ceil($items[2].count)>> /* Empty flasks */
+	<<set $items[3].count = Math.floor($items[3].count)>>
+	<<set $items[25].count = Math.floor($items[25].count)>>
+	<<for _i = 0; _i < $flaskMatrix.length; ++_i>>
+		<<set $flaskMatrix[_i] = Math.floor($flaskMatrix[_i])>>
+	<</for>>
+<</if>>
 
 <</capture>>
 <</widget>>
-
-:: GeneralTimeFinal [nobr]
-/* Ensure that _daysOfEnergyRations is now 0. */
-<<set _daysOfEnergyRations = 0>>
-
-/* Ensure that we aren't left with a fractional number of rations. */
-<<set $items[1].count = Math.floor($items[1].count)>>
-<<set $items[24].count = Math.floor($items[24].count)>>
-
-/* Ensure that we aren't left with a fractional amount of water. */
-<<set $items[0].count = Math.floor($items[0].count)>>
-<<set $items[2].count = Math.ceil($items[2].count)>> /* Empty flasks */
-<<set $items[3].count = Math.floor($items[3].count)>>
-<<set $items[25].count = Math.floor($items[25].count)>>
-<<for _i = 0; _i < $flaskMatrix.length; ++_i>>
-	<<set $flaskMatrix[_i] = Math.floor($flaskMatrix[_i])>>
-<</for>>
 
 :: Drinking code [nobr]
 <<FlaskFirst>>
@@ -2364,13 +2429,11 @@ How many dubloons would you like to pay back?
 			<<set $corruption -= 1>>
 		<</if>>
 	<</if>>
-	<<set _drank = true>>
 <<elseif $items[25].count >= _consumptionPerDay>>
 	<<set $items[25].count -= _consumptionPerDay>>
 	<<if $hexflame > 9>>
 		<<set $hexflame -= 1>>
 	<</if>>
-	<<set _drank = true>>
 <<else>>
 	<<set _drank = false>>
 <</if>>
@@ -2427,16 +2490,9 @@ $flaskMatrixLabel[$flaskPref] ($flaskMatrix[$flaskPref] remaining)
 You can set up camp and rest here for a while before continuing your journey. You still need to eat and drink and the layer's threats continue to loom over you even as you rest. This won't accomplish much on its own, but if you'd like to spend some time sampling the local cuisine or studying this layer's threats, then this could be a good way to do that. 
 
 How many days would you like to rest here?
-<<set _string = "Layer" + $currentLayer + " Hub" >>
 <<textbox "_temp" "0">>
-<<nobr>><<link "Set up camp and wait" _string>>
-	<<set _tempTimeWait = parseInt(_temp)>>
-
-	<<for _tempTimeWait; _tempTimeWait >0; _tempTimeWait-->>
-		<<PassTime 1>>
-	<</for>>
-	<<include "GeneralTimeFinal">>
-
+<<nobr>><<link "Set up camp and wait" `"Layer" + $currentLayer + " Hub"`>>
+	<<PassTime `parseInt(_temp, 10)`>>
 <</link>><</nobr>>
 
 :: Curse Descriptions

--- a/src/init.twee
+++ b/src/init.twee
@@ -108,6 +108,7 @@ document.documentElement.setAttribute("lang", "en");
 <<set $steadyForced = 0>>
 <<set $layerExit = 0>>
 <<set $layerExitTime = 0>>
+<<set $passTimeState = new Map()>>
 <<set $riverVisit = 0>>
 <<set $cut = 0>>
 <<set $light = 0>>

--- a/src/layer1.twee
+++ b/src/layer1.twee
@@ -944,7 +944,7 @@ But gradually, a newfound certainty washes over you - the realization that your 
 <<nobr>>
 <<set $corruption -= $playerCurses[$temp].corr>>
 <<set $iconUsed = 1>>
-<<AdjustedTravelTime "$tempTime" 3>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" 3>><<PassTime $tempTime>>
 The Curse, $playerCurses[$temp].name, has been successfully removed and your corruption has been refunded.<br>
 <<RemoveCurse $playerCurses[$temp]>>
 <</nobr>>
@@ -977,14 +977,10 @@ Traveling back to the surface from here will take 1 day, and will cost 10 corrup
 <</if>>
 <<if $layerExit == 0>>
 	<<set $layerExit = 1>>
-	<<AdjustedTravelTime "$tempTime" 1>>
-	<<set $layerExitTime=$tempTime>>
+	<<AdjustedTravelTime "$layerExitTime" 1>>
 <</if>>
 
-<<for $layerExitTime; $layerExitTime >0; $layerExitTime-->>
-	<<PassTime 1>>
-<</for>>
-<<include "GeneralTimeFinal">>
+<<PassTime $layerExitTime>>
 
 <<set $corruption -= (10 - $corRed)>>
 

--- a/src/layer1.twee
+++ b/src/layer1.twee
@@ -944,7 +944,7 @@ But gradually, a newfound certainty washes over you - the realization that your 
 <<nobr>>
 <<set $corruption -= $playerCurses[$temp].corr>>
 <<set $iconUsed = 1>>
-<<AdjustedTravelTime "$tempTime" 3>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" 3>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
 The Curse, $playerCurses[$temp].name, has been successfully removed and your corruption has been refunded.<br>
 <<RemoveCurse $playerCurses[$temp]>>
 <</nobr>>
@@ -982,8 +982,7 @@ Traveling back to the surface from here will take 1 day, and will cost 10 corrup
 <</if>>
 
 <<for $layerExitTime; $layerExitTime >0; $layerExitTime-->>
-	<<set $tempTime=1>>
-	<<include "GeneralTimeStats">>
+	<<PassTime 1>>
 <</for>>
 <<include "GeneralTimeFinal">>
 

--- a/src/layer2.twee
+++ b/src/layer2.twee
@@ -1,7 +1,7 @@
 :: Layer2 1 [layer2]
 <<nobr>>
 <<masteraudio stop>><<audio "layer2" volume 0.2 play loop>>
-<<AdjustedTravelTime "$tempTime" 2>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" 2>><<PassTime $tempTime>>
 <<set $timeL2T1 = 0>>
 <<set $currentLayer = 2>>
 <</nobr>>\
@@ -527,7 +527,7 @@ What type of fur would you like to gain?
 <<nobr>>
 <<set $corruption += 100>>
 <<set $brokerUsed = 1>>
-<<AdjustedTravelTime "$tempTime" 2>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" 2>><<PassTime $tempTime>>
 <</nobr>>
 [img[setup.ImagePath+'Wonders/empty-handedbroker.png']]
 
@@ -575,7 +575,7 @@ Whose body do you find yourself in?
 <<set $corruption += 70>>
 <<set $starUsed = 1>>
 <<set $swapComp = $temp>>
-<<AdjustedTravelTime "$tempTime" 3>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" 3>><<PassTime $tempTime>>
 <<set $hiredCompanions[$swapComp].carry = $temp2>>
 <<CarryAdjust>>
 <<set _companionSwapHandle = $hiredCompanions[$swapComp]>>
@@ -1416,29 +1416,27 @@ A few tests and you can confirm you have pure water to fill your flasks with! No
 <<nobr>>
 <<if $layerExit == 0>>
 	<<set $layerExit = 1>>
-	<<AdjustedTravelTime "$tempTime" 5>>
-	<<set $layerExitTime=$tempTime>>
+	<<AdjustedTravelTime "$layerExitTime" 5>>
 <</if>>
+<<set _triggers = {
+	bayingGourmet: () => $timeL2T1 > 3 && $hiredCompanions.length < 4,
+}>>
 
-<<for $layerExitTime; $layerExitTime >0; $layerExitTime-->>
-	<<PassTime 1>>
+<<PassTime $layerExitTime _triggers "_done">>
 
-	<<if $timeL2T1 > 3 && $hiredCompanions.length < 4>>
+<<if _triggers.bayingGourmet()>>
 	Suddenly, you hear a deep, guttural growl that echoes through the layer. A shiver runs down your spine as you recognize it as the ominous call of the Baying Gourmet. The very ground beneath you seems to tremble with anticipation, and a sense of dread washes over you. You clutch your belongings closer, acutely aware of the abundance of food rations you carry.<br><br>
 
-	[[Deal with the Baying Gourmet|Layer2 Threat1][$returnPassage = "Layer2 Exit2"]]
-		<<set $layerExitTime -= 1>><<break>>
-	<</if>>
-	
-<</for>>
-<<include "GeneralTimeFinal">>
+	[[Deal with the Baying Gourmet|Layer2 Threat1][$returnPassage = passage()]]<br>
+<</if>>
 
-<</nobr>><<if $layerExitTime == 0 && !($timeL2T1 > 3 && $hiredCompanions.length < 4)>>
+<</nobr>><<if _done>>
 Subtle changes in your surroundings continue, large rocks start to appear in your path, and the entire terrain changes from the lush rainforest you previously found yourself in to a more temperate forest. But slowly the trees become more sparse and the rocks become more common.
 
 <<include "Curse Descriptions">>
 
-[[Enter the deep caverns|Layer3 1]]<</if>>
+[[Enter the deep caverns|Layer3 1]]
+<</if>>
 
 :: Layer2 Ascend2 [layer2]
 <<nobr>>
@@ -1451,24 +1449,21 @@ Subtle changes in your surroundings continue, large rocks start to appear in you
 	<<if $DaedalusFly==true>>
 		<<set $tempTime= Math.ceil($tempTime/2)>>
 	<</if>>
-	<<AdjustedTravelTime "$tempTime" $tempTime>>
-	<<set $layerExitTime=$tempTime>>
+	<<AdjustedTravelTime "$layerExitTime" $tempTime>>
 <</if>>
-<<for $layerExitTime; $layerExitTime >0; $layerExitTime-->>
-	<<PassTime 1>>
+<<set _triggers = {
+	bayingGourmet: () => $timeL2T1 > 3 && $hiredCompanions.length < 4,
+}>>
 
-	<<if $timeL2T1 > 3 && $hiredCompanions.length < 4>>
-		Suddenly, you hear a deep, guttural growl that echoes through the layer. A shiver runs down your spine as you recognize it as the ominous call of the Baying Gourmet. The very ground beneath you seems to tremble with anticipation, and a sense of dread washes over you. You clutch your belongings closer, acutely aware of the abundance of food rations you carry.<br><br>
+<<PassTime $layerExitTime _triggers "_done">>
 
-		[[Deal with the Baying Gourmet|Layer2 Threat1][$returnPassage = "Layer2 Ascend2"]]<br>
-		<<set $layerExitTime -= 1>><<break>>
-	<</if>>
+<<if _triggers.bayingGourmet()>>
+	Suddenly, you hear a deep, guttural growl that echoes through the layer. A shiver runs down your spine as you recognize it as the ominous call of the Baying Gourmet. The very ground beneath you seems to tremble with anticipation, and a sense of dread washes over you. You clutch your belongings closer, acutely aware of the abundance of food rations you carry.<br><br>
 
-<</for>>
-<<include "GeneralTimeFinal">>
+	[[Deal with the Baying Gourmet|Layer2 Threat1][$returnPassage = passage()]]<br>
+<</if>>
 
-
-<</nobr>><<if $layerExitTime == 0 && !($timeL2T1 > 3 && $hiredCompanions.length < 4)>>
+<</nobr>><<if _done>>
 <<nobr>>
 <<set $corruption -= (15 - $corRed)>>
 <</nobr>>

--- a/src/layer2.twee
+++ b/src/layer2.twee
@@ -1,7 +1,7 @@
 :: Layer2 1 [layer2]
 <<nobr>>
 <<masteraudio stop>><<audio "layer2" volume 0.2 play loop>>
-<<AdjustedTravelTime "$tempTime" 2>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" 2>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
 <<set $timeL2T1 = 0>>
 <<set $currentLayer = 2>>
 <</nobr>>\
@@ -527,7 +527,7 @@ What type of fur would you like to gain?
 <<nobr>>
 <<set $corruption += 100>>
 <<set $brokerUsed = 1>>
-<<AdjustedTravelTime "$tempTime" 2>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" 2>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
 <</nobr>>
 [img[setup.ImagePath+'Wonders/empty-handedbroker.png']]
 
@@ -575,7 +575,7 @@ Whose body do you find yourself in?
 <<set $corruption += 70>>
 <<set $starUsed = 1>>
 <<set $swapComp = $temp>>
-<<AdjustedTravelTime "$tempTime" 3>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" 3>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
 <<set $hiredCompanions[$swapComp].carry = $temp2>>
 <<CarryAdjust>>
 <<set _companionSwapHandle = $hiredCompanions[$swapComp]>>
@@ -1421,9 +1421,7 @@ A few tests and you can confirm you have pure water to fill your flasks with! No
 <</if>>
 
 <<for $layerExitTime; $layerExitTime >0; $layerExitTime-->>
-
-	<<set $tempTime = 1>>
-	<<include "GeneralTimeStats">>
+	<<PassTime 1>>
 
 	<<if $timeL2T1 > 3 && $hiredCompanions.length < 4>>
 	Suddenly, you hear a deep, guttural growl that echoes through the layer. A shiver runs down your spine as you recognize it as the ominous call of the Baying Gourmet. The very ground beneath you seems to tremble with anticipation, and a sense of dread washes over you. You clutch your belongings closer, acutely aware of the abundance of food rations you carry.<br><br>
@@ -1457,9 +1455,7 @@ Subtle changes in your surroundings continue, large rocks start to appear in you
 	<<set $layerExitTime=$tempTime>>
 <</if>>
 <<for $layerExitTime; $layerExitTime >0; $layerExitTime-->>
-
-	<<set $tempTime=1>>
-	<<include "GeneralTimeStats">>
+	<<PassTime 1>>
 
 	<<if $timeL2T1 > 3 && $hiredCompanions.length < 4>>
 		Suddenly, you hear a deep, guttural growl that echoes through the layer. A shiver runs down your spine as you recognize it as the ominous call of the Baying Gourmet. The very ground beneath you seems to tremble with anticipation, and a sense of dread washes over you. You clutch your belongings closer, acutely aware of the abundance of food rations you carry.<br><br>

--- a/src/layer3.twee
+++ b/src/layer3.twee
@@ -200,11 +200,11 @@ You have already used the scales on your journey. You may not use them again.
 <<elseif $skewedForced < 4>>
 	Would you like to use the Skewed Shrine to give a Curse to one of your willing companions at the cost of <<print ($skewedUsed * 5)>> dubloons?<br>
 	<<link "Yes, use the Skewed Shrine to transfer a Curse" "Layer3 Skewed1a">>
-		<<AdjustedTravelTime "$tempTime" 3>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+		<<AdjustedTravelTime "$tempTime" 3>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
 	<</link>><br><br>
 	Would you like to use the Skewed Shrine to force a Curse upon one of your unwilling companions at the cost of <<print ($skewedUsed * 5)>> dubloons?<br>
 	<<link "Yes, use the Skewed Shrine to force a Curse" "Layer3 Skewed 2a">>
-		<<AdjustedTravelTime "$tempTime" 3>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+		<<AdjustedTravelTime "$tempTime" 3>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
 	<</link>><br><br>
 <<else>>
 	None of your companions trust you at this shrine anymore. None will get close enough for you to use the shrine with them. They watch you with eyes full of fear and anger, as if they could bolt at any moment and leave you alone in the Abyss.<br><br>
@@ -272,8 +272,7 @@ In the deeper parts of the layer, a cold breeze occasionally blows through the c
 <</if>>
 
 <<for $layerExitTime; $layerExitTime >0; $layerExitTime-->>
-	<<set $tempTime=1>>
-	<<include "GeneralTimeStats">>	
+	<<PassTime 1>>
 /* 		<<set $timeL3T1 += 1>>
 	<<if !setup.haveTravelLightSource>>
 		<<set $timeL3T2 += 1>>
@@ -342,7 +341,7 @@ In the deeper parts of the layer, a cold breeze occasionally blows through the c
 <<set $temp = Math.round($corruption / 5)>>
 <<set $dubloons += $temp>>
 <<set $scalesUsed = 1>>
-<<AdjustedTravelTime "$tempTime" 2>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" 2>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
 <</nobr>>
 [img[setup.ImagePath+'Wonders/gossameryscales.png']]
 
@@ -358,7 +357,7 @@ Once you pick them up, the luster of the scales fades, indicating that they will
 <<set $temp = Math.round($dubloons / 5)>>
 <<set $corruption += $temp>>
 <<set $scalesUsed = 1>>
-<<AdjustedTravelTime "$tempTime" 2>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" 2>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
 <</nobr>>
 [img[setup.ImagePath+'Wonders/gossameryscales.png']]
 
@@ -851,7 +850,7 @@ On the other hand, the idea of each encounter feeling like your first time holds
 <<set $tempTime = (Math.max(4 -$abyssKnow - $riverVisit, 0))>>
 <<set $riverVisit = 1>>
 
-<<AdjustedTravelTime "$tempTime" $tempTime>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" $tempTime>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
 
 <<for _i = 0; _i < 999; _i++>>
 	<<if $items[2].count > 0>>
@@ -1278,9 +1277,7 @@ Please enter your new skin/eye color:
 <</if>>
 
 <<for $layerExitTime; $layerExitTime >0; $layerExitTime-->>
-
-	<<set $tempTime = 1>>
-	<<include "GeneralTimeStats">>
+	<<PassTime 1>>
 	/* 
 	<<if $forageWater == 0>>
 		<<if $items[3].count > 0>>

--- a/src/layer3.twee
+++ b/src/layer3.twee
@@ -408,7 +408,7 @@ Which Curse would you like to transfer to your willing companion? It can't be to
 			<</switch>>
 
 			<<if _flag>>
-				<<capture _companion, _curse, _tempName>>
+				<<capture _companion _curse _tempName>>
 					&nbsp; _curse.name
 					<<link "Choose" "Layer3 Skewed1a">>
 						<<set _companion.curses.push(_curse)>>
@@ -899,7 +899,7 @@ The magic of the shrine wisps through the air menacingly as your victim struggle
 	<</switch>>
 
 	<<if _flag>>
-		<<capture _companion, _tempName>>
+		<<capture _companion _tempName>>
 			<<set _choiceText = "Transfer to " + _tempName>>
 			<<link _choiceText "Layer3 Skewed Apply">>
 				<<set _companion.curses.push(_curse)>>

--- a/src/layer3.twee
+++ b/src/layer3.twee
@@ -200,11 +200,11 @@ You have already used the scales on your journey. You may not use them again.
 <<elseif $skewedForced < 4>>
 	Would you like to use the Skewed Shrine to give a Curse to one of your willing companions at the cost of <<print ($skewedUsed * 5)>> dubloons?<br>
 	<<link "Yes, use the Skewed Shrine to transfer a Curse" "Layer3 Skewed1a">>
-		<<AdjustedTravelTime "$tempTime" 3>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
+		<<AdjustedTravelTime "$tempTime" 3>><<PassTime $tempTime>>
 	<</link>><br><br>
 	Would you like to use the Skewed Shrine to force a Curse upon one of your unwilling companions at the cost of <<print ($skewedUsed * 5)>> dubloons?<br>
 	<<link "Yes, use the Skewed Shrine to force a Curse" "Layer3 Skewed 2a">>
-		<<AdjustedTravelTime "$tempTime" 3>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
+		<<AdjustedTravelTime "$tempTime" 3>><<PassTime $tempTime>>
 	<</link>><br><br>
 <<else>>
 	None of your companions trust you at this shrine anymore. None will get close enough for you to use the shrine with them. They watch you with eyes full of fear and anger, as if they could bolt at any moment and leave you alone in the Abyss.<br><br>
@@ -267,65 +267,28 @@ In the deeper parts of the layer, a cold breeze occasionally blows through the c
 	<<if $DaedalusFly==true>>
 		<<set $tempTime= Math.ceil($tempTime/2)>>
 	<</if>>
-	<<AdjustedTravelTime "$tempTime" $tempTime>>
-	<<set $layerExitTime=$tempTime>>
+	<<AdjustedTravelTime "$layerExitTime" $tempTime>>
+<</if>>
+<<set _triggers = {
+	lesserTentacleBeast: () => $timeL3T1 > 5,
+	slackslime: () => $timeL3T2 > 4,
+}>>
+
+<<PassTime $layerExitTime _triggers "_done">>
+
+<<if _triggers.lesserTentacleBeast()>>
+	<br><<include "Layer3 Tentacle Encounter">><br><br>
+
+	[[Deal with the lesser tentacle beast|Layer3 Threat1][$returnPassage = passage()]]<br>
+	<<set _breakForEvent = true>>
+<<elseif _triggers.slackslime()>>
+	<br><<include "Layer3 Slackslime Encounter">><br><br>
+
+	[[Deal with the slackslime|Layer3 Threat2][$returnPassage = passage()]]<br>
+	<<set _breakForEvent = true>>
 <</if>>
 
-<<for $layerExitTime; $layerExitTime >0; $layerExitTime-->>
-	<<PassTime 1>>
-/* 		<<set $timeL3T1 += 1>>
-	<<if !setup.haveTravelLightSource>>
-		<<set $timeL3T2 += 1>>
-	<</if>>
-	<<if $forageWater == 0>>
-		<<if $items[3].count > 0>>
-			<<set $items[3].count -= 1>>
-			<<set $items[2].count += 1>>
-		<<else>>
-			<<set $items[0].count -= 1>>
-		<</if>>
-		<<else>>
-		<<set $waterL3 += 1>>
-	<</if>>
-<<if $forageFood == 0>>
-		<<set $items[1].count -= 1>>
-	<<else>>
-		<<set $foodL3 += $tempTime>>
-		<<if $abyssKnow == 0>>
-			<<for _i = 0; _i < $tempTime; $i++>>
-				<<set $AgeLog.push($ForageFoodMajor)>>
-			<</for>>
-		<<else>>
-			<<for _i = 0; _i < $tempTime; $i++>>
-				<<set $AgeLog.push($ForageFoodMinor)>>
-			<</for>>
-		<</if>>
-<</if>>
-	<<set $time += 1>>
-	<<if $hexflame > 9>>
-		<<set $hexflame -= 1>>
-	<</if>>
-	*/
-
-	<<if $timeL3T1 > 5>>
-
-		<br><<include "Layer3 Tentacle Encounter">><br><br>
-
-		[[Deal with the lesser tentacle beast|Layer3 Threat1][$returnPassage="Layer3 Ascend2"]]<br>
-
-		<<set $layerExitTime -= 1>><<break>>
-	<</if>>
-
-	<<if $timeL3T2 > 4>>
-		<br><<include "Layer3 Slackslime Encounter">><br><br>
-
-		[[Deal with the slackslime|Layer3 Threat2][$returnPassage="Layer3 Ascend2"]]<br>
-		<<set $layerExitTime -= 1>><<break>>
-	<</if>>
-
-<</for>>
-<<include "GeneralTimeFinal">>
-<<if $layerExitTime == 0 && !($timeL3T1 > 5) && !($timeL3T2 > 4)>>
+<<if _done>>
 	<<set $corruption -= (25 - $corRed)>>
 	<br>You continue through the dark winding caverns for days on end. After a long and monotonous journey, broken up only by evading threats that may have interrupted you, you notice that the caves are opening up. The sheer stone walls morphing into large rock formations, then shrinking and making way for the jungle of the second layer. A familiar sound of eternal rainfall welcomes you back to the second layer.
 	<br><br><<include "Curse Descriptions">><br><br>
@@ -341,7 +304,7 @@ In the deeper parts of the layer, a cold breeze occasionally blows through the c
 <<set $temp = Math.round($corruption / 5)>>
 <<set $dubloons += $temp>>
 <<set $scalesUsed = 1>>
-<<AdjustedTravelTime "$tempTime" 2>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" 2>><<PassTime $tempTime>>
 <</nobr>>
 [img[setup.ImagePath+'Wonders/gossameryscales.png']]
 
@@ -357,7 +320,7 @@ Once you pick them up, the luster of the scales fades, indicating that they will
 <<set $temp = Math.round($dubloons / 5)>>
 <<set $corruption += $temp>>
 <<set $scalesUsed = 1>>
-<<AdjustedTravelTime "$tempTime" 2>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" 2>><<PassTime $tempTime>>
 <</nobr>>
 [img[setup.ImagePath+'Wonders/gossameryscales.png']]
 
@@ -850,7 +813,7 @@ On the other hand, the idea of each encounter feeling like your first time holds
 <<set $tempTime = (Math.max(4 -$abyssKnow - $riverVisit, 0))>>
 <<set $riverVisit = 1>>
 
-<<AdjustedTravelTime "$tempTime" $tempTime>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" $tempTime>><<PassTime $tempTime>>
 
 <<for _i = 0; _i < 999; _i++>>
 	<<if $items[2].count > 0>>
@@ -1272,63 +1235,25 @@ Please enter your new skin/eye color:
 <<nobr>>
 <<if $layerExit == 0>>
 	<<set $layerExit = 1>>
-	<<AdjustedTravelTime "$tempTime" 6>>
-	<<set $layerExitTime=$tempTime>>
+	<<AdjustedTravelTime "$layerExitTime" 6>>
+<</if>>
+<<set _triggers = {
+	lesserTentacleBeast: () => $timeL3T1 > 5,
+	slackslime: () => $timeL3T2 > 4,
+}>>
+
+<<PassTime $layerExitTime _triggers "_done">>
+
+<<if _triggers.lesserTentacleBeast()>>
+	<br><<include "Layer3 Tentacle Encounter">><br><br>
+	[[Deal with the lesser tentacle beast|Layer3 Threat1][$returnPassage = passage()]]<br><br>
+<<elseif _triggers.slackslime()>>
+	<br><<include "Layer3 Slackslime Encounter">><br><br>
+	[[Deal with the slackslime|Layer3 Threat2][$returnPassage = passage()]]<br><br>
 <</if>>
 
-<<for $layerExitTime; $layerExitTime >0; $layerExitTime-->>
-	<<PassTime 1>>
-	/* 
-	<<if $forageWater == 0>>
-		<<if $items[3].count > 0>>
-			<<set $items[3].count -= 1>>
-			<<set $items[2].count += 1>>
-			<<else>>
-			<<set $items[0].count -= 1>>
-		<</if>>
-		<<else>>
-		<<set $waterL3 += 1>>
-	<</if>>
-<<if $forageFood == 0>>
-		<<set $items[1].count -= 1>>
-	<<else>>
-		<<set $foodL3 += 1>>
-		<<if $abyssKnow == 0>>
-			<<for _i = 0; _i < $tempTime; $i++>>
-				<<set $AgeLog.push($ForageFoodMajor)>>
-			<</for>>
-		<<else>>
-			<<for _i = 0; _i < $tempTime; $i++>>
-				<<set $AgeLog.push($ForageFoodMinor)>>
-			<</for>>
-		<</if>>
-<</if>>
-	<<set $time += 1>>
-	<<if $hexflame > 9>>
-		<<set $hexflame -= 1>>
-	<</if>>
-	*/
-
-	<<if $timeL3T1 > 5>>
-
-		<br><<include "Layer3 Tentacle Encounter">><br><br>
-
-		[[Deal with the lesser tentacle beast|Layer3 Threat1][$returnPassage="Layer3 Exit2"]]<br><br>
-
-		<<set $layerExitTime -= 1>><<break>>
-	<</if>>
-	
-	<<if $timeL3T2 > 4>>
-		<br><<include "Layer3 Slackslime Encounter">><br><br>
-
-		[[Deal with the slackslime|Layer3 Threat2][$returnPassage="Layer3 Exit2"]]<br><br>
-		<<set $layerExitTime -= 1>><<break>>
-	<</if>>
-
-<</for>>
-<<include "GeneralTimeFinal">>
 <</nobr>>
-<<if $layerExitTime == 0 && !($timeL3T1 > 5) && !($timeL3T2 > 4)>>
+<<if _done>>
 	<<nobr>>
 	<<set $timeL4T1 = 0>>
 	<</nobr>>

--- a/src/layer4.twee
+++ b/src/layer4.twee
@@ -234,11 +234,11 @@ The Brave Vector Relic you can find here is a perfect example of something you m
 <<elseif $steadyForced < 4>>
 	Would you like to use the Steady Shrine to copy a Curse to one of your willing companions at the cost of <<print ($skewedUsed * 5)>> dubloons?<br>
 	<<link "Yes, use the Steady Shrine to copy a Curse" "Layer4 Steady1a">>
-		<<AdjustedTravelTime "$tempTime" 3>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
+		<<AdjustedTravelTime "$tempTime" 3>><<PassTime $tempTime>>
 	<</link>><br><br>
 	Would you like to use the Steady Shrine to forcibly copy a Curse onto one of your unwilling companions at the cost of <<print ($skewedUsed * 5)>> dubloons?<br>
 	<<link "Yes, use the Steady Shrine to forcibly copy a Curse" "Layer4 Steady 2a">>
-		<<AdjustedTravelTime "$tempTime" 3>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
+		<<AdjustedTravelTime "$tempTime" 3>><<PassTime $tempTime>>
 	<</link>><br><br>
 <<else>>
 	None of your companions trust you at this shrine anymore. None will get close enough for you to use the shrine with them. They watch you with eyes full of fear and anger, as if they could bolt at any moment and leave you alone in the Abyss.<br><br>
@@ -854,7 +854,7 @@ Which Curse would you like to forcibly copy onto your unwilling companion?
 :: Layer4 Purity 1 [layer4]
 <<nobr>>
 <<set $purityUsed = 1>>
-<<AdjustedTravelTime "$tempTime" 5>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" 5>><<PassTime $tempTime>>
 <</nobr>>
 [img[setup.ImagePath+'Wonders/puritytree.png']]
 
@@ -1156,61 +1156,21 @@ You have successfully taken the $relic48.name Relic. Hopefully you can make good
 		<<set $tempTime = 19>>
 	<</if>>
 
-	<<AdjustedTravelTime "$tempTime" $tempTime>>
-	<<set $layerExitTime=$tempTime>>
+	<<AdjustedTravelTime "$layerExitTime" $tempTime>>
+<</if>>
+<<set _triggers = {
+	driftingSwallower: () => $timeL4T1 > 6,
+}>>
 
+<<PassTime $layerExitTime _triggers "_done">>
+
+<<if _triggers.driftingSwallower()>>
+	<br>During your long trip down towards the fifth layer you hear a great hissing sound, as if a blimp were leaking its helium, fills your ears as a dark form descends on you from above. A monstrous beast floats above your head and unveils its tentacles in preparation of its attempt to shovel you into its enormous maw.<br><br>
+
+	[[Deal with the Drifting Swallower|Layer4 Threat1][$returnPassage = passage()]]<br>
 <</if>>
 
-<<for $layerExitTime; $layerExitTime >0; $layerExitTime-->>
-	<<PassTime 1>>
-	
-	<<if $timeL4T1 > 6>>
-		<br>During your long trip down towards the fifth layer you hear a great hissing sound, as if a blimp were leaking its helium, fills your ears as a dark form descends on you from above. A monstrous beast floats above your head and unveils its tentacles in preparation of its attempt to shovel you into its enormous maw.<br><br>
-
-		[[Deal with the Drifting Swallower|Layer4 Threat1][$returnPassage = "Layer4 Exit2"]]<br>
-		<<set $layerExitTime -= 1>><<break>>
-	<</if>>
-/*
-	<<if $items[1].count > 9>>
-		<<set $timeL4T1 += 1>>
-	<</if>>
-<<if $forageFood == 1 && (($items[13].count > 0 && $items[20].count > 1) || $slingshot == 1)>>
-	<<if $slingshot == 0>>
-		<<set $items[20].count -= Math.max((2 * $tempTime) - $bullRed, 1)>>
-	<</if>>
-	<<set $foodL4 += 1>>
-	<<if $abyssKnow == 0>>
-		<<set $HeightLog.push($ForageFoodMajor)>>
-	<<else>>
-		<<set $HeightLog.push($ForageFoodMinor)>>
-	<</if>>
-<<else>>
-	<<set $items[1].count -= 1>>
-<</if>>
-<<for $i = 0; $i < 1; $i++>>
-	<<if $forageWater == 0>>
-		<<if $items[3].count > 0>>
-			<<set $items[3].count -= 1, 0>>
-			<<set $items[2].count += 1, 0>>
-		<<else>>
-			<<set $items[0].count -= 1>>
-		<</if>>
-		<<else>>
-		<<set $waterL4 += 1>>
-		<<if $abyssKnow == 0>>
-			<<set $algalSize += 1>>
-		<</if>>
-	<</if>>
-<</for>>
-	<<set $time += 1>>
-	<<if $hexflame > 9>>
-		<<set $hexflame -= 1>>
-	<</if>>
-	*/
-<</for>>
-<<include "GeneralTimeFinal">>
-
-<<if $layerExitTime == 0 && !($timeL4T1 > 6)>>
+<<if _done>>
 	<<nobr>>
 	<<set $currentLayer = 5>>
 	<<set $timeL5T1 = 0>>
@@ -1239,66 +1199,23 @@ You have successfully taken the $relic48.name Relic. Hopefully you can make good
 	<<if $DaedalusFly==true>>
 		<<set $tempTime= Math.ceil($tempTime/2)>>
 	<</if>>
-	<<AdjustedTravelTime "$tempTime" $tempTime>>
-	<<set $layerExitTime=$tempTime>>
+	<<AdjustedTravelTime "$layerExitTime" $tempTime>>
 <</if>>
+<<set _triggers = {
+	driftingSwallower: () => $timeL4T1 > 6,
+}>>
 
-<<for $layerExitTime; $layerExitTime >0; $layerExitTime-->>
-	<<PassTime 1>>
+<<PassTime $layerExitTime _triggers "_done">>
 
-	<<if $timeL4T1 > 6>>
-		<br>
+<<if _triggers.driftingSwallower()>>
+	<br>
 	During your long hike back up towards the third layer you hear a great hissing sound, as if a blimp were leaking its helium, fills your ears as a dark form descends on you from above. A monstrous beast floats above your head and unveils its tentacles in preparation of its attempt to shovel you into its enormous maw.<br><br>
 
-	[[Deal with the Drifting Swallower|Layer4 Threat1][$returnPassage = "Layer4 Ascend2"]]<br>
-		<<set $layerExitTime -= 1>><<break>>
-	<</if>>
-
-	/* 
-	<<if $items[1].count > 9>>
-		<<set $timeL4T1 += 1>>
-	<</if>>
-<<if $forageFood == 1 && (($items[13].count > 0 && $items[20].count > 1) || $slingshot == 1)>>
-	<<if $slingshot == 0>>
-		<<set $items[20].count -= Math.max((2 * $tempTime) - $bullRed, 1)>>
-	<</if>>
-	<<set $foodL4 += 1>>
-	<<if $abyssKnow == 0>>
-		<<set $HeightLog.push($ForageFoodMajor)>>
-	<<else>>
-		<<set $HeightLog.push($ForageFoodMinor)>>
-	<</if>>
-<<else>>
-	<<set $items[1].count -= 1>>
+	[[Deal with the Drifting Swallower|Layer4 Threat1][$returnPassage = passage()]]<br>
 <</if>>
-<<for $i = 0; $i < 1; $i++>>
-	<<if $forageWater == 0>>
-		<<if $items[3].count > 0>>
-			<<set $items[3].count -= 1, 0>>
-			<<set $items[2].count += 1, 0>>
-		<<else>>
-			<<set $items[0].count -= 1>>
-		<</if>>
-		<<else>>
-		<<set $waterL4 += 1>>
-		<<if $abyssKnow == 0>>
-			<<set $algalSize += 1>>
-		<</if>>
-	<</if>>
-<</for>>
-	<<set $time += 1>>
-	<<if $hexflame > 9>>
-		<<set $hexflame -= 1>>
-	<</if>>
-	<<set $layerExitTime -= 1>>
-	<<if $layerExitTime == 0>>
-		<<break>>
-	<</if>>*/
-<</for>>
-<<include "GeneralTimeFinal">>
 
 <</nobr>>
-<<if $layerExitTime == 0 && !($timeL4T1 > 6)>>
+<<if _done>>
 	<<nobr>>
 	<<set $corruption -= (35 - $corRed)>>
 	<<set $forageWater = 0>>

--- a/src/layer4.twee
+++ b/src/layer4.twee
@@ -795,7 +795,7 @@ Which Curse would you like to transfer to your willing companion? It can't be to
 			<</switch>>
 
 			<<if _flag>>
-				<<capture _companion, _curse, _tempName>>
+				<<capture _companion _curse _tempName>>
 					&nbsp; _curse.name
 					<<link "Choose" "Layer4 Steady1a">>
 						<<set _companion.curses.push(_curse)>>
@@ -905,7 +905,7 @@ The magic of the shrine wisps through the air menacingly as your victim struggle
 	<</switch>>
 
 	<<if _flag>>
-		<<capture _companion, _tempName>>
+		<<capture _companion _tempName>>
 			<<set _choiceText = "Transfer to " + _tempName>>
 			<<link _choiceText "Layer4 Steady Apply">>
 				<<set _companion.curses.push(_curse)>>

--- a/src/layer4.twee
+++ b/src/layer4.twee
@@ -234,11 +234,11 @@ The Brave Vector Relic you can find here is a perfect example of something you m
 <<elseif $steadyForced < 4>>
 	Would you like to use the Steady Shrine to copy a Curse to one of your willing companions at the cost of <<print ($skewedUsed * 5)>> dubloons?<br>
 	<<link "Yes, use the Steady Shrine to copy a Curse" "Layer4 Steady1a">>
-		<<AdjustedTravelTime "$tempTime" 3>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+		<<AdjustedTravelTime "$tempTime" 3>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
 	<</link>><br><br>
 	Would you like to use the Steady Shrine to forcibly copy a Curse onto one of your unwilling companions at the cost of <<print ($skewedUsed * 5)>> dubloons?<br>
 	<<link "Yes, use the Steady Shrine to forcibly copy a Curse" "Layer4 Steady 2a">>
-		<<AdjustedTravelTime "$tempTime" 3>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+		<<AdjustedTravelTime "$tempTime" 3>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
 	<</link>><br><br>
 <<else>>
 	None of your companions trust you at this shrine anymore. None will get close enough for you to use the shrine with them. They watch you with eyes full of fear and anger, as if they could bolt at any moment and leave you alone in the Abyss.<br><br>
@@ -854,7 +854,7 @@ Which Curse would you like to forcibly copy onto your unwilling companion?
 :: Layer4 Purity 1 [layer4]
 <<nobr>>
 <<set $purityUsed = 1>>
-<<AdjustedTravelTime "$tempTime" 5>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" 5>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
 <</nobr>>
 [img[setup.ImagePath+'Wonders/puritytree.png']]
 
@@ -1162,9 +1162,7 @@ You have successfully taken the $relic48.name Relic. Hopefully you can make good
 <</if>>
 
 <<for $layerExitTime; $layerExitTime >0; $layerExitTime-->>
-
-	<<set $tempTime = 1>>
-	<<include "GeneralTimeStats">>
+	<<PassTime 1>>
 	
 	<<if $timeL4T1 > 6>>
 		<br>During your long trip down towards the fifth layer you hear a great hissing sound, as if a blimp were leaking its helium, fills your ears as a dark form descends on you from above. A monstrous beast floats above your head and unveils its tentacles in preparation of its attempt to shovel you into its enormous maw.<br><br>
@@ -1246,9 +1244,7 @@ You have successfully taken the $relic48.name Relic. Hopefully you can make good
 <</if>>
 
 <<for $layerExitTime; $layerExitTime >0; $layerExitTime-->>
-
-	<<set $tempTime = 1>>
-	<<include "GeneralTimeStats">>
+	<<PassTime 1>>
 
 	<<if $timeL4T1 > 6>>
 		<br>

--- a/src/layer5.twee
+++ b/src/layer5.twee
@@ -149,8 +149,7 @@ Use the following option only if you have specifically considered your inventory
 
 
 :: Layer5 Threat1 Main [layer5]
-<<set $tempTime = 1>>\
-<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>\
+<<PassTime 1>><<include "GeneralTimeFinal">>\
 <<set $timeL5T1 -= 8>>\
 [img[setup.ImagePath+'Threats/mayflyscuttler.png']]
 
@@ -300,8 +299,7 @@ You can also wait at the Oasis if you'd like to pass the time while waiting for 
 		<<set $items[2].count = 0>>
 		<<set $items[0].count += (5 - $items[3].count)>>
 	<</if>>
-	<<set $tempTime = parseInt($temp)>>
-	<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+	<<PassTime `parseInt($temp, 10)`>><<include "GeneralTimeFinal">>
 <</link>><br><br><</nobr>>
 <</nobr>>
 
@@ -506,7 +504,7 @@ Layer 5 is the last layer that anyone on the surface currently has any reliable 
 	<<set $status.penalty = 0>>
 <</if>>
 <<set $tempTime = (Math.max(4 - ($oasisVisit * 2) - $abyssKnow, 0))>>
-<<AdjustedTravelTime "$tempTime" $tempTime>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" $tempTime>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
 
 <<for $i = 0; $i < 999; $i++>>
 	<<if $items[2].count > 0>>
@@ -1398,7 +1396,7 @@ Please enter your new exoskeleton color:
 
 :: Layer5 Tunnel [layer5]
 <<nobr>>
-<<AdjustedTravelTime "$tempTime" 2>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" 2>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
 <</nobr>>
 [img[setup.ImagePath+'Wonders/one-sidedtunnel.png']]
 
@@ -1451,7 +1449,7 @@ Testing your Pocket Hoard, you stick a hand into the pink rucksack, but find you
 <<if $timeL5T1 < 8 && $timeL5T2 < 11>>[img[setup.ImagePath+'Wonders/miragevault.png']]
 <<nobr>>
 <<if $vaultWait == 0>>
-	<<AdjustedTravelTime "$tempTime" 3>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+	<<AdjustedTravelTime "$tempTime" 3>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
 <<else>>
 	<<set $vaultWait = 0>>
 <</if>>
@@ -1466,9 +1464,8 @@ The timer on the door reads <<print (60 - $time + $vaultTimer)>>.
 You can wait here for a while if you'd like to check when the door is open. If you'd like to wait, enter the number of days you'd like to wait and choose to wait.
 <<textbox "$temp" "0">>
 <<nobr>><<link "Wait" "Layer5 Vault">>
-	<<set $tempTime = parseInt($temp)>>
 	<<set $vaultWait = 1>>
-	<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+	<<PassTime `parseInt($temp, 10)`>><<include "GeneralTimeFinal">>
 <</link>><br><br><</nobr>>
 
 <<if (60 - $time + $vaultTimer) > 0>>
@@ -1527,9 +1524,7 @@ The radiant sun empowers your Breathless Exhale Relic, its energy pulsating with
 <</if>>
 
 <<for $layerExitTime; $layerExitTime >0; $layerExitTime-->>
-
-	<<set $tempTime = 1>>
-	<<include "GeneralTimeStats">>
+	<<PassTime 1>>
 
 	<<if $timeL5T2 > 8>>
 		<br><<include "Layer5 Borer Encounter">><br><br>
@@ -1601,8 +1596,7 @@ Use the following option only if you have specifically considered your inventory
 
 
 :: Layer5 Threat1 Ascend [layer5]
-<<set $tempTime = 1>>\
-<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>\
+<<PassTime 1>><<include "GeneralTimeFinal">>\
 <<set $timeL5T1 -= 8>>\
 [img[setup.ImagePath+'Threats/mayflyscuttler.png']]
 
@@ -1624,9 +1618,7 @@ Use the following option only if you have specifically considered your inventory
 <</if>>
 
 <<for $layerExitTime; $layerExitTime >0; $layerExitTime-->>
-
-	<<set $tempTime = 1>>
-	<<include "GeneralTimeStats">>
+	<<PassTime 1>>
 
 	<<if $timeL5T2 > 8>>
 
@@ -1695,8 +1687,7 @@ Use the following option only if you have specifically considered your inventory
 
 
 :: Layer5 Threat1 Descend [layer5]
-<<set $tempTime = 1>>\
-<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>\
+<<PassTime 1>><<include "GeneralTimeFinal">>\
 <<set $timeL5T1 -= 8>>\
 [img[setup.ImagePath+'Threats/mayflyscuttler.png']]
 

--- a/src/layer5.twee
+++ b/src/layer5.twee
@@ -149,7 +149,7 @@ Use the following option only if you have specifically considered your inventory
 
 
 :: Layer5 Threat1 Main [layer5]
-<<PassTime 1>><<include "GeneralTimeFinal">>\
+<<PassTime 1>>\
 <<set $timeL5T1 -= 8>>\
 [img[setup.ImagePath+'Threats/mayflyscuttler.png']]
 
@@ -299,7 +299,7 @@ You can also wait at the Oasis if you'd like to pass the time while waiting for 
 		<<set $items[2].count = 0>>
 		<<set $items[0].count += (5 - $items[3].count)>>
 	<</if>>
-	<<PassTime `parseInt($temp, 10)`>><<include "GeneralTimeFinal">>
+	<<PassTime `parseInt($temp, 10)`>>
 <</link>><br><br><</nobr>>
 <</nobr>>
 
@@ -504,7 +504,7 @@ Layer 5 is the last layer that anyone on the surface currently has any reliable 
 	<<set $status.penalty = 0>>
 <</if>>
 <<set $tempTime = (Math.max(4 - ($oasisVisit * 2) - $abyssKnow, 0))>>
-<<AdjustedTravelTime "$tempTime" $tempTime>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" $tempTime>><<PassTime $tempTime>>
 
 <<for $i = 0; $i < 999; $i++>>
 	<<if $items[2].count > 0>>
@@ -1396,7 +1396,7 @@ Please enter your new exoskeleton color:
 
 :: Layer5 Tunnel [layer5]
 <<nobr>>
-<<AdjustedTravelTime "$tempTime" 2>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" 2>><<PassTime $tempTime>>
 <</nobr>>
 [img[setup.ImagePath+'Wonders/one-sidedtunnel.png']]
 
@@ -1449,7 +1449,7 @@ Testing your Pocket Hoard, you stick a hand into the pink rucksack, but find you
 <<if $timeL5T1 < 8 && $timeL5T2 < 11>>[img[setup.ImagePath+'Wonders/miragevault.png']]
 <<nobr>>
 <<if $vaultWait == 0>>
-	<<AdjustedTravelTime "$tempTime" 3>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
+	<<AdjustedTravelTime "$tempTime" 3>><<PassTime $tempTime>>
 <<else>>
 	<<set $vaultWait = 0>>
 <</if>>
@@ -1465,7 +1465,7 @@ You can wait here for a while if you'd like to check when the door is open. If y
 <<textbox "$temp" "0">>
 <<nobr>><<link "Wait" "Layer5 Vault">>
 	<<set $vaultWait = 1>>
-	<<PassTime `parseInt($temp, 10)`>><<include "GeneralTimeFinal">>
+	<<PassTime `parseInt($temp, 10)`>>
 <</link>><br><br><</nobr>>
 
 <<if (60 - $time + $vaultTimer) > 0>>
@@ -1519,36 +1519,30 @@ The radiant sun empowers your Breathless Exhale Relic, its energy pulsating with
 	<<if $DaedalusFly==true>>
 		<<set $tempTime= Math.ceil($tempTime/2)>>
 	<</if>>
-	<<AdjustedTravelTime "$tempTime" $tempTime>>
-	<<set $layerExitTime=$tempTime>>
+	<<AdjustedTravelTime "$layerExitTime" $tempTime>>
+<</if>>
+<<set _triggers = {
+	duneDevouringBorer: () => $timeL5T2 > 8,
+	mayflyScuttler: () => $timeL5T1 > 7,
+}>>
+
+<<PassTime $layerExitTime _triggers "_done">>
+
+<<if _triggers.duneDevouringBorer()>>
+	<br><<include "Layer5 Borer Encounter">><br><br>
+	[[Deal with the Dune Devouring Borer|Layer5 Threat2][$returnPassage = passage()]]<br>
+<<elseif _triggers.mayflyScuttler()>>
+	<br>When you wake up in the morning, you hear an enormous amount of buzzing in the air, luckily you managed to stay out of the swarm when you woke up, but you'll need to decide what to do with the swarm today.<br><br>
+	[[Deal with the Mayfly Scuttler|Layer5 Threat1 Ascend]]<br>
+
+	<<if $ownedRelics.some(e => e.name === "Breathless Exhale")>>
+		<br>The radiant sun empowers your Breathless Exhale Relic, its energy pulsating within your grasp. You can sense the potential of the Relic, trembling with anticipation, ready to alter the wind's course and drive the insects away from you.<br><br>
+		[[Summon a powerful gust to drive the swarm away from you|Layer5 Ascend2][$timeL5T1 -= 8]]<br>
+	<</if>>
 <</if>>
 
-<<for $layerExitTime; $layerExitTime >0; $layerExitTime-->>
-	<<PassTime 1>>
-
-	<<if $timeL5T2 > 8>>
-		<br><<include "Layer5 Borer Encounter">><br><br>
-
-		[[Deal with the Dune Devouring Borer|Layer5 Threat2][$returnPassage = "Layer5 Ascend2"]]<br><br>
-
-		<<set $layerExitTime -= 1>><<break>>
-	<</if>>
-	
-	<<if $timeL5T1 > 7>>
-		<br>When you wake up in the morning, you hear an enormous amount of buzzing in the air, luckily you managed to stay out of the swarm when you woke up, but you'll need to decide what to do with the swarm today. <br><br>
-
-		[[Deal with the Mayfly Scuttler|Layer5 Threat1 Ascend]]<br><br><<if $ownedRelics.some(e => e.name === "Breathless Exhale")>>
-
-		The radiant sun empowers your Breathless Exhale Relic, its energy pulsating within your grasp. You can sense the potential of the Relic, trembling with anticipation, ready to alter the wind's course and drive the insects away from you.
-		[[Summon a powerful gust to drive the swarm away from you|Layer5 Ascend2][$timeL5T1 -= 8]]
-		<</if>>
-		<<set $layerExitTime -= 1>><<break>>
-	<</if>>
-
-<</for>>
-<<include "GeneralTimeFinal">>
 <</nobr>>
-<<if $layerExitTime == 0 && !($timeL5T2 > 8) && !($timeL5T1 > 7)>>
+<<if _done>>
 	<<set $timeL4T1 = 0>>\
 	<<set $corruption -= (50 - $corRed + (5 * Math.trunc($hexflame / 10)))>>\
 	<<set $currentLayer = 5>>\
@@ -1596,7 +1590,7 @@ Use the following option only if you have specifically considered your inventory
 
 
 :: Layer5 Threat1 Ascend [layer5]
-<<PassTime 1>><<include "GeneralTimeFinal">>\
+<<PassTime 1>>\
 <<set $timeL5T1 -= 8>>\
 [img[setup.ImagePath+'Threats/mayflyscuttler.png']]
 
@@ -1613,45 +1607,37 @@ Use the following option only if you have specifically considered your inventory
 <<nobr>>
 <<if $layerExit == 0>>
 	<<set $layerExit = 1>>
-	<<AdjustedTravelTime "$tempTime" 13>>
-	<<set $layerExitTime=$tempTime>>
+	<<AdjustedTravelTime "$layerExitTime" 13>>
+<</if>>
+<<set _triggers = {
+	duneDevouringBorer: () => $timeL5T2 > 8,
+	mayflyScuttler: () => $timeL5T1 > 7,
+}>>
+
+<<PassTime $layerExitTime _triggers "_done">>
+
+<<if _triggers.duneDevouringBorer()>>
+	<br><<include "Layer5 Borer Encounter">><br><br>
+	[[Deal with the Dune Devouring Borer|Layer5 Threat2][$returnPassage = passage()]]<br>
+<<elseif _triggers.mayflyScuttler()>>
+	<br>When you wake up in the morning, you hear an enormous amount of buzzing in the air, luckily you managed to stay out of the swarm when you woke up, but you'll need to decide what to do with the swarm today.<br><br>
+	[[Deal with the Mayfly Scuttler|Layer5 Threat1 Descend]]<br>
+
+	<<if $ownedRelics.some(e => e.name === "Breathless Exhale")>>
+		<br>The radiant sun empowers your Breathless Exhale Relic, its energy pulsating within your grasp. You can sense the potential of the Relic, trembling with anticipation, ready to alter the wind's course and drive the insects away from you.<br><br>
+		[[Summon a powerful gust to drive the swarm away from you|Layer5 Exit2][$timeL5T1 -= 8]]<br>
+	<</if>>
 <</if>>
 
-<<for $layerExitTime; $layerExitTime >0; $layerExitTime-->>
-	<<PassTime 1>>
-
-	<<if $timeL5T2 > 8>>
-
-		<br><<include "Layer5 Borer Encounter">><br><br>
-
-		[[Deal with the Dune Devouring Borer|Layer5 Threat2][$returnPassage = "Layer5 Exit2"]]<br><br>
-
-		<<set $layerExitTime -= 1>><<break>>
-	<</if>>
-
-	<<if $timeL5T1 > 7>>
-		<br>When you wake up in the morning, you hear an enormous amount of buzzing in the air, luckily you managed to stay out of the swarm when you woke up, but you'll need to decide what to do with the swarm today. <br><br>
-
-		[[Deal with the Mayfly Scuttler|Layer5 Threat1 Descend]]<br><br><<if $ownedRelics.some(e => e.name === "Breathless Exhale")>>
-
-		The radiant sun empowers your Breathless Exhale Relic, its energy pulsating within your grasp. You can sense the potential of the Relic, trembling with anticipation, ready to alter the wind's course and drive the insects away from you.
-		[[Summon a powerful gust to drive the swarm away from you|Layer5 Exit2][$timeL5T1 -= 8]]
-		<</if>>
-		<<set $layerExitTime -= 1>><<break>>
-	<</if>>
-<</for>>
-<<include "GeneralTimeFinal">>
-
-<<if $layerExitTime == 0 && !($timeL5T2 > 8) && !($timeL5T1 > 7)>>
-<<set $timeL6T1 = 0>>
-<<set $timeL6T2 = 0>>
+<<if _done>>
+	<<set $timeL6T1 = 0>>
+	<<set $timeL6T2 = 0>>
 
 	You continue through the scorching desert for days on end, but the heat only seems to get more intense. But the smell is different, you catch a whiff of more exotic, meaty scents than the fragrance of the flowers of the fifth layer. As the ground begins to change from sand to a more organic texture, you know you're approaching the sixth layer.<br><br>
 
 	<<include "Curse Descriptions">><br><br>
 
 	[[Descend to the sixth layer|Layer6 1]]
-
 <</if>>
 <</nobr>>
 
@@ -1687,7 +1673,7 @@ Use the following option only if you have specifically considered your inventory
 
 
 :: Layer5 Threat1 Descend [layer5]
-<<PassTime 1>><<include "GeneralTimeFinal">>\
+<<PassTime 1>>\
 <<set $timeL5T1 -= 8>>\
 [img[setup.ImagePath+'Threats/mayflyscuttler.png']]
 

--- a/src/layer6.twee
+++ b/src/layer6.twee
@@ -430,7 +430,7 @@ There is a very easily accessible source of water on this layer, the River Dycx,
 [img[setup.ImagePath+'Clipped-Fin/Abyss Diver Page 7-wonders.png']]
 <<nobr>>
 <<set _totalRelics = $ownedRelics.concat($soldRelics)>>
-<<AdjustedTravelTime "$tempTime" 3>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" 3>><<PassTime $tempTime>>
 <</nobr>><<if $mawUse == 0>>
 As you press through the thicket of incessantly writhing tentacles, the tentacles subtly change their rhythm. The heat has long ago seared your sense of comfort away, replaced with a strange duality of torment and transcendence. The harsh, yet strangely savory, scent of burning flesh punctuates the air, becoming richer and more distinct. Suddenly, the sea of tentacles parts like the Red Sea before Moses, revealing a broad expanse of barren rock.
 
@@ -1086,7 +1086,7 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 
 
 :: Layer6 Threat1 Main2 [layer6]
-<<PassTime $tentacleFucked>><<include "GeneralTimeFinal">>\
+<<PassTime $tentacleFucked>>\
 
 <<if $khemiaFucked == 0>>
 	After an intense encounter with the greater tentacle beast, you are left in a sorry state, needing to be left stationary for $tentacleFucked days. Slowly you regain your sensations and manage to prepare yourself to get going and continue your travels on the sixth layer.
@@ -1109,32 +1109,24 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 	<<if $DaedalusFly==true>>
 		<<set $tempTime= Math.ceil($tempTime/2)>>
 	<</if>>
-	<<AdjustedTravelTime "$tempTime" $tempTime>>
-	<<set $layerExitTime=$tempTime>>
+	<<AdjustedTravelTime "$layerExitTime" $tempTime>>
+<</if>>
+<<set _triggers = {
+	fellDragon: () => $timeL6T2 > 7 && $dragonKill < 5,
+	greaterTentacleBeast: () => $timeL6T1 > 14,
+}>>
+
+<<PassTime $layerExitTime _triggers "_done">>
+
+<<if _triggers.fellDragon()>>
+	<br><<include "Layer6 Dragon Encounter">><br><br>
+	[[Deal with the Fell Dragon|Layer6 Threat2][$returnPassage = passage()]]<br><br>
+<<elseif _triggers.greaterTentacleBeast()>>
+	<br><<include "Layer6 Tentacle Encounter">><br><br>
+	[[Deal with the Greater Tentacle Beast|Layer6 Threat1 1][$returnPassage = passage()]]<br><br>
 <</if>>
 
-<<for $layerExitTime; $layerExitTime >0; $layerExitTime-->>
-	<<PassTime 1>>
-
-	<<if $timeL6T2 > 7 && $dragonKill < 5>>
-
-		<br><<include "Layer6 Dragon Encounter">><br><br>
-
-		[[Deal with the Fell Dragon|Layer6 Threat2][$returnPassage = "Layer6 Ascend2"]]<br><br>
-
-		<<set $layerExitTime -= 1>><<break>>
-
-	<</if>>
-		<<if $timeL6T1 > 14>>
-		<br><<include "Layer6 Tentacle Encounter">><br><br>
-
-		[[Deal with the Greater Tentacle Beast|Layer6 Threat1 1][$returnPassage = "Layer6 Ascend2"]]<br><br>
-		<<set $layerExitTime -= 1>><<break>>
-	<</if>>
-<</for>>
-<<include "GeneralTimeFinal">>
-
-<</nobr>><<if $layerExitTime == 0 && !($timeL6T2 > 7 && $dragonKill < 5) && !($timeL6T1 > 14)>>
+<</nobr>><<if _done>>
 	<<nobr>>
 	<<set $corruption -= (65 - $corRed)>>
 	<<set $timeL5T1 = 0>>
@@ -1263,7 +1255,7 @@ Use the following option only if you have specifically considered your inventory
 
 
 :: Layer6 Threat1 Ascend2 [layer6]
-<<PassTime $tentacleFucked>><<include "GeneralTimeFinal">>\
+<<PassTime $tentacleFucked>>\
 
 <<if $khemiaFucked == 0>>
 	After an intense encounter with the greater tentacle beast, you are left in a sorry state, needing to be left stationary for $tentacleFucked days. Slowly you regain your sensations and manage to prepare yourself to get going and continue your travels on the sixth layer.
@@ -1279,32 +1271,24 @@ Use the following option only if you have specifically considered your inventory
 <<nobr>>
 <<if $layerExit == 0>>
 	<<set $layerExit = 1>>
-	<<AdjustedTravelTime "$tempTime" 16>>
-	<<set $layerExitTime=$tempTime>>
+	<<AdjustedTravelTime "$layerExitTime" 16>>
+<</if>>
+<<set _triggers = {
+	fellDragon: () => $timeL6T2 > 7 && $dragonKill < 5,
+	greaterTentacleBeast: () => $timeL6T1 > 14,
+}>>
+
+<<PassTime $layerExitTime _triggers "_done">>
+
+<<if _triggers.fellDragon()>>
+	<br><<include "Layer6 Dragon Encounter">><br><br>
+	[[Deal with the Fell Dragon|Layer6 Threat2 Descend][$returnPassage = passage()]]<br><br>
+<<elseif _triggers.greaterTentacleBeast()>>
+	<br><<include "Layer6 Tentacle Encounter">><br><br>
+	[[Deal with the Greater Tentacle Beast|Layer6 Threat1 1][$returnPassage = passage()]]<br><br>
 <</if>>
 
-<<for $layerExitTime; $layerExitTime >0; $layerExitTime-->>
-	<<PassTime 1>>
-
-	<<if $timeL6T2 > 7 && $dragonKill < 5>>
-
-		<br><<include "Layer6 Dragon Encounter">><br><br>
-
-		[[Deal with the Fell Dragon|Layer6 Threat2 Descend][$returnPassage = "Layer6 Exit2"]]<br><br>
-
-		<<set $layerExitTime -= 1>><<break>>
-	<</if>>
-
-	<<if $timeL6T1 > 14>>
-		<br><<include "Layer6 Tentacle Encounter">><br><br>
-
-		[[Deal with the Greater Tentacle Beast|Layer6 Threat1 1][$returnPassage = "Layer6 Exit2"]]<br><br>
-		<<set $layerExitTime -= 1>><<break>>
-	<</if>>
-<</for>>
-<<include "GeneralTimeFinal">>
-
-<</nobr>><<if $layerExitTime == 0 && !($timeL6T2 > 7 && $dragonKill < 5) && !($timeL6T1 > 14)>>
+<</nobr>><<if _done>>
 <<set $timeL7T2 = 0>>
 	You continue through the playfully ticklish yet hellishly searing tentacles for a long hike downward. You find some small hints of paved paths that have long since degraded, but no other indication of what is next for you, until suddenly you are faced with a metal barricade, signaling the end of the sixth layer and the start of the seventh.
 
@@ -1424,7 +1408,7 @@ Use the following option only if you have specifically considered your inventory
 [[Use a combination of Relics not mentioned above you believe would be able to defeat the beast|Layer6 Exit2]]
 
 :: Layer6 Threat1 Descend2 [layer6]
-<<PassTime $tentacleFucked>><<include "GeneralTimeFinal">>\
+<<PassTime $tentacleFucked>>\
 
 <<if $khemiaFucked == 0>>
 	After an intense encounter with the greater tentacle beast, you are left in a sorry state, needing to be left stationary for $tentacleFucked days. Slowly you regain your sensations and manage to prepare yourself to get going and continue your travels on the sixth layer.
@@ -1648,7 +1632,7 @@ Use the following option only if you have specifically considered your inventory
 
 :: Layer6 Threat1 2 [layer6]
 [img[setup.ImagePath+'Threats/greatertentaclebeast.png']]
-<<PassTime $tentacleFucked>><<include "GeneralTimeFinal">>\
+<<PassTime $tentacleFucked>>\
 
 <<if $khemiaFucked == 0 && $app.vagina == 1 && $app.breastsCor > 0>>\
 	In a flash, the greater tentacle beast lunges toward you, its countless tendrils erupting from the ground and surrounding you in a suffocating embrace. The slick, sinewy tendrils coil around your limbs, binding you tightly as they explore every inch of your body with perverse curiosity. Their touch is deceptively gentle, yet insistent, sending shivers down your spine as they delicately caress your $app.breastsLabel cup breasts, teasing your nipples, and exploring the soft flesh of your inner thighs.

--- a/src/layer6.twee
+++ b/src/layer6.twee
@@ -430,7 +430,7 @@ There is a very easily accessible source of water on this layer, the River Dycx,
 [img[setup.ImagePath+'Clipped-Fin/Abyss Diver Page 7-wonders.png']]
 <<nobr>>
 <<set _totalRelics = $ownedRelics.concat($soldRelics)>>
-<<AdjustedTravelTime "$tempTime" 3>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" 3>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
 <</nobr>><<if $mawUse == 0>>
 As you press through the thicket of incessantly writhing tentacles, the tentacles subtly change their rhythm. The heat has long ago seared your sense of comfort away, replaced with a strange duality of torment and transcendence. The harsh, yet strangely savory, scent of burning flesh punctuates the air, becoming richer and more distinct. Suddenly, the sea of tentacles parts like the Red Sea before Moses, revealing a broad expanse of barren rock.
 
@@ -1086,8 +1086,7 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 
 
 :: Layer6 Threat1 Main2 [layer6]
-<<set $tempTime = $tentacleFucked>>\
-<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>\
+<<PassTime $tentacleFucked>><<include "GeneralTimeFinal">>\
 
 <<if $khemiaFucked == 0>>
 	After an intense encounter with the greater tentacle beast, you are left in a sorry state, needing to be left stationary for $tentacleFucked days. Slowly you regain your sensations and manage to prepare yourself to get going and continue your travels on the sixth layer.
@@ -1115,9 +1114,7 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 <</if>>
 
 <<for $layerExitTime; $layerExitTime >0; $layerExitTime-->>
-
-	<<set $tempTime = 1>>
-	<<include "GeneralTimeStats">>
+	<<PassTime 1>>
 
 	<<if $timeL6T2 > 7 && $dragonKill < 5>>
 
@@ -1266,8 +1263,7 @@ Use the following option only if you have specifically considered your inventory
 
 
 :: Layer6 Threat1 Ascend2 [layer6]
-<<set $tempTime = $tentacleFucked>>\
-<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>\
+<<PassTime $tentacleFucked>><<include "GeneralTimeFinal">>\
 
 <<if $khemiaFucked == 0>>
 	After an intense encounter with the greater tentacle beast, you are left in a sorry state, needing to be left stationary for $tentacleFucked days. Slowly you regain your sensations and manage to prepare yourself to get going and continue your travels on the sixth layer.
@@ -1288,9 +1284,7 @@ Use the following option only if you have specifically considered your inventory
 <</if>>
 
 <<for $layerExitTime; $layerExitTime >0; $layerExitTime-->>
-
-	<<set $tempTime = 1>>
-	<<include "GeneralTimeStats">>
+	<<PassTime 1>>
 
 	<<if $timeL6T2 > 7 && $dragonKill < 5>>
 
@@ -1430,8 +1424,7 @@ Use the following option only if you have specifically considered your inventory
 [[Use a combination of Relics not mentioned above you believe would be able to defeat the beast|Layer6 Exit2]]
 
 :: Layer6 Threat1 Descend2 [layer6]
-<<set $tempTime = $tentacleFucked>>\
-<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>\
+<<PassTime $tentacleFucked>><<include "GeneralTimeFinal">>\
 
 <<if $khemiaFucked == 0>>
 	After an intense encounter with the greater tentacle beast, you are left in a sorry state, needing to be left stationary for $tentacleFucked days. Slowly you regain your sensations and manage to prepare yourself to get going and continue your travels on the sixth layer.
@@ -1655,8 +1648,7 @@ Use the following option only if you have specifically considered your inventory
 
 :: Layer6 Threat1 2 [layer6]
 [img[setup.ImagePath+'Threats/greatertentaclebeast.png']]
-<<set $tempTime = $tentacleFucked>>\
-<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>\
+<<PassTime $tentacleFucked>><<include "GeneralTimeFinal">>\
 
 <<if $khemiaFucked == 0 && $app.vagina == 1 && $app.breastsCor > 0>>\
 	In a flash, the greater tentacle beast lunges toward you, its countless tendrils erupting from the ground and surrounding you in a suffocating embrace. The slick, sinewy tendrils coil around your limbs, binding you tightly as they explore every inch of your body with perverse curiosity. Their touch is deceptively gentle, yet insistent, sending shivers down your spine as they delicately caress your $app.breastsLabel cup breasts, teasing your nipples, and exploring the soft flesh of your inner thighs.

--- a/src/layer7.twee
+++ b/src/layer7.twee
@@ -320,8 +320,7 @@ If you're not dissuaded and choose to continue onward, it will take you 8 days t
 :: Layer7 Threat2 Main [layer7]
 <<nobr>>
 <<set $timeL7T2 -= 6>>
-<<set $tempTime = 1>>
-<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+<<PassTime 1>><<include "GeneralTimeFinal">>
 <</nobr>>
 [img[setup.ImagePath+'Threats/securityrobot.png']]
 <<if $playerCurses.some(e => e.name === "Hypno Happytime") && $layer7Hypno < 3>><<set $layer7Hypno += 1>>
@@ -1376,7 +1375,7 @@ You retrieve your Relics and find that you have successfully switched the abilit
 
 [[Continue your business on the seventh layer|Layer7 Hub]]<br><br>
 
-<<AdjustedTravelTime "$tempTime" 2>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" 2>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
 <<set $dubloons -= 4>>
 
 <<set $temp = $relicSwap.length>>
@@ -1412,9 +1411,7 @@ You have no choice, you gain consciousness a few times to see yourself in a surg
 <</if>>
 
 <<for $layerExitTime; $layerExitTime >0; $layerExitTime-->>
-
-	<<set $tempTime = 1>>
-	<<include "GeneralTimeStats">>
+	<<PassTime 1>>
 
 	<<if $dubloons < 0 && $easymode==false>>
 		<br>[img[setup.ImagePath+'Threats/taxdrone.png']]<br><br>
@@ -1486,8 +1483,7 @@ You have no choice, you gain consciousness a few times to see yourself in a surg
 :: Layer7 Threat2 Ascend [layer7]
 <<nobr>>
 <<set $timeL7T2 -= 6>>
-<<set $tempTime = 1>>
-<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+<<PassTime 1>><<include "GeneralTimeFinal">>
 <</nobr>>
 [img[setup.ImagePath+'Threats/securityrobot.png']]
 
@@ -1556,10 +1552,7 @@ You have no choice, you gain consciousness a few times to see yourself in a surg
 <</if>>
 
 <<for $layerExitTime; $layerExitTime >0; $layerExitTime-->>
-
-	<<set $tempTime = 1>>
-	<<include "GeneralTimeStats">>
-
+	<<PassTime 1>>
 
 	<<if $dubloons < 0 && $easymode==false>>
 		<br>[img[setup.ImagePath+'Threats/taxdrone.png']]<br><br>
@@ -1622,7 +1615,7 @@ You have no choice, you gain consciousness a few times to see yourself in a surg
 :: Layer7 Threat2 Descend [layer7]
 <<nobr>>
 <<set $timeL7T2 -= 6>>
-<<AdjustedTravelTime "$tempTime" 1>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" 1>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
 <</nobr>>
 [img[setup.ImagePath+'Threats/securityrobot.png']]
 
@@ -1695,11 +1688,7 @@ You have no choice, you gain consciousness a few times to see yourself in a surg
 	<<set $heavyLiftDubloons += $temp2>>
 <</if>>
 <<set $dubloons += $temp2>>
-<<set $tempTime = $temp1>>
-<<if $tempTime < 0>>
-	<<set $tempTime = 0>>
-<</if>>
-<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+<<PassTime `Math.max($temp1, 0)`>><<include "GeneralTimeFinal">>
 <</nobr>>
 [img[setup.ImagePath+'Foraging/heavylifting.png']]
 
@@ -1721,12 +1710,7 @@ You have worked $temp1 days and moved $temp2 loads of "construction material" to
 	<<set $landExcavDubloons += $temp2>>
 <</if>>
 <<set $dubloons += $temp2>>
-
-<<set $tempTime = $temp1>>
-<<if $tempTime < 0>>
-	<<set $tempTime = 0>>
-<</if>>
-<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+<<PassTime `Math.max($temp1, 0)`>><<include "GeneralTimeFinal">>
 <</nobr>>
 [img[setup.ImagePath+'Foraging/landexcavation.png']]
 
@@ -1748,12 +1732,7 @@ You have worked $temp1 days and excavated $temp2 2x2x2 cubic meters of earth to 
 	<<set $cityPaintDubloons += $temp2>>
 <</if>>
 <<set $dubloons += $temp2>>
-
-<<set $tempTime = $temp1>>
-<<if $tempTime < 0>>
-	<<set $tempTime = 0>>
-<</if>>
-<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+<<PassTime `Math.max($temp1, 0)`>><<include "GeneralTimeFinal">>
 <</nobr>>
 [img[setup.ImagePath+'Foraging/citypainter.png']]
 
@@ -1775,12 +1754,7 @@ You have worked $temp1 days and painted $temp2 square km of building surface to 
 	<<set $energyGenDubloons += $temp2>>
 <</if>>
 <<set $dubloons += $temp2>>
-
-<<set $tempTime = $temp1>>
-<<if $tempTime < 0>>
-	<<set $tempTime = 0>>
-<</if>>
-<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+<<PassTime `Math.max($temp1, 0)`>><<include "GeneralTimeFinal">>
 <</nobr>>
 [img[setup.ImagePath+'Foraging/energygenerator.png']]
 
@@ -1802,12 +1776,7 @@ You have worked $temp1 days and generated <<print ($temp2 / 4)>> kWh of energy t
 	<<set $roboProstituteDubloons += $temp2>>
 <</if>>
 <<set $dubloons += $temp2>>
-
-<<set $tempTime = $temp1>>
-<<if $tempTime < 0>>
-	<<set $tempTime = 0>>
-<</if>>
-<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+<<PassTime `Math.max($temp1, 0)`>><<include "GeneralTimeFinal">>
 <</nobr>>
 [img[setup.ImagePath+'Foraging/energygenerator.png']]
 
@@ -1824,8 +1793,7 @@ You have worked $temp1 days and brought robots to artificial orgasm $temp2 times
 :: Layer7 Threat2 [layer7]
 <<nobr>>
 <<set $timeL7T2 -= 6>>
-<<set $tempTime = 1>>
-<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+<<PassTime 1>><<include "GeneralTimeFinal">>
 <</nobr>>
 [img[setup.ImagePath+'Threats/securityrobot.png']]
 

--- a/src/layer7.twee
+++ b/src/layer7.twee
@@ -320,7 +320,7 @@ If you're not dissuaded and choose to continue onward, it will take you 8 days t
 :: Layer7 Threat2 Main [layer7]
 <<nobr>>
 <<set $timeL7T2 -= 6>>
-<<PassTime 1>><<include "GeneralTimeFinal">>
+<<PassTime 1>>
 <</nobr>>
 [img[setup.ImagePath+'Threats/securityrobot.png']]
 <<if $playerCurses.some(e => e.name === "Hypno Happytime") && $layer7Hypno < 3>><<set $layer7Hypno += 1>>
@@ -1375,7 +1375,7 @@ You retrieve your Relics and find that you have successfully switched the abilit
 
 [[Continue your business on the seventh layer|Layer7 Hub]]<br><br>
 
-<<AdjustedTravelTime "$tempTime" 2>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" 2>><<PassTime $tempTime>>
 <<set $dubloons -= 4>>
 
 <<set $temp = $relicSwap.length>>
@@ -1406,59 +1406,54 @@ You have no choice, you gain consciousness a few times to see yourself in a surg
 	<<if $DaedalusFly==true>>
 		<<set $tempTime= Math.ceil($tempTime/2)>>
 	<</if>>
-	<<AdjustedTravelTime "$tempTime" $tempTime>>
-	<<set $layerExitTime=$tempTime>>
+	<<AdjustedTravelTime "$layerExitTime" $tempTime>>
+<</if>>
+<<set _triggers = {
+	inDebt: () => $dubloons < 0,
+	rehabilitated: () => $timeL7T2 > 5,
+}>>
+
+<<PassTime $layerExitTime _triggers "_done">>
+
+<<if _triggers.inDebt() && $easymode>>
+	<br>[img[setup.ImagePath+'Threats/taxdrone.png']]<br><br>
+
+	<br>A quiet humming sound descends upon you as you see the Taxdrone floating towards you from over a nearby building. You reach into your pack to get your typical dubloon payment, but then you realize something is wrong, you can't find any dubloons! Perhaps you didn't keep track of them properly? But it's too late to get any now, the taxes are already due.<br><br>
+
+	The Taxdrone patiently requests that you submit your taxes as it displays a slot for you to deposit the dubloons into, but soon it realizes you will not be paying and the typically soft blue lights on the drone change to glaring red and an alarm sounds.<br><br>
+
+	Within a moment you are restrained by nets made of light and you feel a prick on your neck. You notice the drone has stabbed you with a syringe, but at this point it's too late to resist and your consciousness begins to fade, leaving you to succumb to your fate.<br><br>
+
+	As you awaken later that day you feel your entire body still aching. However, the Taxdrone is nowhere to be found and you feel like you escaped a terrible fate.<br><br>
+
+	[[Continue your journey|Layer7 Ascend2]]<br><br>
+	<<set $status.penalty += 2>>
+	<<set $status.duration += 1>>
+	<<set $dubloons = 3>>
+<<elseif _triggers.inDebt() && !$easymode>>
+	<br>[img[setup.ImagePath+'Threats/taxdrone.png']]<br><br>
+
+	<br>A quiet humming sound descends upon you as you see the Taxdrone floating towards you from over a nearby building. You reach into your pack to get your typical dubloon payment, but then you realize something is wrong, you can't find any dubloons! Perhaps you didn't keep track of them properly? But it's too late to get any now, the taxes are already due.<br><br>
+
+	The Taxdrone patiently requests that you submit your taxes as it displays a slot for you to deposit the dubloons into, but soon it realizes you will not be paying and the typically soft blue lights on the drone change to glaring red and an alarm sounds.<br><br>
+
+	Within a moment you are restrained by nets made of light and you feel a prick on your neck. You notice the drone has stabbed you with a syringe, but at this point it's too late to resist and your consciousness begins to fade, leaving you to succumb to your fate.<br><br>
+
+	You are now forced to become a permanent resident of Layer 7.<br><br>
+
+	[[Awaken to your new life|Layer7 Tax End]]<br><br>
+<<elseif _triggers.rehabilitated()>>
+	<br>A an enormous rumbling catches your attention as you walk through the seventh layer. A brief glance around reveals the source, an enormous, building-sized machine that is now rapidly approaching you. You consider running, but the Security Robot is moving at an incredible speed, leaving you no chance to get away. <br><br>
+
+	"ACCEPT REHABILITATION" a synthetic voice calls out, with the huge robot nearly upon you. <br><br>
+
+	And suddenly, it's here, reaching down to grab you with shining metallic arms and pulling you into its shell.<br><br>
+
+	[[Get rehabilitated|Layer7 Threat2][$returnPassage = passage()]]<br><br>
 <</if>>
 
-<<for $layerExitTime; $layerExitTime >0; $layerExitTime-->>
-	<<PassTime 1>>
-
-	<<if $dubloons < 0 && $easymode==false>>
-		<br>[img[setup.ImagePath+'Threats/taxdrone.png']]<br><br>
-
-		<br>A quiet humming sound descends upon you as you see the Taxdrone floating towards you from over a nearby building. You reach into your pack to get your typical dubloon payment, but then you realize something is wrong, you can't find any dubloons! Perhaps you didn't keep track of them properly? But it's too late to get any now, the taxes are already due.<br><br>
-
-		The Taxdrone patiently requests that you submit your taxes as it displays a slot for you to deposit the dubloons into, but soon it realizes you will not be paying and the typically soft blue lights on the drone change to glaring red and an alarm sounds.<br><br>
-
-		Within a moment you are restrained by nets made of light and you feel a prick on your neck. You notice the drone has stabbed you with a syringe, but at this point it's too late to resist and your consciousness begins to fade, leaving you to succumb to your fate.<br><br>
-
-		You are now forced to become a permanent resident of Layer 7.<br><br>
-
-		[[Awaken to your new life|Layer7 Tax End]]<br><br>
-
-		<<set $layerExitTime -= 1>><<break>>
-	<<elseif  $dubloons < 0 && $easymode==true>>
-
-		<br>[img[setup.ImagePath+'Threats/taxdrone.png']]<br><br>
-
-		<br>A quiet humming sound descends upon you as you see the Taxdrone floating towards you from over a nearby building. You reach into your pack to get your typical dubloon payment, but then you realize something is wrong, you can't find any dubloons! Perhaps you didn't keep track of them properly? But it's too late to get any now, the taxes are already due.<br><br>
-
-		The Taxdrone patiently requests that you submit your taxes as it displays a slot for you to deposit the dubloons into, but soon it realizes you will not be paying and the typically soft blue lights on the drone change to glaring red and an alarm sounds.<br><br>
-
-		Within a moment you are restrained by nets made of light and you feel a prick on your neck. You notice the drone has stabbed you with a syringe, but at this point it's too late to resist and your consciousness begins to fade, leaving you to succumb to your fate.<br><br>
-
-		As you awaken later that day you feel your entire body still aching. However, the Taxdrone is nowhere to be found and you feel like you escaped a terrible fate.<br><br>
-		<<set $status.penalty += 2>>
-		<<set $status.duration += 1>><br><br>
-		<<set $dubloons = 3>>
-
-	<</if>>
-		
-	<<if $timeL7T2 > 5>>
-		<br>A an enormous rumbling catches your attention as you walk through the seventh layer. A brief glance around reveals the source, an enormous, building-sized machine that is now rapidly approaching you. You consider running, but the Security Robot is moving at an incredible speed, leaving you no chance to get away. <br><br>
-
-		"ACCEPT REHABILITATION" a synthetic voice calls out, with the huge robot nearly upon you. <br><br>
-
-		And suddenly, it's here, reaching down to grab you with shining metallic arms and pulling you into its shell.<br><br>
-
-		[[Get rehabilitated|Layer7 Threat2][$returnPassage = "Layer7 Ascend2"]]<br><br>
-		<<set $layerExitTime -= 1>><<break>>
-	<</if>>
-<</for>>
-<<include "GeneralTimeFinal">>
-
 <</nobr>>
-<<if $layerExitTime == 0 && !($dubloons < 0) && !($timeL7T2 > 5)>>
+<<if _done>>
 	<<nobr>>
 	<<set $corruption -= (80 - $corRed)>>
 
@@ -1483,7 +1478,7 @@ You have no choice, you gain consciousness a few times to see yourself in a surg
 :: Layer7 Threat2 Ascend [layer7]
 <<nobr>>
 <<set $timeL7T2 -= 6>>
-<<PassTime 1>><<include "GeneralTimeFinal">>
+<<PassTime 1>>
 <</nobr>>
 [img[setup.ImagePath+'Threats/securityrobot.png']]
 
@@ -1547,58 +1542,53 @@ You have no choice, you gain consciousness a few times to see yourself in a surg
 <<nobr>>
 <<if $layerExit == 0>>
 	<<set $layerExit = 1>>
-	<<AdjustedTravelTime "$tempTime" 8>>
-	<<set $layerExitTime=$tempTime>>
+	<<AdjustedTravelTime "$layerExitTime" 8>>
+<</if>>
+<<set _triggers = {
+	inDebt: () => $dubloons < 0,
+	rehabilitated: () => $timeL7T2 > 5,
+}>>
+
+<<PassTime $layerExitTime _triggers "_done">>
+
+<<if _triggers.inDebt() && $easymode>>
+	<br>[img[setup.ImagePath+'Threats/taxdrone.png']]<br><br>
+
+	<br>A quiet humming sound descends upon you as you see the Taxdrone floating towards you from over a nearby building. You reach into your pack to get your typical dubloon payment, but then you realize something is wrong, you can't find any dubloons! Perhaps you didn't keep track of them properly? But it's too late to get any now, the taxes are already due.<br><br>
+
+	The Taxdrone patiently requests that you submit your taxes as it displays a slot for you to deposit the dubloons into, but soon it realizes you will not be paying and the typically soft blue lights on the drone change to glaring red and an alarm sounds.<br><br>
+
+	Within a moment you are restrained by nets made of light and you feel a prick on your neck. You notice the drone has stabbed you with a syringe, but at this point it's too late to resist and your consciousness begins to fade, leaving you to succumb to your fate.<br><br>
+
+	As you awaken later that day you feel your entire body still aching. However, the Taxdrone is nowhere to be found and you feel like you escaped a terrible fate.<br><br>
+
+	[[Continue your journey|Layer7 Exit2]]<br><br>
+	<<set $status.penalty += 2>>
+	<<set $status.duration += 1>>
+	<<set $dubloons = 3>>
+<<elseif _triggers.inDebt() && !$easymode>>
+	<br>[img[setup.ImagePath+'Threats/taxdrone.png']]<br><br>
+
+	<br>A quiet humming sound descends upon you as you see the Taxdrone floating towards you from over a nearby building. You reach into your pack to get your typical dubloon payment, but then you realize something is wrong, you can't find any dubloons! Perhaps you didn't keep track of them properly? But it's too late to get any now, the taxes are already due.<br><br>
+
+	The Taxdrone patiently requests that you submit your taxes as it displays a slot for you to deposit the dubloons into, but soon it realizes you will not be paying and the typically soft blue lights on the drone change to glaring red and an alarm sounds.<br><br>
+
+	Within a moment you are restrained by nets made of light and you feel a prick on your neck. You notice the drone has stabbed you with a syringe, but at this point it's too late to resist and your consciousness begins to fade, leaving you to succumb to your fate.<br><br>
+
+	You are now forced to become a permanent resident of Layer 7.<br><br>
+
+	[[Awaken to your new life|Layer7 Tax End]]<br><br>
+<<elseif _triggers.rehabilitated()>>
+	<br>A an enormous rumbling catches your attention as you walk through the seventh layer. A brief glance around reveals the source, an enormous, building-sized machine that is now rapidly approaching you. You consider running, but the Security Robot is moving at an incredible speed, leaving you no chance to get away. <br><br>
+
+	"ACCEPT REHABILITATION" a synthetic voice calls out, with the huge robot nearly upon you. <br><br>
+
+	And suddenly, it's here, reaching down to grab you with shining metallic arms and pulling you into its shell.<br><br>
+
+	[[Get rehabilitated|Layer7 Threat2][$returnPassage = passage()]]<br><br>
 <</if>>
 
-<<for $layerExitTime; $layerExitTime >0; $layerExitTime-->>
-	<<PassTime 1>>
-
-	<<if $dubloons < 0 && $easymode==false>>
-		<br>[img[setup.ImagePath+'Threats/taxdrone.png']]<br><br>
-
-		<br>A quiet humming sound descends upon you as you see the Taxdrone floating towards you from over a nearby building. You reach into your pack to get your typical dubloon payment, but then you realize something is wrong, you can't find any dubloons! Perhaps you didn't keep track of them properly? But it's too late to get any now, the taxes are already due.<br><br>
-
-		The Taxdrone patiently requests that you submit your taxes as it displays a slot for you to deposit the dubloons into, but soon it realizes you will not be paying and the typically soft blue lights on the drone change to glaring red and an alarm sounds.<br><br>
-
-		Within a moment you are restrained by nets made of light and you feel a prick on your neck. You notice the drone has stabbed you with a syringe, but at this point it's too late to resist and your consciousness begins to fade, leaving you to succumb to your fate.<br><br>
-
-		You are now forced to become a permanent resident of Layer 7.<br><br>
-
-		[[Awaken to your new life|Layer7 Tax End]]<br><br>
-
-		<<set $layerExitTime -= 1>><<break>>
-	<<elseif  $dubloons < 0 && $easymode==true>>
-
-		<br>[img[setup.ImagePath+'Threats/taxdrone.png']]<br><br>
-
-		<br>A quiet humming sound descends upon you as you see the Taxdrone floating towards you from over a nearby building. You reach into your pack to get your typical dubloon payment, but then you realize something is wrong, you can't find any dubloons! Perhaps you didn't keep track of them properly? But it's too late to get any now, the taxes are already due.<br><br>
-
-		The Taxdrone patiently requests that you submit your taxes as it displays a slot for you to deposit the dubloons into, but soon it realizes you will not be paying and the typically soft blue lights on the drone change to glaring red and an alarm sounds.<br><br>
-
-		Within a moment you are restrained by nets made of light and you feel a prick on your neck. You notice the drone has stabbed you with a syringe, but at this point it's too late to resist and your consciousness begins to fade, leaving you to succumb to your fate.<br><br>
-
-		As you awaken later that day you feel your entire body still aching. However, the Taxdrone is nowhere to be found and you feel like you escaped a terrible fate.<br><br>
-		<<set $status.penalty += 2>>
-		<<set $status.duration += 1>><br><br>
-		<<set $dubloons = 3>>
-	<</if>>
-		
-	<<if $timeL7T2 > 5>>
-		<br>A an enormous rumbling catches your attention as you walk through the seventh layer. A brief glance around reveals the source, an enormous, building-sized machine that is now rapidly approaching you. You consider running, but the Security Robot is moving at an incredible speed, leaving you no chance to get away. <br><br>
-
-		"ACCEPT REHABILITATION" a synthetic voice calls out, with the huge robot nearly upon you. <br><br>
-
-		And suddenly, it's here, reaching down to grab you with shining metallic arms and pulling you into its shell.<br><br>
-
-		[[Get rehabilitated|Layer7 Threat2][$returnPassage = "Layer7 Exit2"]]<br><br>
-		<<set $layerExitTime -= 1>><<break>>
-	<</if>>
-
-<</for>>
-<<include "GeneralTimeFinal">>
-
-<</nobr>><<if $layerExitTime == 0 && !($dubloons < 0) && !($timeL7T2 > 5)>>
+<</nobr>><<if _done>>
 
 <<set $timeL8T1 = 0>>\
 <<set $timeL8T2a = 0>>\
@@ -1615,7 +1605,7 @@ You have no choice, you gain consciousness a few times to see yourself in a surg
 :: Layer7 Threat2 Descend [layer7]
 <<nobr>>
 <<set $timeL7T2 -= 6>>
-<<AdjustedTravelTime "$tempTime" 1>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
+<<AdjustedTravelTime "$tempTime" 1>><<PassTime $tempTime>>
 <</nobr>>
 [img[setup.ImagePath+'Threats/securityrobot.png']]
 
@@ -1688,7 +1678,7 @@ You have no choice, you gain consciousness a few times to see yourself in a surg
 	<<set $heavyLiftDubloons += $temp2>>
 <</if>>
 <<set $dubloons += $temp2>>
-<<PassTime `Math.max($temp1, 0)`>><<include "GeneralTimeFinal">>
+<<PassTime `Math.max($temp1, 0)`>>
 <</nobr>>
 [img[setup.ImagePath+'Foraging/heavylifting.png']]
 
@@ -1710,7 +1700,7 @@ You have worked $temp1 days and moved $temp2 loads of "construction material" to
 	<<set $landExcavDubloons += $temp2>>
 <</if>>
 <<set $dubloons += $temp2>>
-<<PassTime `Math.max($temp1, 0)`>><<include "GeneralTimeFinal">>
+<<PassTime `Math.max($temp1, 0)`>>
 <</nobr>>
 [img[setup.ImagePath+'Foraging/landexcavation.png']]
 
@@ -1732,7 +1722,7 @@ You have worked $temp1 days and excavated $temp2 2x2x2 cubic meters of earth to 
 	<<set $cityPaintDubloons += $temp2>>
 <</if>>
 <<set $dubloons += $temp2>>
-<<PassTime `Math.max($temp1, 0)`>><<include "GeneralTimeFinal">>
+<<PassTime `Math.max($temp1, 0)`>>
 <</nobr>>
 [img[setup.ImagePath+'Foraging/citypainter.png']]
 
@@ -1754,7 +1744,7 @@ You have worked $temp1 days and painted $temp2 square km of building surface to 
 	<<set $energyGenDubloons += $temp2>>
 <</if>>
 <<set $dubloons += $temp2>>
-<<PassTime `Math.max($temp1, 0)`>><<include "GeneralTimeFinal">>
+<<PassTime `Math.max($temp1, 0)`>>
 <</nobr>>
 [img[setup.ImagePath+'Foraging/energygenerator.png']]
 
@@ -1776,7 +1766,7 @@ You have worked $temp1 days and generated <<print ($temp2 / 4)>> kWh of energy t
 	<<set $roboProstituteDubloons += $temp2>>
 <</if>>
 <<set $dubloons += $temp2>>
-<<PassTime `Math.max($temp1, 0)`>><<include "GeneralTimeFinal">>
+<<PassTime `Math.max($temp1, 0)`>>
 <</nobr>>
 [img[setup.ImagePath+'Foraging/energygenerator.png']]
 
@@ -1793,7 +1783,7 @@ You have worked $temp1 days and brought robots to artificial orgasm $temp2 times
 :: Layer7 Threat2 [layer7]
 <<nobr>>
 <<set $timeL7T2 -= 6>>
-<<PassTime 1>><<include "GeneralTimeFinal">>
+<<PassTime 1>>
 <</nobr>>
 [img[setup.ImagePath+'Threats/securityrobot.png']]
 

--- a/src/layer7.twee
+++ b/src/layer7.twee
@@ -626,7 +626,7 @@ Choose the Relic you would like to sell:
 <<nobr>>
 <<set _callback = v => v - 15 + $sellAdd / 2>>
 <<for _relic range $ownedRelics>>
-	<<capture _callback, _relic>>
+	<<capture _callback _relic>>
 		<<set _linkText = `Sell ${_relic.name} for ${Math.max(_callback(_relic.value), 0)} dubloons`>>
 		/* Add a bit of indentation: */ &nbsp;
 		<<switch _relic.name>>

--- a/src/layer8.twee
+++ b/src/layer8.twee
@@ -1304,36 +1304,32 @@ Ready? Getting back up out of this terrible prison and back to layer 7 will take
 	<<if $DaedalusFly==true>>
 		<<set $tempTime= Math.ceil($tempTime/2)>>
 	<</if>>
-	<<AdjustedTravelTime "$tempTime" $tempTime>>
-	<<set $layerExitTime=$tempTime>>
+	<<AdjustedTravelTime "$layerExitTime" $tempTime>>
+<</if>>
+<<set _triggers = {
+	dementialAberrations2a: () => ($timeL8T2a > 6 && !$hiredCompanions.some(e => e.name === "Maru") && $L8T1aCount < 2) || ($timeL8T2a > 7 && $L8T1aCount < 2),
+	dementialAberrations2b: () => ($timeL8T2b > 20 && !$hiredCompanions.some(e => e.name === "Maru")) || $timeL8T2b > 23,
+}>>
+
+<<PassTime $layerExitTime _triggers "_done">>
+
+<<if _triggers.dementialAberrations2a()>>
+	[img[setup.ImagePath+'Threats/dementialaberrations.png']]<br>
+
+	Behind every corner there seems to be a hint of something strange and wrong. The combination of the stress and the inherent wrongness of this layer is calling your
+	<<if $hiredCompanions.length > 0>> party's<</if>> sanity into question. And even if you know that these things aren't real, 
+	it doesn't mean you aren't stopped in your tracks for a day while you reckon with the horrific visions.<br>
+	[[Deal with the Demential Aberrations|Layer 8 Threat 2a][$returnPassage = passage(), $L8loopLim=false]]
+<<elseif _triggers.dementialAberrations2b()>>
+	[img[setup.ImagePath+'Threats/dementialaberrations.png']]<br>
+
+	You can feel the deepest fears of your party manifesting into reality once again. 
+	However, this time, they are not mere visions, but physical manifestations of your fears.<br>
+	[[Deal with the Demential Aberrations|Layer 8 Threat 2b][$returnPassage = passage(), $L8loopLim=false]]
 <</if>>
 
-<<for $layerExitTime; $layerExitTime >0; $layerExitTime-->>
-	<<PassTime 1>>
-	
-	<<if ($timeL8T2a > 6 && !$hiredCompanions.some(e => e.name === "Maru") && $L8T1aCount < 2) || ($timeL8T2a > 7 && $L8T1aCount < 2)>>
-		[img[setup.ImagePath+'Threats/dementialaberrations.png']]<br>
-
-		Behind every corner there seems to be a hint of something strange and wrong. The combination of the stress and the inherent wrongness of this layer is calling your
-		<<if $hiredCompanions.length > 0>> party's<</if>> sanity into question. And even if you know that these things aren't real, 
-		it doesn't mean you aren't stopped in your tracks for a day while you reckon with the horrific visions.<br>
-		[[Deal with the Demential Aberrations|Layer 8 Threat 2a][$returnPassage = "Layer8 Ascend2", $L8loopLim=false]]
-		<<set $layerExitTime -= 1>><<break>>
-
-	<<elseif ($timeL8T2b > 20 && !$hiredCompanions.some(e => e.name === "Maru")) || $timeL8T2b > 23>>
-		[img[setup.ImagePath+'Threats/dementialaberrations.png']]<br>
-
-		You can feel the deepest fears of your party manifesting into reality once again. 
-		However, this time, they are not mere visions, but physical manifestations of your fears.<br>
-		[[Deal with the Demential Aberrations|Layer 8 Threat 2b][$returnPassage = "Layer8 Ascend2", $L8loopLim=false]]
-		<<set $layerExitTime -= 1>><<break>>
-	<</if>>
-	<<set $L8loopLim=true>>
-<</for>>
-<<include "GeneralTimeFinal">>
-
 <</nobr>>
-<<if $layerExitTime == 0 && !(($timeL8T2a > 6 && !$hiredCompanions.some(e => e.name === "Maru") && $L8T1aCount < 2) || ($timeL8T2a > 7 && $L8T1aCount < 2)) && !(($timeL8T2b > 20 && !$hiredCompanions.some(e => e.name === "Maru")) || $timeL8T2b > 23)>>
+<<if _done>>
 	<<set $corruption -= (100 - $corRed)>><<set $timeL7T2 = 0>>\
 	Despite the fact your journey was through hallways and staircases rather than fields of tentacles or sandy deserts the journey was somehow especially arduous. The dimension-bending appearance of this layer combined with the horrific visions and terrifying manifestions it brought upon you makes you grateful to return to the dystopian city you descended from.
 
@@ -1360,35 +1356,31 @@ If you continue your descent in spite of everything, descending past this layer'
 <<nobr>>
 <<if $layerExit == 0>>
 	<<set $layerExit = 1>>
-	<<AdjustedTravelTime "$tempTime" 45>>
-	<<set $layerExitTime=$tempTime>>
+	<<AdjustedTravelTime "$layerExitTime" 45>>
+<</if>>
+<<set _triggers = [
+	() => ($timeL8T2a > 6 && !$hiredCompanions.some(e => e.name === "Maru") && $L8T1aCount < 2) || ($timeL8T2a > 7 && $L8T1aCount < 2),
+	() => ($timeL8T2b > 20 && !$hiredCompanions.some(e => e.name === "Maru")) || $timeL8T2b > 23,
+]>>
+
+<<PassTime $layerExitTime _triggers "_done">>
+
+<<if _triggers[0]()>>
+	[img[setup.ImagePath+'Threats/dementialaberrations.png']]<br>
+
+	Behind every corner there seems to be a hint of something strange and wrong. The combination of the stress and the inherent wrongness of this layer is calling your
+	<<if $hiredCompanions.length > 0>> party's<</if>> sanity into question. And even if you know that these things aren't real, 
+	it doesn't mean you aren't stopped in your tracks for a day while you reckon with the horrific visions.<br>
+	[[Deal with the Demential Aberrations|Layer 8 Threat 2a][$returnPassage = passage(), $L8loopLim=false]]
+<<elseif _triggers[1]()>>
+	[img[setup.ImagePath+'Threats/dementialaberrations.png']]<br>
+
+	You can feel the deepest fears of your party manifesting into reality once again. 
+	However, this time, they are not mere visions, but physical manifestations of your fears.<br>
+	[[Deal with the Demential Aberrations|Layer 8 Threat 2b][$returnPassage = passage(), $L8loopLim=false]]
 <</if>>
 
-<<for $layerExitTime; $layerExitTime >0; $layerExitTime-->>
-	<<PassTime 1>>
-
-	<<if ($timeL8T2a > 6 && !$hiredCompanions.some(e => e.name === "Maru") && $L8T1aCount < 2) || ($timeL8T2a > 7 && $L8T1aCount < 2)>>
-		[img[setup.ImagePath+'Threats/dementialaberrations.png']]<br>
-
-		Behind every corner there seems to be a hint of something strange and wrong. The combination of the stress and the inherent wrongness of this layer is calling your
-		<<if $hiredCompanions.length > 0>> party's<</if>> sanity into question. And even if you know that these things aren't real, 
-		it doesn't mean you aren't stopped in your tracks for a day while you reckon with the horrific visions.<br>
-		[[Deal with the Demential Aberrations|Layer 8 Threat 2a][$returnPassage = "Layer8 Exit2", $L8loopLim=false]]
-		<<set $layerExitTime -= 1>><<break>>
-
-	<<elseif ($timeL8T2b > 20 && !$hiredCompanions.some(e => e.name === "Maru")) || $timeL8T2b > 23>>
-		[img[setup.ImagePath+'Threats/dementialaberrations.png']]<br>
-
-		You can feel the deepest fears of your party manifesting into reality once again. 
-		However, this time, they are not mere visions, but physical manifestations of your fears.<br>
-		[[Deal with the Demential Aberrations|Layer 8 Threat 2b][$returnPassage = "Layer8 Exit2", $L8loopLim=false]]
-		<<set $layerExitTime -= 1>><<break>>
-	<</if>>
-	<<set $L8loopLim=true>>
-<</for>>
-<<include "GeneralTimeFinal">>
-
-<<if $layerExitTime == 0 && !(($timeL8T2a > 6 && !$hiredCompanions.some(e => e.name === "Maru") && $L8T1aCount < 2) || ($timeL8T2a > 7 && $L8T1aCount < 2)) && !(($timeL8T2b > 20 && !$hiredCompanions.some(e => e.name === "Maru")) || $timeL8T2b > 23)>>
+<<if _done>>
 
 	At the very bottom of the layer you come across what appears to be a very deep pool of water. There doesn't seem to be any other way through besides this pool, so you'll need some kind of way to breathe underwater to continue forwards. The diving gear from Outset town or the Merfolk Curse could work, or you could use the Pneuma Wisp Relic to bypass the issue entirely. Other than that, you would need to get creative.<br><br>
 	<<set $L8loopLim=false>>

--- a/src/layer8.twee
+++ b/src/layer8.twee
@@ -1309,9 +1309,7 @@ Ready? Getting back up out of this terrible prison and back to layer 7 will take
 <</if>>
 
 <<for $layerExitTime; $layerExitTime >0; $layerExitTime-->>
-
-	<<set $tempTime = 1>>
-	<<include "GeneralTimeStats">>
+	<<PassTime 1>>
 	
 	<<if ($timeL8T2a > 6 && !$hiredCompanions.some(e => e.name === "Maru") && $L8T1aCount < 2) || ($timeL8T2a > 7 && $L8T1aCount < 2)>>
 		[img[setup.ImagePath+'Threats/dementialaberrations.png']]<br>
@@ -1367,9 +1365,7 @@ If you continue your descent in spite of everything, descending past this layer'
 <</if>>
 
 <<for $layerExitTime; $layerExitTime >0; $layerExitTime-->>
-
-	<<set $tempTime = 1>>
-	<<include "GeneralTimeStats">>
+	<<PassTime 1>>
 
 	<<if ($timeL8T2a > 6 && !$hiredCompanions.some(e => e.name === "Maru") && $L8T1aCount < 2) || ($timeL8T2a > 7 && $L8T1aCount < 2)>>
 		[img[setup.ImagePath+'Threats/dementialaberrations.png']]<br>

--- a/src/layer9.twee
+++ b/src/layer9.twee
@@ -26,7 +26,7 @@ Hopefully you'll be able to get used to it.
 
 [[Version End]]
 
-[[Walk through the sixth layer of the Abyss|Layer9 Hub]]<<nobr>><<if $hiredCompanions.some(e => e.name === "Cherry")>>
+[[Walk through the ninth layer of the Abyss|Layer9 Hub]]<<nobr>><<if $hiredCompanions.some(e => e.name === "Cherry")>>
 <<if $visitL9 == 0>>
 	<br><<print "[[Use Cherry's chaotic luck|Layer9 Cherry]]">><</if>>
 <</if>><</nobr>>

--- a/src/script.js
+++ b/src/script.js
@@ -223,10 +223,18 @@ setup.SoundPath = setup.Path + "sounds/";
 Macro.add('say', {
 		tags: null,
 		handler: function () {
-			let person = this.args[0];
-			let output = '<div class="say clearfix" style="'+ person.style + person.style1 +'">';
-			output += '<div class="avatar"><img src="'+ setup.ImagePath + person.imageIcon +'"  width="100" height="100"></div>';
-			output += '<span class="say-nameB">' + person.name + '</span><hr><span class="say-contents"><span class ="gdr' +person.genderVoice+'">' + this.payload[0].contents + '</span></span></div>';
+			const person = this.args[0];
+			const output =
+				`<div class="say clearfix" style="${person?.style ?? ''}${person?.style1 ?? ''}">` +
+					`<div class="avatar">` +
+						`<img src="${setup.ImagePath}${person?.imageIcon ?? ''}" style="width:100px;height:100px">` +
+					`</div>` +
+					`<span class="say-nameB">${person?.name ?? ''}</span>` +
+					`<hr>` +
+					`<span class="say-contents">` +
+						`<span class="gdr${person?.genderVoice ?? ''}">${this.payload[0].contents}</span>` +
+					`</span>` +
+				`</div>`;
 			$(this.output).wiki(output);
 		}
 });

--- a/src/widgets.twee
+++ b/src/widgets.twee
@@ -2118,7 +2118,7 @@
 			<</if>>
 			Uncertain of how to handle the egg<<if _eggs>1>>s<</if>>, you ultimately decide to dispose of <<if _eggs>1>>them<<else>>it<</if>>. Exhausted from the ordeal, you can do nothing but rest, your day effectively wasted.
 			<br><br>
-			<<PassTime 1>><<include "GeneralTimeFinal">>
+			<<PassTime 1>>
 		<<else>>
 			<<if !settings.MenCycleToggleFilter>>
 				<<if $menFirstCycle == true>>
@@ -3017,7 +3017,7 @@
 <<capture _relic>>
 	<<set _relic = _args[0]>>
 	<<set $ownedRelics.push(_relic)>>
-	<<AdjustedTravelTime "$tempTime" _relic.time false `-$SibylBuff`>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
+	<<AdjustedTravelTime "$tempTime" _relic.time false `-$SibylBuff`>><<PassTime $tempTime>>
 	<<set $corruption -= Math.max(_relic.corr - $corRed + ($currentLayer != 6 ? 5 * Math.trunc($hexflame / 10) : 0), 0)>>
 	<<if _relic.pic>>
 		[img[setup.ImagePath + _relic.pic]]<br>

--- a/src/widgets.twee
+++ b/src/widgets.twee
@@ -646,7 +646,7 @@
 
 :: Age widget [widget nobr]
 <<widget "AgeCorrected">>
-<<capture _handle, _AgeLog>>
+<<capture _handle _AgeLog>>
 	<<for _handle range $hiredCompanions>>
 		<<set _tempName = _handle.name != $companionTwin.name ? _handle.name : "Twin">>
 		<<set _AgeLog = State.variables["AgeLog" + (_handle.name != $companionTwin.name ? _handle.name : "Twin")]>>
@@ -659,7 +659,7 @@
 <</widget>>
 
 :: CorrectAge [nobr]
-<<capture _oldTime, _eventAge, _ageEvent, _newTime>>
+<<capture _oldTime _eventAge _ageEvent _newTime>>
 	<<set _oldTime = 0>>
 	<<set _eventAge = _handle.age>>
 	<<for _ageEvent range _AgeLog>>

--- a/src/widgets.twee
+++ b/src/widgets.twee
@@ -2118,8 +2118,7 @@
 			<</if>>
 			Uncertain of how to handle the egg<<if _eggs>1>>s<</if>>, you ultimately decide to dispose of <<if _eggs>1>>them<<else>>it<</if>>. Exhausted from the ordeal, you can do nothing but rest, your day effectively wasted.
 			<br><br>
-			<<set $tempTime=1>>
-			<<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+			<<PassTime 1>><<include "GeneralTimeFinal">>
 		<<else>>
 			<<if !settings.MenCycleToggleFilter>>
 				<<if $menFirstCycle == true>>
@@ -3018,7 +3017,7 @@
 <<capture _relic>>
 	<<set _relic = _args[0]>>
 	<<set $ownedRelics.push(_relic)>>
-	<<AdjustedTravelTime "$tempTime" _relic.time false `-$SibylBuff`>><<include "GeneralTimeStats">><<include "GeneralTimeFinal">>
+	<<AdjustedTravelTime "$tempTime" _relic.time false `-$SibylBuff`>><<PassTime $tempTime>><<include "GeneralTimeFinal">>
 	<<set $corruption -= Math.max(_relic.corr - $corRed + ($currentLayer != 6 ? 5 * Math.trunc($hexflame / 10) : 0), 0)>>
 	<<if _relic.pic>>
 		[img[setup.ImagePath + _relic.pic]]<br>

--- a/t3lt.twee-config.yml
+++ b/t3lt.twee-config.yml
@@ -116,6 +116,10 @@ sugarcube-2:
       name: ObjectivePronoun
       parameters:
         - ""
+    PassTime:
+      name: PassTime
+      parameters:
+        - "var|number"
     PenisLengthText:
       name: PenisLengthText
       parameters:

--- a/t3lt.twee-config.yml
+++ b/t3lt.twee-config.yml
@@ -119,7 +119,7 @@ sugarcube-2:
     PassTime:
       name: PassTime
       parameters:
-        - "var|number"
+        - "var|number |+ var |+ string"
     PenisLengthText:
       name: PenisLengthText
       parameters:


### PR DESCRIPTION
This is a pretty big one:
* Turns the `GeneralTimeStats` passage into the `<<PassTime>>` widget.
* Performs all checks (layer adjustments, eating and drinking) in one big loop to keep them consistent.
* Replaces the layer exit loops with the `<<PassTime>>` widget by passing the event triggers into it.
* Makes the time reduction from endless aeonglass work through the `<<PassTime>>` widget.

The `<<PassTime>>` widget tracks its own state via a `Map`, using the active passage name as the key. This means that it can be nested without causing problems and it can resume across passage transitions. In theory you could even bounce back and forth between the same two ongoing time events, although I wouldn't recommend it.

For layer exit events, you now pass an object containing all of the event triggers. Once the macro returns, the same object is used to check which (if any) event to display. If no triggers fired, the macro cleans up and sets an optional output variable to `true`, which can be checked to move on.

For example, here is how the passage for descending from layer 6 to layer 7 looks now:

![image](https://github.com/FloricSpacer/AbyssDiver/assets/133602907/7d8e919a-39af-4ed2-ac3d-58a1eb9354f5)

Since `<<PassTime>>` now tracks its own state, `$layerExitTime` could also be turned into a temporary variable, but I didn't do that here.

I tested various events that cause time to pass (like descending and ascending) and didn't notice any issues, but this is still a pretty big change so it might end up needing some follow-up fixes.