### PR TITLE
Move layer ascent/descent event logic into travel event passage

### DIFF
--- a/src/global.twee
+++ b/src/global.twee
@@ -1807,12 +1807,13 @@ How many dubloons would you like to pay back?
 	_args[1]: var|number   = the raw, unadjusted travel time
 	_args[2]: [bool]       = whether to avoid adjustments beyond the travel time (optional, defaults to false)
 	_args[3]: [var|number] = initial additive modifier (optional, can be negative)
+	_args[4]: [var|number] = initial multiplicative modifier (optional, <1 is a bonus, >1 is a penalty)
 */
 <<set _inputTime = _args[1]>>
 <<set _forPreview = _args[2]>>
 
 /* Start by computing the overall additive modifier. */
-<<set _additiveModifier = _args[3] || 0>>
+<<set _additiveModifier = _args[3] ?? 0>>
 
 /* Apply time reduction from having Khemia with you. */
 <<set _additiveModifier -= $timeRed>>
@@ -1898,7 +1899,7 @@ How many dubloons would you like to pay back?
 
 /* If travel time wasn't eliminated entirely, apply multiplicative modifiers. */
 <<if _inputTime > 0>>
-	<<set _multiplicativeModifier = 1>>
+	<<set _multiplicativeModifier = _args[4] ?? 1>>
 	/* Double travel time if player has a size handicap (Colossal-able, or Minish-ish with no one to carry them). */
 	<<if $SizeHandicap>>
 		The burden of your inconvenient size hampers your progress, increasing your travel time.<br>
@@ -1972,53 +1973,8 @@ How many dubloons would you like to pay back?
 <</widget>>
 
 <<widget "PassTime">>
-<<capture _consumptionPerDay _doneVar _passage _random _state _threshold _timeWeight _triggers>>
-<<set _triggers = _args[1] ?? {}>> /* The event triggers, if any. */
-<<set _doneVar = _args[2]>> /* The variable to write to if we don't break early. */
-
-/* Let the caller know that we aren't done. */
-<<if _doneVar>><<print `<<set ${_doneVar} = false>>`>><</if>>
-
-/* Get the persistent state. */
-<<set _passage = passage()>>
-<<set $passTimeState ??= new Map()>>
-<<if $passTimeState.has(_passage)>>
-	/* We already have state for this passage, so use it. */
-	<<set _state = $passTimeState.get(_passage)>>
-<<else>>
-	/* Add new state for this passage. */
-	<<set _state = {
-		expectedDays: _args[0], /* The number of days of time to pass, modulo the time weight. */
-		unweightedDayIndex: 0,
-		weightedDayIndex: 0,
-		unweightedDay: 0,
-		weightedDay: 0,
-		nextRealDay: 0,
-		energy: _daysOfEnergyRations ?? 0,
-	}>>
-	<<set $passTimeState.set(_passage, _state)>>
-
-	/* Check for wetting events. */
-	<<if $WettingSolution == 0>>
-		<<if $playerCurses.some(e => e.name === "Urine Reamplification A") || $playerCurses.some(e => e.name === "Urine Reamplification B")>>
-			<<if $playerCurses.some(e => e.name === "Urine Reamplification A") && $playerCurses.some(e => e.name === "Urine Reamplification B")>>
-				<<set _random = random(1, Math.pow(3, _days))>>
-				<<set _threshold = Math.pow(3, _days) - Math.pow(2, _days)>>
-			<<else>>
-				<<set _random = random(1, Math.pow(15, _days))>>
-				<<set _threshold = Math.pow(15, _days) - Math.pow(14, _days)>>
-			<</if>>
-			<<if _random <= _threshold>>
-				<<include "Wetting Events">>
-			<</if>>
-		<</if>>
-	<</if>>
-
-	/* Check for Semen Demon events. */
-	<<if $playerCurses.some(e => e.name === "Semen Demon")>>
-		<<SemenDemonCalc _days>>
-	<</if>>
-<</if>>
+<<capture _consumptionPerDay _random _state _threshold _timeWeight _triggers>>
+<<set _triggers = typeof _args[0] == 'object' ? _args[0] : {}>> /* The event triggers, if any. */
 
 /* Calculate the amount of food and drink that needs to be consumed per day. */
 <<set _consumptionPerDay = 1>>
@@ -2031,6 +1987,38 @@ How many dubloons would you like to pay back?
 
 /* Set time weight to 1/2 if the Aeonglass with Endless Time relic is active. */
 <<set _timeWeight = $EndlessAeonglass ? 1/2 : 1>>
+
+/* Get the persistent state for the active passage. */
+<<set _state = setup.passingTime()>>
+<<if !_state>>
+	/* If we aren't passing time yet, assume that the number of days was passed in the first argument. */
+	<<set _state = setup.startPassingTime(_args[0])>>
+<</if>>
+<<if _state.expectedDays && !_state.unweightedDayIndex>>
+	/* Temporarily use the weighted day index to store the weighted expected number of days. */
+	<<set _state.weightedDayIndex = Math.round(_timeWeight * _state.expectedDays)>>
+	/* Check for wetting events. */
+	<<if $WettingSolution == 0>>
+		<<if $playerCurses.some(e => e.name === "Urine Reamplification A") || $playerCurses.some(e => e.name === "Urine Reamplification B")>>
+			<<if $playerCurses.some(e => e.name === "Urine Reamplification A") && $playerCurses.some(e => e.name === "Urine Reamplification B")>>
+				<<set _random = random(1, Math.pow(3, _state.weightedDayIndex))>>
+				<<set _threshold = Math.pow(3, _state.weightedDayIndex) - Math.pow(2, _state.weightedDayIndex)>>
+			<<else>>
+				<<set _random = random(1, Math.pow(15, _state.weightedDayIndex))>>
+				<<set _threshold = Math.pow(15, _state.weightedDayIndex) - Math.pow(14, _state.weightedDayIndex)>>
+			<</if>>
+			<<if _random <= _threshold>>
+				<<include "Wetting Events">>
+			<</if>>
+		<</if>>
+	<</if>>
+	/* Check for Semen Demon events. */
+	<<if $playerCurses.some(e => e.name === "Semen Demon")>>
+		<<SemenDemonCalc _state.weightedDayIndex>>
+	<</if>>
+	/* Reset the weighted day index. */
+	<<set _state.weightedDayIndex = 0>>
+<</if>>
 
 <<set _breakForEvent = false>>
 <<for _state.unweightedDayIndex < _state.expectedDays>>
@@ -2370,10 +2358,7 @@ How many dubloons would you like to pay back?
 
 <<if !_breakForEvent>>
 	/* Remove the persistent state for this passage. */
-	<<set $passTimeState.delete(_passage)>>
-
-	/* Let the caller know that we're done. */
-	<<if _doneVar>><<print `<<set ${_doneVar} = true>>`>><</if>>
+	<<set setup.stopPassingTime()>>
 
 	/* Print a notice if travel time was longer than predicted due to starvation or dehydration. */
 	<<if Math.round(_state.weightedDay) > Math.round(_state.weightedDayIndex)>>

--- a/src/init.twee
+++ b/src/init.twee
@@ -40,7 +40,6 @@ document.documentElement.setAttribute("lang", "en");
 <<set $timeL7 = 0>>
 <<set $timeL7T2 = 0>>
 <<set $timeL8 = 0>>
-<<set $timeL8T1 = 0>>
 <<set $timeL8T2a = 0>>
 <<set $timeL8T2b = 0>>
 <<set $timeL9 = 0>>
@@ -106,8 +105,6 @@ document.documentElement.setAttribute("lang", "en");
 <<set $skewedUsed = 0>>
 <<set $skewedForced = 0>>
 <<set $steadyForced = 0>>
-<<set $layerExit = 0>>
-<<set $layerExitTime = 0>>
 <<set $passTimeState = new Map()>>
 <<set $riverVisit = 0>>
 <<set $cut = 0>>

--- a/src/layer1.twee
+++ b/src/layer1.twee
@@ -1,9 +1,11 @@
 :: Layer1 1 [layer1]
 <<nobr>>
 <<set $currentLayer = 1>>
-<<masteraudio stop>><<audio "layer1" volume 0.2 play loop>>
+<<masteraudio stop>>
+<<audio "layer1" volume 0.2 play loop>>
+/* No threat timers to reset on layer 1. */
 <<if $dubloons < 0>>
-	<<set $debt += parseInt(Math.round(-1 * $dubloons * 1.2))>>
+	<<set $debt += Math.round(-1.2 * $dubloons)>>
 	<<set $dubloons = 0>>
 <</if>>
 <</nobr>>\
@@ -25,12 +27,16 @@ Traveling back to the surface from here will take 1 day, and will cost 10 corrup
 :: Layer1 Hub [layer1]
 <<nobr>>
 <<set $currentLayer = 1>>
+<<if !isPlaying("layer1")>>
+	<<masteraudio stop>>
+	<<audio "layer1" volume 0.2 play loop>>
+<</if>>
 <<CarryAdjust>>
 
 You find yourself amidst the slightly-off natural splendor of the first layer.<br><br> 
 <<if $visitL1 == 0>>
-	<<set $layerTemp = 8>>
 	<<set $visitL1 = 1>>
+	<<set $layerTemp = 8>>
 <<elseif $secondVisitL1 == 0>>
 	<<set $secondVisitL1 = 1>>
 	<<set $layerTemp = 18>>
@@ -92,8 +98,8 @@ What do you want to do while you're here?<br><br>
 [[Set up camp and rest here|Layer1 Camp]]
 [[View the Layer 1 habitation option|Layer1 Habitation]]
 
-[[Look up towards the surface|Layer1 Ascend]]
-[[Look down at the next layer|Layer1 Exit]]
+[[Look up towards the surface|Layer1 Ascend 1]]
+[[Look down at the next layer|Layer1 Exit1]]
 
 
 :: Layer1 Threats [image layer1]
@@ -317,14 +323,32 @@ You sit by the fire with your party and chat, the mood is pretty upbeat and opti
 <</nobr>>
 
 
-:: Layer1 Exit [layer1]
+:: Layer1 Exit1 [layer1]
 
 Descending to the next layer will take 2 days. How are your supplies of food and water? It's only going to get harder from here.
 
-You notice the air is a bit more humid and the plants are a bit greener as you approach the path towards the second layer.
+[[Turn back and continue your business on the first layer|Layer1 Hub]]
+[[Continue your descent to the second layer|Layer1 Exit2]]
 
-[[Stay on layer 1|Layer1 Hub]]
-[[Descend down to the second layer|Layer2 1]]
+
+:: Layer1 Exit2 [layer1]
+<<nobr>>
+
+<<if !setup.passingTime()>>
+	<<AdjustedTravelTime "_travelTime" 2>>
+	<<set setup.startPassingTime(_travelTime)>>
+<</if>>
+
+<<include "Layer1 Travel Events">>
+
+<</nobr>>\
+<<if !setup.passingTime()>>
+	You notice the air is a bit more humid and the plants are a bit greener as you approach the path towards the second layer.
+
+	<<include "Curse Descriptions">>
+
+	[[Descend down to the second layer|Layer2 1]]
+<</if>>
 
 
 :: Layer1 Cherry [layer1]
@@ -951,17 +975,17 @@ The Curse, $playerCurses[$temp].name, has been successfully removed and your cor
 [[Continue exploring the layer|Layer1 Hub]]
 
 
-:: Layer1 Ascend [layer1]
+:: Layer1 Ascend 1 [layer1]
 Traveling back to the surface from here will take 1 day, and will cost 10 corruption. Leaving the Abyss also requires that you don't have any negative corruption points even if you plan to come back.
 
 <<if $corruption >= (10 - $corRed)>>\
 	<<if $DaedalusEquip==true >>\
 		<<if $DaedalusFly==false>>\
 			You are currently commited to simply walking to the surface, though it iss only a one day walk.
-			[[Flap your wings and prepare to fly to the surface|Layer1 Ascend][$DaedalusFly=true]]
+			[[Flap your wings and prepare to fly to the surface|Layer1 Ascend 1][$DaedalusFly=true]]
 		<<else>>\
 			You are about to fly to the surface, which you can of course do if you want! On the other hand, it's only a one day walk.
-			[[Maybe it's better to walk to the surface|Layer1 Ascend][$DaedalusFly=false]]
+			[[Maybe it's better to walk to the surface|Layer1 Ascend 1][$DaedalusFly=false]]
 		<</if>>\
 	<</if>>\
 	[[Continue your ascent|Layer1 Ascend2]]
@@ -970,28 +994,44 @@ Traveling back to the surface from here will take 1 day, and will cost 10 corrup
 <</if>>
 [[Turn back and continue your business on the first layer|Layer1 Hub]]
 
+
+:: Layer1 Travel Events [layer1 nobr]
+<<set _triggers = {
+	/* No timed events for layer 1. */
+}>>
+
+<<PassTime _triggers>>
+
+
 :: Layer1 Ascend2 [layer1]
 <<nobr>>
-<<if $DaedalusFly==true>>
-	<<include "Companions Stranded">>
+
+<<if !setup.passingTime()>>
+	<<set _multiplier = 1>>
+	<<if $DaedalusFly>>
+		<<include "Companions Stranded">>
+		<<set _multiplier = 1/2>>
+	<</if>>
+	<<AdjustedTravelTime "_travelTime" 1 false 0 _multiplier>>
+	<<set setup.startPassingTime(_travelTime)>>
 <</if>>
-<<if $layerExit == 0>>
-	<<set $layerExit = 1>>
-	<<AdjustedTravelTime "$layerExitTime" 1>>
+
+<<include "Layer1 Travel Events">>
+
+<</nobr>>\
+<<if !setup.passingTime()>>
+	<<nobr>>
+		<<set $corruption -= 10 - $corRed + 5 * Math.trunc($hexflame / 10)>>
+	<</nobr>>
+	You continue your hike and eventually you see the edge of the Abyss, then eventually the buildings you recall from Outset Town come back into view and welcome you back to the surface world.
+
+	<<include "Curse Descriptions">>
+	<<if $TwinFly == true>>
+		<<include "Twin rejoin">>
+	<</if>>
+	[[Return to Outset Town|Surface Hub]]
 <</if>>
 
-<<PassTime $layerExitTime>>
-
-<<set $corruption -= (10 - $corRed)>>
-
-<</nobr>><<masteraudio stop>><<audio "surface" volume 0.2 play loop>>
-You continue your hike and eventually you see the edge of the Abyss, then eventually the buildings you recall from Outset Town come back into view and welcome you back to the surface world.
-
-<<include "Curse Descriptions">>
-<<if $TwinFly == true>>
-	<<include "Twin rejoin">>
-<</if>>
-[[Return to Outset Town|Surface Hub]]
 
 :: Layer1 Flasks [layer1]
 <<nobr>>
@@ -1028,7 +1068,7 @@ Using your knowledge of the Abyss, you specifically look to make sure you can ge
 <</for>>
 <<include "Curse Randomizer">>
 
-:: Layer1 Threat1 Ascend [layer1]
+:: Layer1 Threat1 [layer1]
 
 [img[setup.ImagePath+'Threats/opportunisticbandits.png']]
 

--- a/src/layer2.twee
+++ b/src/layer2.twee
@@ -1,9 +1,9 @@
 :: Layer2 1 [layer2]
 <<nobr>>
-<<masteraudio stop>><<audio "layer2" volume 0.2 play loop>>
-<<AdjustedTravelTime "$tempTime" 2>><<PassTime $tempTime>>
-<<set $timeL2T1 = 0>>
 <<set $currentLayer = 2>>
+<<masteraudio stop>>
+<<audio "layer2" volume 0.2 play loop>>
+<<set $timeL2T1 = 0>>
 <</nobr>>\
 \
 @@.layerTitle;
@@ -23,13 +23,19 @@ This layer is filled with a very dense growth of vines, bushes, and other plant 
 
 
 :: Layer2 Hub [layer2]
-<<nobr>><<set $currentLayer = 2>>
-<<set $layerExit = 0>>
+<<nobr>>
+<<set $currentLayer = 2>>
+<<if !isPlaying("layer2")>>
+	<<masteraudio stop>>
+	<<audio "layer2" volume 0.2 play loop>>
+<</if>>
 <<CarryAdjust>>
-<</nobr>><<if $timeL2T1 < 4 || $hiredCompanions.length > 3>><<nobr>>
+
+<</nobr>>\
+<<if $timeL2T1 < 4 || $hiredCompanions.length > 3>><<nobr>>
 	<<if $visitL2 == 0>>
-		<<set $layerTemp = 8>>
 		<<set $visitL2 = 1>>
+		<<set $layerTemp = 8>>
 	<<elseif $secondVisitL2 == 0>>
 		<<set $secondVisitL2 = 1>>
 		<<set $layerTemp = 18>>
@@ -101,7 +107,7 @@ This layer is filled with a very dense growth of vines, bushes, and other plant 
 	[[View the Layer 2 habitation option|Layer2 Habitation]]
 
 	[[Look up towards the surface|Layer2 Ascend 1]]
-	[[Look down at the next layer|Layer2 Exit]]
+	[[Look down at the next layer|Layer2 Exit1]]
 
 <<else>>
 
@@ -323,7 +329,7 @@ Returning to the first layer will take 4 days, and cost 15 corruption.
 [[Turn back and continue your business on the second layer|Layer2 Hub]]
 
 
-:: Layer2 Exit [layer2]
+:: Layer2 Exit1 [layer2]
 Descending to the next layer will take 5 days. As you travel further down, the layer tends to get larger, both vertically and horizontally.
 
 Accessing drinkable water tends to get a but more difficult from here on out, so having a fair emergency supply of water would be a good idea before continuing onward. At a minimum, about a week's worth of water should be enough to avoid the worst case scenario.
@@ -1329,59 +1335,6 @@ You can use this Relic to see into your future and see what awaits you on the la
 [[Continue exploring the second layer|Layer2 Hub]]
 
 
-/* :: Layer2 Threat1 Main [image layer2]
-<<set $timeL2T1 -= 4>>
-[img[setup.ImagePath+'Clipped-Fin/Abyss Diver Page 3-threats.png']]
-
-How do you want to deal with the beast moving in on you?
-
-
-<<nobr>>
-<<if $items[14].count > 0>>
-	A simple beast like this could be fought off by even an amateur using a human weapon, like a sword.<br>[[Fight it off with your sword|Layer2 Hub]]<br><br>
-<</if>>
-<<if $items[13].count > 0 && $items[20].count > 2>>
-	While the beast is large and burly, a few shots from a gun will easily bring it down.<br>
-	[[Shoot it 3 times with your pistol|Layer2 Hub][$items[20].count -= 3]]<br><br>
-<</if>>
-<<if $items[1].count > 4>>
-	The ravenous creature doesn't want much besides food. Luckily you have an ample supply, so you could give it some of your rations and cause it to leave you alone.<br>
-	[[Feed it 5 days of your food rations|Layer2 Hub][$items[1].count -= 5]]<br><br>
-<</if>>
-<<if $hiredCompanions.length > 3>>
-	[[Scare it off with your large group of companions|Layer2 Hub]]<br>
-<</if>>
-<<if $slingshot == 1>>
-Your Brave Vector slingshot can be used like a gun and is able to easily dispatch the beast with only a few well-placed shots.
-[[Defeat it with the Brave Vector|Layer2 Hub]]
-<</if>>
-
-<<link "Allow it to overpower you" "Layer2 Hub">>
-	<<set $status.duration = (4 - $statRed)>>
-	<<set $status.penalty = 1>>
-	<<if $playerCurses.some(e => e.name === "Omnitool")>>
-		<<PregCheck>>
-	<</if>>
-<</link>>
-<br>
-
-<<if $hiredCompanions.length < 1 && $ownedRelics.some(e => e.name === "Creepy Doll") && $app.appAge<18>>
-<br><br>As the beast approaches you, you suddenly hear an ethereal voice talking to you, seeming to come from nowhere and all around at the same time.<br><br>
-
-<<say $creepydoll>>Don't be scared, nobody will hurt you. Just hold me tight and all the bad things will disappear. <</say>><br>
-
-A pleasant warmth radiates from the Creepy Doll, ushering you to hold it close and invite it into yout heart.<br><br>
-
-<<link "Hold the doll tight and squeeze your eyes shut" "Layer2 Hub">>
-  <<dollTF>>
-<</link>><br>
-<</if>>
-<</nobr>>
-
-Use the following option only if you have specifically considered your inventory and made a plan of how to use what you have to take down a beast.
-[[Use a combination of Relics not mentioned above you believe would be able to overpower one of the beasts|Layer2 Hub]]
-*/
-
 :: Layer2 Flasks [layer2]
 <<nobr>>
 <<for $i = 0; $i < 999; $i++>>
@@ -1412,17 +1365,12 @@ A few tests and you can confirm you have pure water to fill your flasks with! No
 [[Return to exploring your food and water options on this layer|Layer2 Forage]]
 
 
-:: Layer2 Exit2 [layer2]
-<<nobr>>
-<<if $layerExit == 0>>
-	<<set $layerExit = 1>>
-	<<AdjustedTravelTime "$layerExitTime" 5>>
-<</if>>
+:: Layer2 Travel Events [layer2 nobr]
 <<set _triggers = {
 	bayingGourmet: () => $timeL2T1 > 3 && $hiredCompanions.length < 4,
 }>>
 
-<<PassTime $layerExitTime _triggers "_done">>
+<<PassTime _triggers>>
 
 <<if _triggers.bayingGourmet()>>
 	Suddenly, you hear a deep, guttural growl that echoes through the layer. A shiver runs down your spine as you recognize it as the ominous call of the Baying Gourmet. The very ground beneath you seems to tremble with anticipation, and a sense of dread washes over you. You clutch your belongings closer, acutely aware of the abundance of food rations you carry.<br><br>
@@ -1430,127 +1378,80 @@ A few tests and you can confirm you have pure water to fill your flasks with! No
 	[[Deal with the Baying Gourmet|Layer2 Threat1][$returnPassage = passage()]]<br>
 <</if>>
 
-<</nobr>><<if _done>>
-Subtle changes in your surroundings continue, large rocks start to appear in your path, and the entire terrain changes from the lush rainforest you previously found yourself in to a more temperate forest. But slowly the trees become more sparse and the rocks become more common.
-
-<<include "Curse Descriptions">>
-
-[[Enter the deep caverns|Layer3 1]]
-<</if>>
 
 :: Layer2 Ascend2 [layer2]
 <<nobr>>
-<<if $DaedalusFly==true>>
-	<<include "Companions Stranded">>
-<</if>>
-<<if $layerExit == 0>>
-	<<set $layerExit = 1>>
-	<<set $tempTime=4>>
-	<<if $DaedalusFly==true>>
-		<<set $tempTime= Math.ceil($tempTime/2)>>
+
+<<if !setup.passingTime()>>
+	<<set _multiplier = 1>>
+	<<if $DaedalusFly>>
+		<<include "Companions Stranded">>
+		<<set _multiplier = 1/2>>
 	<</if>>
-	<<AdjustedTravelTime "$layerExitTime" $tempTime>>
-<</if>>
-<<set _triggers = {
-	bayingGourmet: () => $timeL2T1 > 3 && $hiredCompanions.length < 4,
-}>>
-
-<<PassTime $layerExitTime _triggers "_done">>
-
-<<if _triggers.bayingGourmet()>>
-	Suddenly, you hear a deep, guttural growl that echoes through the layer. A shiver runs down your spine as you recognize it as the ominous call of the Baying Gourmet. The very ground beneath you seems to tremble with anticipation, and a sense of dread washes over you. You clutch your belongings closer, acutely aware of the abundance of food rations you carry.<br><br>
-
-	[[Deal with the Baying Gourmet|Layer2 Threat1][$returnPassage = passage()]]<br>
+	<<AdjustedTravelTime "_travelTime" 4 false 0 _multiplier>>
+	<<set setup.startPassingTime(_travelTime)>>
 <</if>>
 
-<</nobr>><<if _done>>
-<<nobr>>
-<<set $corruption -= (15 - $corRed)>>
-<</nobr>>
+<<include "Layer2 Travel Events">>
 
-
-You continue your hike and try to keep somewhat dry from the droplets continually falling on your head, but eventually the dripping halts. You find yourself first in a sparse forest, then eventually back to the open, picturesque plains of the first layer.
-<<CarryAdjust>>
-<<Threat1Criterion>>
-<<include "Curse Descriptions">>
-<<if $TwinFly == true>>
-	<<include "Twin rejoin">>
-<</if>>
-
-<<if $threat1Crit == 1>>
-	<br>Worn down by the long trek up through the dense jungle of the previous layer, you're relieved when you finally reach the bridge to the Outcast Village. However, upon approaching the bridge a figure appears from behind a column.
-
-	<<say $Banditleader>> Well now, what do we have here?<</say>>
-	Turning around, you find yourself surrounded by a group of bandits, shrouded in ragged cloaks, emerging from the bushes behind you.
-
+<</nobr>>\
+<<if !setup.passingTime()>>
 	<<nobr>>
-	<<if $hiredCompanions.length < 1>>
-		<<say $Banditleader>> It looks like a <<PerceivedStature $app>> <<PerceivedGender $app>> all by <<ObjectivePronoun>>self, with an awful lot of valuable stuff for 1 person. How about we take that stuff of your hands so you don't have to worry about it anymore, hmm?<</say>>
-	<<elseif $hiredCompanions.length == 1 && $app.appAge>13 >>
-		<<say $Banditleader>> It looks like a <<PerceivedStature $app>> <<PerceivedGender $app>> on date with <<PossesivePronoun>> love. You seem to be carrying more than you need for your date, hmm? How about we take some of that stuff off your hands, so you don't have to worry about it anymore?<</say>>
-	<<elseif $hiredCompanions.length == 1 && $app.appAge<=13 >>
-		<<say $Banditleader>> It looks like a <<PerceivedStature $app>> <<PerceivedGender $app>> on a stroll with <<PossesivePronoun>> babysitter. It seems you're carrying a lot of adult stuff that you don't really need. How about we take that stuff of your hands, so you don't have to worry about it anymore, hmm?<</say>> <br><br>
-	<<else>>
-		<<say $Banditleader>> It looks like a <<PerceivedStature $app>> <<PerceivedGender $app>> with <<PossesivePronoun>> merry band of losers. Don't worry, we wont bite. As long as you do as we ask, we're very friendly. How about we take that stuff off your hands, so you don't have to worry about keeping it safe anymore, hmm?<</say>><br><br>
-	<</if>>
+		<<set $corruption -= 15 - $corRed + 5 * Math.trunc($hexflame / 10)>>
 	<</nobr>>
+	You continue your hike and try to keep somewhat dry from the droplets continually falling on your head, but eventually the dripping halts. You find yourself first in a sparse forest, then eventually back to the open, picturesque plains of the first layer.
+	<<CarryAdjust>>
+	<<Threat1Criterion>>
+	<<include "Curse Descriptions">>
+	<<if $TwinFly == true>>
+		<<include "Twin rejoin">>
+	<</if>>
 
-	[[Deal with the opportunistic bandits|Layer1 Threat1 Ascend]]<br>
-<<else>>
-	<<set $currentLayer = 1>>
-	[[Return to the first layer|Layer1 Hub]]
+	<<if $threat1Crit == 1>>
+		<br>Worn down by the long trek up through the dense jungle of the previous layer, you're relieved when you finally reach the bridge to the Outcast Village. However, upon approaching the bridge a figure appears from behind a column.
+
+		<<say $Banditleader>> Well now, what do we have here?<</say>>
+		Turning around, you find yourself surrounded by a group of bandits, shrouded in ragged cloaks, emerging from the bushes behind you.
+
+		<<nobr>>
+		<<if $hiredCompanions.length < 1>>
+			<<say $Banditleader>> It looks like a <<PerceivedStature $app>> <<PerceivedGender $app>> all by <<ObjectivePronoun>>self, with an awful lot of valuable stuff for 1 person. How about we take that stuff of your hands so you don't have to worry about it anymore, hmm?<</say>>
+		<<elseif $hiredCompanions.length == 1 && $app.appAge>13 >>
+			<<say $Banditleader>> It looks like a <<PerceivedStature $app>> <<PerceivedGender $app>> on date with <<PossesivePronoun>> love. You seem to be carrying more than you need for your date, hmm? How about we take some of that stuff off your hands, so you don't have to worry about it anymore?<</say>>
+		<<elseif $hiredCompanions.length == 1 && $app.appAge<=13 >>
+			<<say $Banditleader>> It looks like a <<PerceivedStature $app>> <<PerceivedGender $app>> on a stroll with <<PossesivePronoun>> babysitter. It seems you're carrying a lot of adult stuff that you don't really need. How about we take that stuff of your hands, so you don't have to worry about it anymore, hmm?<</say>> <br><br>
+		<<else>>
+			<<say $Banditleader>> It looks like a <<PerceivedStature $app>> <<PerceivedGender $app>> with <<PossesivePronoun>> merry band of losers. Don't worry, we wont bite. As long as you do as we ask, we're very friendly. How about we take that stuff off your hands, so you don't have to worry about keeping it safe anymore, hmm?<</say>><br><br>
+		<</if>>
+		<</nobr>>
+
+		[[Deal with the opportunistic bandits|Layer1 Threat1]]<br>
+	<<else>>
+		[[Return to the first layer|Layer1 Hub]]
+	<</if>>
 <</if>>
 
 
-
-<</if>>
-
-/* :: Layer2 Threat1 Ascend [image layer2]
-<<set $timeL2T1 -= 4>>
-[img[setup.ImagePath+'Clipped-Fin/Abyss Diver Page 3-threats.png']]
-
-How do you want to deal with the beast moving in on you?
-
-
+:: Layer2 Exit2 [layer2]
 <<nobr>>
-<<if $items[14].count > 0>>
-	A simple beast like this could be fought off by even an amateur using a human weapon, like a sword.<br>[[Fight it off with your sword|Layer2 Ascend2]]<br><br>
-<</if>>
-<<if $items[13].count > 0 && $items[20].count > 2>>
-	While the beast is large and burly, a few shots from a gun will easily bring it down.<br>
-	[[Shoot it 3 times with your pistol|Layer2 Ascend2][$items[20].count -= 3]]<br><br>
-<</if>>
-<<if $items[1].count > 4>>
-	The ravenous creature doesn't want much besides food. Luckily you have an ample supply, so you could give it some of your rations and cause it to leave you alone.<br>
-	[[Feed it 5 days of your food rations|Layer2 Ascend2][$items[1].count -= 5]]<br><br>
-<</if>>
-<<if $hiredCompanions.length > 3>>
-	[[Scare it off with your large group of companions|Layer2 Ascend2]]<br>
-<</if>>
-<<if $slingshot == 1>>
-Your Brave Vector slingshot can be used like a gun and is able to easily dispatch the beast with only a few well-placed shots.
-[[Defeat it with the Brave Vector|Layer2 Ascend2]]
+
+<<if !setup.passingTime()>>
+	<<AdjustedTravelTime "_travelTime" 5>>
+	<<set setup.startPassingTime(_travelTime)>>
 <</if>>
 
-[[Allow it to overpower you|Layer2 Ascend2][$status.duration = (4 - $statRed), $status.penalty = 1]]<br>
+<<include "Layer2 Travel Events">>
 
-<<if $hiredCompanions.length < 1 && $ownedRelics.some(e => e.name === "Creepy Doll") && $app.appAge<18>>
-<br><br>As the beast approaches you, you suddenly hear an ethereal voice talking to you, seeming to come from nowhere and all around at the same time.<br><br>
+<</nobr>>\
+<<if !setup.passingTime()>>
+	Subtle changes in your surroundings continue, large rocks start to appear in your path, and the entire terrain changes from the lush rainforest you previously found yourself in to a more temperate forest. But slowly the trees become more sparse and the rocks become more common.
 
-<<say $creepydoll>>Don't be scared, nobody will hurt you. Just hold me tight and all the bad things will disappear. <</say>><br>
+	<<include "Curse Descriptions">>
 
-A pleasant warmth radiates from the Creepy Doll, ushering you to hold it close and invite it into yout heart.<br><br>
-
-<<link "Hold the doll tight and squeeze your eyes shut" "Layer2 Ascend2">>
-  <<dollTF>>
-<</link>><br>
+	[[Enter the deep caverns|Layer3 1]]
 <</if>>
-<</nobr>>
 
-Use the following option only if you have specifically considered your inventory and made a plan of how to use what you have to take down a beast.
-[[Use a combination of Relics not mentioned above you believe would be able to overpower one of the beasts|Layer2 Ascend2]]
 
-*/
 :: Layer2 Curses Random [nobr]
 <<set _tempCurses = ["Libido Reinforcement B","Gender Reversal B","Asset Robustness B","Age Reduction A","Fluffy Ears","Fluffy Tail","Maximum Fluff","Heat/Rut","Lightweight","Sex Switcheroo","Futa Fun","Blushing Virgin"]>>
 <<set _totalCurses = $playerCurses>>

--- a/src/layer3.twee
+++ b/src/layer3.twee
@@ -1,11 +1,10 @@
 :: Layer3 1 [layer3]
 <<nobr>>
 <<set $currentLayer = 3>>
-
-<<set $timeL3T1 = 0>>
-<<set $timeL3T2 = 0>>
-
-<<masteraudio stop>><<audio "layer3" volume 0.2 play loop>>
+<<masteraudio stop>>
+<<audio "layer3" volume 0.2 play loop>>
+<<set $timeL2T1 = 0>>
+<<set $timeL3T1 = 0, $timeL3T2 = 0>>
 <<set $forageWater = 0>>
 <</nobr>>\
 \
@@ -25,10 +24,19 @@ The Abyss has various bioluminescent moss, mushrooms, and so on scattered about,
 
 
 :: Layer3 Hub [layer3]
-<<set $currentLayer = 3>><<if $timeL3T1 < 6 && $timeL3T2 < 5>><<set $layerExit = 0>><<CarryAdjust>><<nobr>>
+<<nobr>>
+<<set $currentLayer = 3>>
+<<if !isPlaying("layer3")>>
+	<<masteraudio stop>>
+	<<audio "layer3" volume 0.2 play loop>>
+<</if>>
+<<CarryAdjust>>
+<<set $forageWater = 0>>
+<</nobr>>\
+<<if $timeL3T1 < 6 && $timeL3T2 < 5>><<nobr>>
 <<if $visitL3 == 0>>
-	<<set $layerTemp = 8>>
 	<<set $visitL3 = 1>>
+	<<set $layerTemp = 8>>
 <<elseif $secondVisitL3 == 0>>
 	<<set $secondVisitL3 = 1>>
 	<<set $layerTemp = 18>>
@@ -92,10 +100,10 @@ The Abyss has various bioluminescent moss, mushrooms, and so on scattered about,
 [[Look down at the next layer|Layer3 Exit1]]<<elseif $timeL3T2 < 5>>
 <<include "Layer3 Tentacle Encounter">>
 
-[[Deal with the lesser tentacle beast|Layer3 Threat1][$returnPassage="Layer3 Hub"]]<<else>>
+[[Deal with the lesser tentacle beast|Layer3 Threat1][$returnPassage = passage()]]<<else>>
 <<include "Layer3 Slackslime Encounter">>
 
-[[Deal with the slackslime|Layer3 Threat2][$returnPassage="Layer3 Hub"]]<</if>>
+[[Deal with the slackslime|Layer3 Threat2][$returnPassage = passage()]]<</if>>
 
 
 :: Layer3 Threats [image layer3]
@@ -256,49 +264,53 @@ In the deeper parts of the layer, a cold breeze occasionally blows through the c
 [[Continue your descent to the fourth layer|Layer3 Exit2]]
 
 
-:: Layer3 Ascend2 [layer3]
-<<nobr>>
-<<if $DaedalusFly==true>>
-	<<include "Companions Stranded">>
-<</if>>
-<<if $layerExit == 0>>
-	<<set $layerExit = 1>>
-	<<set $tempTime=6>>
-	<<if $DaedalusFly==true>>
-		<<set $tempTime= Math.ceil($tempTime/2)>>
-	<</if>>
-	<<AdjustedTravelTime "$layerExitTime" $tempTime>>
-<</if>>
+:: Layer3 Travel Events [layer3 nobr]
 <<set _triggers = {
 	lesserTentacleBeast: () => $timeL3T1 > 5,
 	slackslime: () => $timeL3T2 > 4,
 }>>
 
-<<PassTime $layerExitTime _triggers "_done">>
+<<PassTime _triggers>>
 
 <<if _triggers.lesserTentacleBeast()>>
 	<br><<include "Layer3 Tentacle Encounter">><br><br>
-
 	[[Deal with the lesser tentacle beast|Layer3 Threat1][$returnPassage = passage()]]<br>
-	<<set _breakForEvent = true>>
 <<elseif _triggers.slackslime()>>
 	<br><<include "Layer3 Slackslime Encounter">><br><br>
-
 	[[Deal with the slackslime|Layer3 Threat2][$returnPassage = passage()]]<br>
-	<<set _breakForEvent = true>>
 <</if>>
 
-<<if _done>>
-	<<set $corruption -= (25 - $corRed)>>
-	<br>You continue through the dark winding caverns for days on end. After a long and monotonous journey, broken up only by evading threats that may have interrupted you, you notice that the caves are opening up. The sheer stone walls morphing into large rock formations, then shrinking and making way for the jungle of the second layer. A familiar sound of eternal rainfall welcomes you back to the second layer.
-	<br><br><<include "Curse Descriptions">><br><br>
+
+:: Layer3 Ascend2 [layer3]
+<<nobr>>
+
+<<if !setup.passingTime()>>
+	<<set _multiplier = 1>>
+	<<if $DaedalusFly>>
+		<<include "Companions Stranded">>
+		<<set _multiplier = 1/2>>
+	<</if>>
+	<<AdjustedTravelTime "_travelTime" 6 false 0 _multiplier>>
+	<<set setup.startPassingTime(_travelTime)>>
+<</if>>
+
+<<include "Layer3 Travel Events">>
+
+<</nobr>>\
+<<if !setup.passingTime()>>
+	<<nobr>>
+		<<set $corruption -= 25 - $corRed + 5 * Math.trunc($hexflame / 10)>>
+	<</nobr>>
+	You continue through the dark winding caverns for days on end. After a long and monotonous journey, broken up only by evading threats that may have interrupted you, you notice that the caves are opening up. The sheer stone walls morphing into large rock formations, then shrinking and making way for the jungle of the second layer. A familiar sound of eternal rainfall welcomes you back to the second layer.
+	
+	<<include "Curse Descriptions">>
 	<<if $TwinFly == true>>
 		<<include "Twin rejoin">>
 	<</if>>
-	<<set $currentLayer = 2>>
-	<br>[[Return to the second layer|Layer2 Hub]]
+	[[Return to the second layer|Layer2 Hub]]
 <</if>>
-<</nobr>>
+
+
 :: Layer3 Scales 1 [layer3]
 <<nobr>>
 <<set $temp = Math.round($corruption / 5)>>
@@ -896,183 +908,6 @@ The magic of the shrine wisps through the air menacingly as your victim struggle
 [[Continue with your journey|Layer3 Hub]]
 
 
-:: Layer3 Threat1 Main [layer3]
-<<set $timeL3T1 -= 6>>
-[img[setup.ImagePath+'Threats/lessertentaclebeast.png']]
-
-The beast's slick, dark tentacles glisten in the dim light, their tips adorned with suction cups that seem to twitch with anticipation. Its amorphous body is both mesmerizing and repulsive, and you find yourself momentarily paralyzed by the sight of it.
-
-As the creature draws closer, you can almost feel the cool, damp embrace of its probing tendrils. The air around you grows heavy with the scent of damp earth and something more animalistic, a musk that sends shivers down your spine.
-
-Suddenly, you snap back to reality, and a primal instinct to survive takes over. You hastily assess your options, understanding that bullets will be of little use against this strange, amorphous foe. Instead, you weigh the risks of engaging it with your sword, knowing that the battle could leave you injured and vulnerable.
-
-As the tentacle beast inches closer, you can almost taste the cool, slimy texture of its tendrils against your skin. The thought of it ravaging you, leaving you and your companions weak and helpless, spurs you into action. 
-
-How do you want to deal with the tentacle beast moving in on you?
-
-
-<<nobr>>
-<<if $items[14].count > 0>>
-	You can fight it with a sword, but it's dangerous. You'd likely end up with mild injuries increasing your next 3 travel times by 1 days each.<br>
-	[[Fight it off with your sword yourself|Layer3 Hub][$status.duration += (3 - $statRed), $status.penalty += 1]]<br><br>
-<</if>>
-<<if $items[14].count > 0 && $hiredCompanions.some(e => e.name === "Khemia")>>
-	Khemia has enough expertise with a blade to be able to fight it off without taking any injuries or penalties, if you let him fight for you.<br>
-	[[Have Khemia fight it off with a sword|Layer3 Hub]]<br><br>
-<</if>>
-<<if $items[13].count > 0 && $items[20].count > 10>>
-	Due to its amorphous nature, it will take at least 11 bullets to take down the monster.<br>
-	[[Shoot it with your pistol|Layer3 Hub][$items[20].count -= (11 - $bullRed)]]<br><br>
-<</if>>
-<<if $slingshot == 1>>
-Your Brave Vector slingshot can be used like a gun, but it will take many shots to bring down the amorphous creature. Luckily pebbles to use as ammo are abundant in the rocky caves of this layer.<br>
-[[Defeat it with the Brave Vector|Layer3 Hub]]<br><br>
-<</if>>
-If you allow it to overpower you, it will give you <<if $hiredCompanions.length >0>>and the rest of your party <</if>>a very thorough tentacle fucking, leaving you with a serious limp, increasing your next 3 travel times by 2 days each. <br>
-<<link "Allow it to overpower you" "Layer3 Hub">>
-	<<set $status.duration += (3 - $statRed)>>
-	<<set $status.penalty += 2>>
-	<<if $playerCurses.some(e => e.name === "Omnitool")>>
-		<<PregCheck>>
-	<</if>>
-	<<MonsterPregCheckParty>>
-<</link>><br>
-<br>
-
-<<if  ($hiredCompanions.length < 1 || ($hiredCompanions.some(e => e.name === "Golem") && $hiredCompanions.length < 2 )) && $ownedRelics.some(e => e.name === "Creepy Doll") && $app.appAge<18>>
-<br><br>As the tentacles close in on you, you suddenly hear an ethereal voice talking to you, seeming to come from nowhere and all around at the same time.<br><br>
-
-<<say $creepydoll>>Don't be scared, nobody will hurt you. Just hold me tight and all the bad things will disappear. <</say>><br>
-
-A pleasant warmth radiates from the Creepy Doll, ushering you to hold it close and invite it into yout heart.<br><br>
-
-<<link "Hold the doll tight and squeeze your eyes shut" "Layer3 Hub">>
-  <<dollTF>>
-<</link>><br>
-<</if>>
-
-<</nobr>>
-
-Use the following option only if you have specifically considered your inventory and made a plan of how to use what you have to take down a beast.
-[[Use a combination of Relics not mentioned above you believe would be able to overpower one of the beasts|Layer3 Hub]]
-
-
-:: Layer3 Threat2 Main [layer3]
-<<nobr>>
-<<set $tempTime = 2>>
-<<set $timeL3T2 -= 5>>
-<<if $playerCurses.some(e => e.name === "Gooey")>>
-	<<set $tempTime = 1>>
-<</if>>
-<<set $items[0].count -= $tempTime>>
-<<set $items[1].count -= $tempTime>>
-<<set $time += $tempTime>>
-<<set $timeL3 += $tempTime>>
-<</nobr>>
-[img[setup.ImagePath+'Threats/slackslime.png']]
-
-The ameboid creature that has trapped you seem to hiss slightly, then you smell something a little strange before your muscles completely relax. It seems that no matter how much you try, you aren't able to move at all.
-
-The slime moves slowly, but surely over your paralyzed body and into your most sensitive locations. Even though you can't move, you can feel every moment the creature spends milking your sexual fluids for protein.
-
-<<if $playerCurses.some(e => e.name === "Gooey")>>
-The slime lets you go after only 1 day, perhaps feeling some sense of kinship with a slimey being such as yourself.
-<<else>>
-The process lasts two days before the slime finally moves on and allows you to go on your way.
-<</if>>
-
-[[You continue on your way after the slime releases you|Layer3 Hub]]
-
-
-:: Layer3 Threat1 Ascend [layer3]
-<<set $timeL3T1 -= 6>>
-[img[setup.ImagePath+'Threats/lessertentaclebeast.png']]
-
-The beast's slick, dark tentacles glisten in the dim light, their tips adorned with suction cups that seem to twitch with anticipation. Its amorphous body is both mesmerizing and repulsive, and you find yourself momentarily paralyzed by the sight of it.
-
-As the creature draws closer, you can almost feel the cool, damp embrace of its probing tendrils. The air around you grows heavy with the scent of damp earth and something more animalistic, a musk that sends shivers down your spine.
-
-Suddenly, you snap back to reality, and a primal instinct to survive takes over. You hastily assess your options, understanding that bullets will be of little use against this strange, amorphous foe. Instead, you weigh the risks of engaging it with your sword, knowing that the battle could leave you injured and vulnerable.
-
-As the tentacle beast inches closer, you can almost taste the cool, slimy texture of its tendrils against your skin. The thought of it ravaging you, leaving you and your companions weak and helpless, spurs you into action. 
-
-How do you want to deal with the tentacle beast moving in on you?
-
-
-<<nobr>>
-<<if $items[14].count > 0>>
-	You can fight it with a sword, but it's dangerous. You'd likely end up with mild injuries increasing your next 3 travel times by 1 days each.<br>
-	[[Fight it off with your sword yourself|Layer3 Ascend2][$status.duration += (3 - $statRed), $status.penalty += 1]]<br><br>
-<</if>>
-<<if $items[14].count > 0 && $hiredCompanions.some(e => e.name === "Khemia")>>
-	Khemia has enough expertise with a blade to be able to fight it off without taking any injuries or penalties, if you let him fight for you.<br>
-	[[Have Khemia fight it off with a sword|Layer3 Ascend2]]<br><br>
-<</if>>
-<<if $items[13].count > 0 && $items[20].count > 10>>
-	Due to its amorphous nature, it will take at least 11 bullets to take down the monster.<br>
-	[[Shoot it with your pistol|Layer3 Ascend2][$items[20].count -= (11 - $bullRed)]]<br><br>
-<</if>>
-<<if $slingshot == 1>>
-Your Brave Vector slingshot can be used like a gun, but it will take many shots to bring down the amorphous creature. Luckily pebbles to use as ammo are abundant in the rocky caves of this layer.<br>
-[[Defeat it with the Brave Vector|Layer3 Ascend2]]<br><br>
-<</if>>
-If you allow it to overpower you, it will give you <<if $hiredCompanions.length >0>>and the rest of your party <</if>>a very thorough tentacle fucking, leaving you with a serious limp, increasing your next 3 travel times by 2 days each. <br>
-<<link "Allow it to overpower you" "Layer3 Ascend2">>
-	<<set $status.duration += (3 - $statRed)>>
-	<<set $status.penalty += 2>>
-	<<if $playerCurses.some(e => e.name === "Omnitool")>>
-		<<PregCheck>>
-	<</if>>
-	<<MonsterPregCheckParty>>
-	<<if $playerCurses.some(e => e.name === "Semen Demon") &&  $curse82.variation!="vaginal fluids" >>
-		<<set $SemenDemonBalance+=10>>
-	<</if>>
-<</link>><br>
-<br>
-<<if  ($hiredCompanions.length < 1 || ($hiredCompanions.some(e => e.name === "Golem") && $hiredCompanions.length < 2 )) && $ownedRelics.some(e => e.name === "Creepy Doll") && $app.appAge<18>>
-<br><br>As the tentacles close in on you, you suddenly hear an ethereal voice talking to you, seeming to come from nowhere and all around at the same time.<br><br>
-
-<<say $creepydoll>>Don't be scared, nobody will hurt you. Just hold me tight and all the bad things will disappear. <</say>><br>
-
-A pleasant warmth radiates from the Creepy Doll, ushering you to hold it close and invite it into yout heart.<br><br>
-
-<<link "Hold the doll tight and squeeze your eyes shut" "Layer3 Ascend2">>
-  <<dollTF>>
-<</link>><br>
-<</if>>
-<</nobr>>
-
-Use the following option only if you have specifically considered your inventory and made a plan of how to use what you have to take down a beast.
-[[Use a combination of Relics not mentioned above you believe would be able to overpower one of the beasts|Layer3 Ascend2]]
-
-
-:: Layer3 Threat2 Ascend [layer3]
-<<nobr>>
-<<set $tempTime = 2>>
-<<set $timeL3T2 -= 5>>
-<<if $playerCurses.some(e => e.name === "Gooey")>>
-	<<set $tempTime = 1>>
-<</if>>
-<<set $items[0].count -= $tempTime>>
-<<set $items[1].count -= $tempTime>>
-<<set $time += $tempTime>>
-<<set $timeL3 += $tempTime>>
-<</nobr>>
-[img[setup.ImagePath+'Threats/slackslime.png']]
-
-The ameboid creature that has trapped you seem to hiss slightly, then you smell something a little strange before your muscles completely relax. It seems that no matter how much you try, you aren't able to move at all.
-
-The slime moves slowly, but surely over your paralyzed body and into your most sensitive locations. Even though you can't move, you can feel every moment the creature spends milking your sexual fluids for protein.
-
-<<if $playerCurses.some(e => e.name === "Gooey")>>
-The slime lets you go after only 1 day, perhaps feeling some sense of kinship with a slimey being such as yourself.
-<<else>>
-The process lasts two days before the slime finally moves on and allows you to go on your way.
-<</if>>
-
-[[You continue on your way after the slime releases you|Layer3 Ascend2]]
-
-
 :: Layer3 Cherry [layer3]
 [img[setup.ImagePath+'Surface/cherry.png']]
 
@@ -1233,126 +1068,24 @@ Please enter your new skin/eye color:
 
 :: Layer3 Exit2 [layer3]
 <<nobr>>
-<<if $layerExit == 0>>
-	<<set $layerExit = 1>>
-	<<AdjustedTravelTime "$layerExitTime" 6>>
-<</if>>
-<<set _triggers = {
-	lesserTentacleBeast: () => $timeL3T1 > 5,
-	slackslime: () => $timeL3T2 > 4,
-}>>
 
-<<PassTime $layerExitTime _triggers "_done">>
-
-<<if _triggers.lesserTentacleBeast()>>
-	<br><<include "Layer3 Tentacle Encounter">><br><br>
-	[[Deal with the lesser tentacle beast|Layer3 Threat1][$returnPassage = passage()]]<br><br>
-<<elseif _triggers.slackslime()>>
-	<br><<include "Layer3 Slackslime Encounter">><br><br>
-	[[Deal with the slackslime|Layer3 Threat2][$returnPassage = passage()]]<br><br>
+<<if !setup.passingTime()>>
+	<<AdjustedTravelTime "_travelTime" 6>>
+	<<set setup.startPassingTime(_travelTime)>>
 <</if>>
 
-<</nobr>>
-<<if _done>>
-	<<nobr>>
-	<<set $timeL4T1 = 0>>
-	<</nobr>>
+<<include "Layer3 Travel Events">>
+
+<</nobr>>\
+<<if !setup.passingTime()>>
 	You continue through the dark winding caverns for days on end. After a long and monotonous journey, broken up only by evading threats that may have interrupted you, you notice that the caves are opening up. But rather than the wet forest from above, you feel the air getting colder, and occasionally notice frost on the walls of the caves.
 
 	Eventually you notice a bright, cool light at the end of the tunnel, it seems like you've made it to the end of the third layer.
 
-<<include "Curse Descriptions">>
+	<<include "Curse Descriptions">>
 
 	[[Emerge onto the fourth layer|Layer4 1]]
 <</if>>
-
-
-:: Layer3 Threat1 Descend [layer3]
-<<set $timeL3T1 -= 6>>
-[img[setup.ImagePath+'Threats/lessertentaclebeast.png']]
-
-The beast's slick, dark tentacles glisten in the dim light, their tips adorned with suction cups that seem to twitch with anticipation. Its amorphous body is both mesmerizing and repulsive, and you find yourself momentarily paralyzed by the sight of it.
-
-As the creature draws closer, you can almost feel the cool, damp embrace of its probing tendrils. The air around you grows heavy with the scent of damp earth and something more animalistic, a musk that sends shivers down your spine.
-
-Suddenly, you snap back to reality, and a primal instinct to survive takes over. You hastily assess your options, understanding that bullets will be of little use against this strange, amorphous foe. Instead, you weigh the risks of engaging it with your sword, knowing that the battle could leave you injured and vulnerable.
-
-As the tentacle beast inches closer, you can almost taste the cool, slimy texture of its tendrils against your skin. The thought of it ravaging you, leaving you and your companions weak and helpless, spurs you into action. 
-
-How do you want to deal with the tentacle beast moving in on you?
-
-
-<<nobr>>
-<<if $items[14].count > 0>>
-	You can fight it with a sword, but it's dangerous. You'd likely end up with mild injuries increasing your next 3 travel times by 1 days each.<br>
-	[[Fight it off with your sword yourself|Layer3 Exit2][$status.duration += (3 - $statRed), $status.penalty += 1]]<br><br>
-<</if>>
-<<if $items[14].count > 0 && $hiredCompanions.some(e => e.name === "Khemia")>>
-	Khemia has enough expertise with a blade to be able to fight it off without taking any injuries or penalties, if you let him fight for you.<br>
-	[[Have Khemia fight it off with a sword|Layer3 Exit2]]<br><br>
-<</if>>
-<<if $items[13].count > 0 && $items[20].count > 10>>
-	Due to its amorphous nature, it will take at least 11 bullets to take down the monster.<br>
-	[[Shoot it with your pistol|Layer3 Exit2][$items[20].count -= (11 - $bullRed)]]<br><br>
-<</if>>
-<<if $slingshot == 1>>
-Your Brave Vector slingshot can be used like a gun, but it will take many shots to bring down the amorphous creature. Luckily pebbles to use as ammo are abundant in the rocky caves of this layer.<br>
-[[Defeat it with the Brave Vector|Layer3 Exit2]]<br><br>
-<</if>>
-
-If you allow it to overpower you, it will give you <<if $hiredCompanions.length >0>>and the rest of your party <</if>>a very thorough tentacle fucking, leaving you with a serious limp, increasing your next 3 travel times by 2 days each. <br>
-<<link "Allow it to overpower you" "Layer3 Exit2">>
-	<<set $status.duration += (3 - $statRed)>>
-	<<set $status.penalty += 2>>
-	<<if $playerCurses.some(e => e.name === "Omnitool")>>
-		<<PregCheck>>
-	<</if>>
-	<<MonsterPregCheckParty>>
-<</link>><br>
-<br>
-
-<<if  ($hiredCompanions.length < 1 || ($hiredCompanions.some(e => e.name === "Golem") && $hiredCompanions.length < 2 )) && $ownedRelics.some(e => e.name === "Creepy Doll") && $app.appAge<18>>
-<br><br>As the tentacles close in on you, you suddenly hear an ethereal voice talking to you, seeming to come from nowhere and all around at the same time.<br><br>
-
-<<say $creepydoll>>Don't be scared, nobody will hurt you. Just hold me tight and all the bad things will disappear. <</say>><br>
-
-A pleasant warmth radiates from the Creepy Doll, ushering you to hold it close and invite it into yout heart.<br><br>
-
-<<link "Hold the doll tight and squeeze your eyes shut" "Layer3 Exit2">>
-  <<dollTF>>
-<</link>><br>
-<</if>>
-<</nobr>>
-
-Use the following option only if you have specifically considered your inventory and made a plan of how to use what you have to take down a beast.
-[[Use a combination of Relics not mentioned above you believe would be able to overpower one of the beasts|Layer3 Exit2]]
-
-
-:: Layer3 Threat2 Descend [layer3]
-<<nobr>>
-<<set $tempTime = 2>>
-<<set $timeL3T2 -= 5>>
-<<if $playerCurses.some(e => e.name === "Gooey")>>
-	<<set $tempTime = 1>>
-<</if>>
-<<set $items[0].count -= $tempTime>>
-<<set $items[1].count -= $tempTime>>
-<<set $time += $tempTime>>
-<<set $timeL3 += $tempTime>>
-<</nobr>>
-[img[setup.ImagePath+'Threats/slackslime.png']]
-
-The ameboid creature that has trapped you seem to hiss slightly, then you smell something a little strange before your muscles completely relax. It seems that no matter how much you try, you aren't able to move at all.
-
-The slime moves slowly, but surely over your paralyzed body and into your most sensitive locations. Even though you can't move, you can feel every moment the creature spends milking your sexual fluids for protein.
-
-<<if $playerCurses.some(e => e.name === "Gooey")>>
-The slime lets you go after only 1 day, perhaps feeling some sense of kinship with a slimey being such as yourself.
-<<else>>
-The process lasts two days before the slime finally moves on and allows you to go on your way.
-<</if>>
-
-[[You continue on your way after the slime releases you|Layer3 Exit2]]
 
 
 :: Pick up the Sibyl Blend [layer3]

--- a/src/layer4.twee
+++ b/src/layer4.twee
@@ -1,7 +1,10 @@
 :: Layer4 1 [layer4]
 <<nobr>>
-<<masteraudio stop>><<audio "layer4" volume 0.2 play loop>>
 <<set $currentLayer = 4>>
+<<masteraudio stop>>
+<<audio "layer4" volume 0.2 play loop>>
+<<set $timeL3T1 = 0, $timeL3T2 = 0>>
+<<set $timeL4T1 = 0>>
 <</nobr>>\
 \
 @@.layerTitle;
@@ -35,12 +38,19 @@ She stands at the edge of your peripheral vision, immaterial and seemingly harml
 [[Walk through the fourth layer of the Abyss|Layer4 Hub]]
 
 :: Layer4 Hub [layer4]
-<<set $currentLayer = 4>><<if $visitL4 == 0>><<set $endSpectre = $time>><</if>><<if $timeL4T1 < 7>><<set $layerExit = 0>><<CarryAdjust>>\
 <<nobr>>
-
+<<set $currentLayer = 4>>
+<<if !isPlaying("layer4")>>
+	<<masteraudio stop>>
+	<<audio "layer4" volume 0.2 play loop>>
+<</if>>
+<<CarryAdjust>>
+<<if $visitL4 == 0>><<set $endSpectre = $time>><</if>>
+<</nobr>>\
+<<if $timeL4T1 < 7>><<nobr>>
 <<if $visitL4 == 0>>
-	<<set $layerTemp = 8>>
 	<<set $visitL4 = 1>>
+	<<set $layerTemp = 8>>
 <<elseif $secondVisitL4 == 0>>
 	<<set $secondVisitL4 = 1>>
 	<<set $layerTemp = 18>>
@@ -127,7 +137,7 @@ She stands at the edge of your peripheral vision, immaterial and seemingly harml
 
 A great hissing sound, as if a blimp were leaking its helium, fills your ears as a dark form descends on you from above. A monstrous beast floats above your head and unveils its tentacles in preparation of its attempt to shovel you into its enormous maw.
 
-[[Deal with the Drifting Swallower|Layer4 Threat1][$returnPassage = "Layer4 Hub"]]
+[[Deal with the Drifting Swallower|Layer4 Threat1][$returnPassage = passage()]]
 
 <</if>>
 
@@ -198,7 +208,7 @@ The Brave Vector Relic you can find here is a perfect example of something you m
 
 <p>A great hissing sound, as if a blimp were leaking its helium, fills your ears as a dark form descends on you from above. A monstrous beast floats above your head and unveils its tentacles in preparation of its attempt to shovel you into its enormous maw.</p>
 
-<p>[[Deal with the Drifting Swallower|Layer4 Threat1][$returnPassage = "Layer4 Hub"]]</p>
+<p>[[Deal with the Drifting Swallower|Layer4 Threat1][$returnPassage = passage()]]</p>
 
 <</if>>
 
@@ -291,55 +301,6 @@ The air seems to get drier as you proceed further down. You might want to stockp
 
 [[Turn back and continue your business on the fourth layer|Layer4 Hub]]
 [[Continue your descent to the fifth layer|Layer4 Exit2]]
-
-
-:: Layer4 Threat1 Main [layer4]
-<<set $timeL4T1 -= 7>>
-[img[setup.ImagePath+'Threats/driftingswallower.png']]
-
-How do you want to deal with the creature descending upon you?
-
-
-<<nobr>>
-<<if $items[14].count > 0 && $hiredCompanions.some(e => e.name === "Khemia")>>
-	Khemia has enough expertise with a blade to be able to fight it off, but even he would be seriously injured by fighting it, increasing your next 6 travel times by 1 day each if you let him fight for you.<br>
-	[[Have Khemia fight it off with a sword|Layer4 Hub][$status.duration += (6 - $statRed), $status.penalty += 1]]<br><br>
-<</if>>
-	<<if ($joyousSword == 1 || $ownedRelics.some(e => e.name === "Sunbeam")) && $hiredCompanions.some(e => e.name === "Khemia")>>
-You can arm Khemia with your more powerful Relic sword and he will be able to defeat the creature without any major issues after a brief battle.<br>
-[[Allow Khemia to defeat it with his Relic blade|Layer4 Hub]]<br><br>
-<</if>>
-<<if $items[13].count > 0 && $items[20].count > 4>>
-	You can take it down effectively with a gun, but you'll need at least 5 bullets to take it down due to the way it moves around and evades your shots.<br>
-	[[Shoot it with your pistol|Layer4 Hub][$items[20].count -= (5 - $bullRed)]]<br><br>
-<</if>>
-	<<if $slingshot == 1>>
-Your Brave Vector slingshot can be used like a gun, and a ranged weapon can efficiently bring down a swallower.<br>
-[[Defeat it with the Brave Vector|Layer4 Hub]]<br><br>
-<</if>>
-<<if $ownedRelics.some(e => e.name === "Tranquility Knell")>>
-The Drifting Swallower detects its prey by the vibrations that surround them, but the Tranquility Knell silences the noise in both the air and all other media, meaning the vibrations are nearly silenced and the Swallower is left nearly blind. This effect should give you 30 minutes where the creature is unable to find you, allowing you to escape unnoticed until you are out of range.<br>
-[[Escape with the Tranquility Knell|Layer4 Hub]]<br><br>
-<</if>>
-If you allow it to overpower you, prepare to be vored! It will swallow you whole and you will spend the next 3 days inside of its large stomach being tickled and lightly burned by gastric juices lapping over your whole body. After you are eventually expelled from the creature, you'll be left with persistant light burns, increasing all travel costs by 1 day until you are cured. This will not heal without a medkit.<br>
-[[Allow it to overpower you|Layer4 Hub][$status.duration += 99, $status.penalty += 1]]
-
-<<if  ($hiredCompanions.length < 1 || ($hiredCompanions.some(e => e.name === "Golem") && $hiredCompanions.length < 2 )) && $ownedRelics.some(e => e.name === "Creepy Doll") && $app.appAge<18>>
-<br><br>As the nightmarish beast drifts closer to you, you suddenly hear a voice talking to you.<br><br>
-
-<<say $creepydoll>>Don't be scared, nobody will hurt you. Just hold me tight and all the bad things will dissapear <</say>><br>
-
-A pleasant warmth is radiating from the doll you found<br>
-<<link "Hold the doll tight and close your eyes" "Layer4 Hub">>
-  <<dollTF>>
-<</link>>
-
-<</if>>
-
-<</nobr>>
-
-Use the following option only if you have specifically considered your inventory and made a plan of how to use what you have to take down a beast.
-[[Use a combination of Relics not mentioned above you believe would be able to overpower one of the beasts|Layer4 Hub]]
 
 
 :: Take on Libido Reinforcement C [layer4]
@@ -1189,186 +1150,73 @@ You have successfully taken the $relic48.name Relic. Hopefully you can make good
 [[Continue exploring the fourth layer|Layer4 Hub]]
 
 
-:: Layer4 Exit2 [layer4]
-<<nobr>>
-<<if $layerExit == 0>>
-	<<set $layerExit = 1>>
-
-	<<if setup.haveRope>>
-		<<set $tempTime = 8>>
-	<<else>>
-		<<set $tempTime = 19>>
-	<</if>>
-
-	<<AdjustedTravelTime "$layerExitTime" $tempTime>>
-<</if>>
+:: Layer4 Travel Events [layer4 nobr]
 <<set _triggers = {
 	driftingSwallower: () => $timeL4T1 > 6,
 }>>
 
-<<PassTime $layerExitTime _triggers "_done">>
+<<PassTime _triggers>>
 
 <<if _triggers.driftingSwallower()>>
-	<br>During your long trip down towards the fifth layer you hear a great hissing sound, as if a blimp were leaking its helium, fills your ears as a dark form descends on you from above. A monstrous beast floats above your head and unveils its tentacles in preparation of its attempt to shovel you into its enormous maw.<br><br>
+	<<if passage() == "Layer4 Ascend2">>
+		<br>During your long hike back up towards the third layer you hear a great hissing sound, as if a blimp were leaking its helium, fills your ears as a dark form descends on you from above. A monstrous beast floats above your head and unveils its tentacles in preparation of its attempt to shovel you into its enormous maw.<br><br>
+	<</if>>
+	<<if passage() == "Layer4 Exit2">>
+		<br>During your long trip down towards the fifth layer you hear a great hissing sound, as if a blimp were leaking its helium, fills your ears as a dark form descends on you from above. A monstrous beast floats above your head and unveils its tentacles in preparation of its attempt to shovel you into its enormous maw.<br><br>
+	<</if>>
 
 	[[Deal with the Drifting Swallower|Layer4 Threat1][$returnPassage = passage()]]<br>
 <</if>>
-
-<<if _done>>
-	<<nobr>>
-	<<set $currentLayer = 5>>
-	<<set $timeL5T1 = 0>>
-	<<set $timeL5T2 = 0>>
-	<</nobr>><br>
-	You continue your hike and try to keep somewhat warm despite the bone-chilling cold and your treacherous journey along the pit of sheer ice. As you get closer to the bottom, the temperature rises and the air starts to dry out.<br><br>
-
-	<<include "Curse Descriptions">><br><br>
-	<<if $TwinFly == true>>
-		<<include "Twin rejoin">>
-	<</if>>
-	[[Continue to the Fifth layer|Layer5 1]]
-
-<</if>>
-<</nobr>>
 
 
 :: Layer4 Ascend2 [layer4]
 <<nobr>>
-<<if $DaedalusFly==true>>
-	<<include "Companions Stranded">>
-<</if>>
-<<if $layerExit == 0>>
-	<<set $layerExit = 1>>
-	<<set $tempTime = 7>>
-	<<if $DaedalusFly==true>>
-		<<set $tempTime= Math.ceil($tempTime/2)>>
+
+<<if !setup.passingTime()>>
+	<<set _multiplier = 1>>
+	<<if $DaedalusFly>>
+		<<include "Companions Stranded">>
+		<<set _multiplier = 1/2>>
 	<</if>>
-	<<AdjustedTravelTime "$layerExitTime" $tempTime>>
-<</if>>
-<<set _triggers = {
-	driftingSwallower: () => $timeL4T1 > 6,
-}>>
-
-<<PassTime $layerExitTime _triggers "_done">>
-
-<<if _triggers.driftingSwallower()>>
-	<br>
-	During your long hike back up towards the third layer you hear a great hissing sound, as if a blimp were leaking its helium, fills your ears as a dark form descends on you from above. A monstrous beast floats above your head and unveils its tentacles in preparation of its attempt to shovel you into its enormous maw.<br><br>
-
-	[[Deal with the Drifting Swallower|Layer4 Threat1][$returnPassage = passage()]]<br>
+	<<AdjustedTravelTime "_travelTime" 7 false 0 _multiplier>>
+	<<set setup.startPassingTime(_travelTime)>>
 <</if>>
 
-<</nobr>>
-<<if _done>>
+<<include "Layer4 Travel Events">>
+
+<</nobr>>\
+<<if !setup.passingTime()>>
 	<<nobr>>
-	<<set $corruption -= (35 - $corRed)>>
-	<<set $forageWater = 0>>
-	<<set $currentLayer = 3>>
+		<<set $corruption -= 35 - $corRed + 5 * Math.trunc($hexflame / 10)>>
 	<</nobr>>
 	You continue your hike and try to keep somewhat warm despite the bone-chilling cold, but eventually the temperature starts to rise. However, once you've gotten to the comfortable warmth of the cave systems, you find the light is once again disappearing, leaving you in the dim darkness of the third layer.
 
 	<<include "Curse Descriptions">>
-
+	<<if $TwinFly == true>>
+		<<include "Twin rejoin">>
+	<</if>>
 	[[Return to the third layer|Layer3 Hub]]
-
 <</if>>
 
 
-:: Layer4 Threat1 Ascend [layer4]
-<<set $timeL4T1 -= 7>>
-[img[setup.ImagePath+'Threats/driftingswallower.png']]
-
-How do you want to deal with the creature descending upon you?
-
-
+:: Layer4 Exit2 [layer4]
 <<nobr>>
-<<if $items[14].count > 0 && $hiredCompanions.some(e => e.name === "Khemia")>>
-	Khemia has enough expertise with a blade to be able to fight it off, but even he would be seriously injured by fighting it, increasing your next 6 travel times by 1 day each if you let him fight for you.<br>
-	[[Have Khemia fight it off with a sword|Layer4 Ascend2][$status.duration += (6 - $statRed), $status.penalty += 1]]<br><br>
-<</if>>
-	<<if ($joyousSword == 1 || $ownedRelics.some(e => e.name === "Sunbeam")) && $hiredCompanions.some(e => e.name === "Khemia")>>
-You can arm Khemia with your more powerful Relic sword and he will be able to defeat the creature without any major issues after a brief battle.<br>
-[[Allow Khemia to defeat it with his Relic blade|Layer4 Ascend2]]<br><br>
-<</if>>
-<<if $items[13].count > 0 && $items[20].count > 4>>
-	You can take it down effectively with a gun, but you'll need at least 5 bullets to take it down due to the way it moves around and evades your shots.<br>
-	[[Shoot it with your pistol|Layer4 Ascend2][$items[20].count -= (5 - $bullRed)]]<br><br>
-<</if>>
-	<<if $slingshot == 1>>
-Your Brave Vector slingshot can be used like a gun, and a ranged weapon can efficiently bring down a swallower.<br>
-[[Defeat it with the Brave Vector|Layer4 Ascend2]]<br><br>
-<</if>>
-<<if $ownedRelics.some(e => e.name === "Tranquility Knell")>>
-The Drifting Swallower detects its prey by the vibrations that surround them, but the Tranquility Knell silences the noise in both the air and all other media, meaning the vibrations are nearly silenced and the Swallower is left nearly blind. This effect should give you 30 minutes where the creature is unable to find you, allowing you to escape unnoticed until you are out of range.<br>
-[[Escape with the Tranquility Knell|Layer4 Ascend2]]<br><br>
+
+<<if !setup.passingTime()>>
+	<<AdjustedTravelTime "_travelTime" `setup.haveRope ? 8 : 19`>>
+	<<set setup.startPassingTime(_travelTime)>>
 <</if>>
 
-If you allow it to overpower you, prepare to be vored! It will swallow you whole and you will spend the next 3 days inside of its large stomach being tickled and lightly burned by gastric juices lapping over your whole body. After you are eventually expelled from the creature, you'll be left with persistant light burns, increasing all travel costs by 1 day until you are cured. This will not heal without a medkit.<br>
-[[Allow it to overpower you|Layer4 Ascend2][$status.duration += 99, $status.penalty += 1]]
+<<include "Layer4 Travel Events">>
 
-<<if  ($hiredCompanions.length < 1 || ($hiredCompanions.some(e => e.name === "Golem") && $hiredCompanions.length < 2 )) && $ownedRelics.some(e => e.name === "Creepy Doll") && $app.appAge<18>>
-<br>As the nightmarish beast drifts closer to you, you suddenly hear a voice talking to you.<br><br>
+<</nobr>>\
+<<if !setup.passingTime()>>
+	You continue your hike and try to keep somewhat warm despite the bone-chilling cold and your treacherous journey along the pit of sheer ice. As you get closer to the bottom, the temperature rises and the air starts to dry out.
 
-<<say $creepydoll>>Don't be scared, nobody will hurt you. Just hold me tight and all the bad things will dissapear <</say>><br>
+	<<include "Curse Descriptions">>
 
-A pleasant warmth is radiating from the doll you found<br>
-<<link "Hold the doll tight and close your eyes" "Layer4 Ascend2">>
-  <<dollTF>>
-<</link>><br>
-
+	[[Continue to the fifth layer|Layer5 1]]
 <</if>>
-
-<</nobr>>
-
-Use the following option only if you have specifically considered your inventory and made a plan of how to use what you have to take down a beast.
-[[Use a combination of Relics not mentioned above you believe would be able to overpower one of the beasts|Layer4 Ascend2]]
-
-
-:: Layer4 Threat1 Descend [layer4]
-<<set $timeL4T1 -= 7>>
-[img[setup.ImagePath+'Threats/driftingswallower.png']]
-
-How do you want to deal with the creature descending upon you?
-
-
-<<nobr>>
-<<if $items[14].count > 0 && $hiredCompanions.some(e => e.name === "Khemia")>>
-	Khemia has enough expertise with a blade to be able to fight it off, but even he would be seriously injured by fighting it, increasing your next 6 travel times by 1 day each if you let him fight for you.<br>
-	[[Have Khemia fight it off with a sword|Layer4 Exit2][$status.duration += (6 - $statRed), $status.penalty += 1]]<br><br>
-<</if>>
-	<<if ($joyousSword == 1 || $ownedRelics.some(e => e.name === "Sunbeam")) && $hiredCompanions.some(e => e.name === "Khemia")>>
-You can arm Khemia with your more powerful Relic sword and he will be able to defeat the creature without any major issues after a brief battle.<br>
-[[Allow Khemia to defeat it with his Relic blade|Layer4 Exit2]]<br><br>
-<</if>>
-<<if $items[13].count > 0 && $items[20].count > 4>>
-	You can take it down effectively with a gun, but you'll need at least 5 bullets to take it down due to the way it moves around and evades your shots.<br>
-	[[Shoot it with your pistol|Layer4 Exit2][$items[20].count -= (5 - $bullRed)]]<br><br>
-<</if>>
-	<<if $slingshot == 1>>
-Your Brave Vector slingshot can be used like a gun, and a ranged weapon can efficiently bring down a swallower.<br>
-[[Defeat it with the Brave Vector|Layer4 Exit2]]<br><br>
-<</if>>
-<<if $ownedRelics.some(e => e.name === "Tranquility Knell")>>
-The Drifting Swallower detects its prey by the vibrations that surround them, but the Tranquility Knell silences the noise in both the air and all other media, meaning the vibrations are nearly silenced and the Swallower is left nearly blind. This effect should give you 30 minutes where the creature is unable to find you, allowing you to escape unnoticed until you are out of range.<br>
-[[Escape with the Tranquility Knell|Layer4 Exit2]]<br><br>
-<</if>>
-If you allow it to overpower you, prepare to be vored! It will swallow you whole and you will spend the next 3 days inside of its large stomach being tickled and lightly burned by gastric juices lapping over your whole body. After you are eventually expelled from the creature, you'll be left with persistant light burns, increasing all travel costs by 1 day until you are cured. This will not heal without a medkit.<br>
-[[Allow it to overpower you|Layer4 Exit2][$status.duration += 99, $status.penalty += 1]]
-
-<<if ($hiredCompanions.length < 1 || ($hiredCompanions.some(e => e.name === "Golem") && $hiredCompanions.length < 2 )) && $ownedRelics.some(e => e.name === "Creepy Doll") && $app.appAge<18>>
-<br>As the nightmarish beast drifts closer you, you suddenly hear a voice talking to you.<br><br>
-
-<<say $creepydoll>>Don't be scared, nobody will hurt you. Just hold me tight and all the bad things will dissapear <</say>><br>
-
-A pleasant warmth is radiating from the doll you found<br>
-<<link "Hold the doll tight and close your eyes" "Layer4 Exit2">>
-  <<dollTF>>
-<</link>><br>
-<</if>>
-
-<</nobr>>
-Use the following option only if you have specifically considered your inventory and made a plan of how to use what you have to take down a beast.
-[[Use a combination of Relics not mentioned above you believe would be able to overpower one of the beasts|Layer4 Exit2]]
 
 
 :: Layer4 Cherry Relic [layer4]
@@ -1585,7 +1433,7 @@ How do you want to deal with the creature descending upon you?
 If you allow it to overpower you, prepare to be vored! It will swallow you whole and you will spend the next 3 days inside of its large stomach being tickled and lightly burned by gastric juices enveloping your entire body. After you are eventually expelled from the creature, you'll be left with persistant light burns, increasing all travel costs by 1 day until you are cured. This will not heal without a medkit.<br>
 [[Allow it to overpower you|Layer4 Swallower Ravage][$status.duration += 99, $status.penalty += 1]]
 
-<<if  ($hiredCompanions.length < 1 || ($hiredCompanions.some(e => e.name === "Golem") && $hiredCompanions.length < 2 )) && $ownedRelics.some(e => e.name === "Creepy Doll") && $app.appAge<18>>
+<<if ($hiredCompanions.length < 1 || ($hiredCompanions.some(e => e.name === "Golem") && $hiredCompanions.length < 2 )) && $ownedRelics.some(e => e.name === "Creepy Doll") && $app.appAge<18>>
 	<br>As the creature descends, a childlike, otherworldly voice whispers to you, its origin both elusive and omnipresent.<br><br>
 
 	<<say $creepydoll>>Don't be afraid, nobody's going to hurt you. Just hold me tight, and all the bad things will go away! <</say>><br>

--- a/src/layer5.twee
+++ b/src/layer5.twee
@@ -1,10 +1,11 @@
 :: Layer5 1 [layer5]
 <<nobr>>
-<<masteraudio stop>><<audio "layer5" volume 0.2 play loop>>
 <<set $currentLayer = 5>>
+<<masteraudio stop>>
+<<audio "layer5" volume 0.2 play loop>>
+<<set $timeL4T1 = 0>>
+<<set $timeL5T1 = 0, $timeL5T2 = 0>>
 <<set $forageWater = 0>>
-<<set $timeL5T1 = 1>>
-<<set $timeL5T2 = 0>>
 <</nobr>>
 
 @@.layerTitle;
@@ -21,11 +22,19 @@ For an area that otherwise bears such a strong resemblance to a surface desert, 
 
 
 :: Layer5 Hub [layer5]
-<<set $currentLayer = 5>><<if $timeL5T1 < 8 && $timeL5T2 < 11>><<set $visitL5 = 1>><<set $layerExit = 0>><<CarryAdjust>>\
 <<nobr>>
+<<set $currentLayer = 5>>
+<<if !isPlaying("layer5")>>
+	<<masteraudio stop>>
+	<<audio "layer5" volume 0.2 play loop>>
+<</if>>
+<<CarryAdjust>>
+
+<</nobr>>\
+<<if $timeL5T1 < 8 && $timeL5T2 < 11>><<nobr>>
 <<if $visitL5 == 0>>
-	<<set $layerTemp = 8>>
 	<<set $visitL5 = 1>>
+	<<set $layerTemp = 8>>
 <<elseif $secondVisitL5 == 0>>
 	<<set $secondVisitL5 = 1>>
 	<<set $layerTemp = 18>>
@@ -95,11 +104,11 @@ For an area that otherwise bears such a strong resemblance to a surface desert, 
 [[Look down at the next layer|Layer5 Exit1]]<<elseif $timeL5T1 < 8>>
 <<include "Layer5 Borer Encounter">>
 
-[[Deal with the Dune Devouring Borer|Layer5 Threat2][$returnPassage = "Layer5 Hub"]]
+[[Deal with the Dune Devouring Borer|Layer5 Threat2][$returnPassage = passage()]]
 <<else>>
 When you wake up in the morning, you hear an enormous amount of buzzing in the air, luckily you managed to stay out of the swarm when you woke up, but you'll need to decide what to do with the swarm today.
 
-[[Deal with the Mayfly Scuttler|Layer5 Threat1 Main]]<<if $ownedRelics.some(e => e.name === "Breathless Exhale")>>
+[[Deal with the Mayfly Scuttler|Layer5 Threat1][$returnPassage = passage()]]<<if $ownedRelics.some(e => e.name === "Breathless Exhale")>>
 
 The radiant sun empowers your Breathless Exhale Relic, its energy pulsating within your grasp. You can sense the potential of the Relic, trembling with anticipation, ready to alter the wind's course and drive the insects away from you.
 [[Summon a powerful gust to drive the swarm away from you|Layer5 Hub][$timeL5T1 -= 8]]
@@ -116,51 +125,6 @@ How would you like to use Cherry's chaotic luck ability?
 [[Get 2 random Curses for +50% corruption|Layer5 Cherry Curse]]
 [[Get 1 Relic and 1 Curse|Layer5 Cherry Mix]]
 
-
-:: Layer5 Threat2 Main [layer5]
-<<set $timeL5T2 -= 9>>
-[img[setup.ImagePath+'Threats/dunedevouringborer.png']]
-
-How do you want to deal with the enormous worm approaching you?
-
-
-<<nobr>>
-<<if $ownedRelics.some(e => e.name === "Sunbeam") && $hiredCompanions.some(e => e.name === "Khemia")>>
-	Khemia has enough expertise with a blade that if you give him the Sunbeam Relic he will be able to fight it off, but even he would be injured by fighting it, taking one day to recover.<br>
-	[[Have Khemia fight it off with Sunbeam|Layer5 Hub][$time += 1]]<br><br>
-<</if>>
-<<if $joyousSword && $hiredCompanions.some(e => e.name === "Khemia")>>
-	The sword Joyous Sunder is a truly terrifying weapon in the hands of an expert like Khemia, allowing him to defeat a worm without even being injured himself.<br>
-	[[Have Khemia fight it off with Joyous Sunder|Layer5 Hub]]<br><br>
-<</if>>
-You can run away, but this requires sacrificing 10 days of water to distract the worm to give you a chance to get away. You will drop the water based on your drinking water priority order, since that is what is most quickly accessible in this dangerous situation.<br>
-	/*[[Use 10 days of water as a distraction to get away|Layer5 Hub][$items[0].count -= 10]]<br><br>*/
-	<<link "Use 10 days of water as a distraction to get away" "Layer5 Hub">>
-		<<for _k=0; _k<10; _k++>>
-			<<include "Water drop code">>
-		<</for>>
-	<</link>>
-	<br><br>
-If you allow it to overpower you, prepare to be vored! However, this will be much more brutal than what may have occured on the previous layer. In this case you will almost certainly die after being eaten by a worm you can't fight off. It's reccomended you don't allow that to happen.
-<</nobr>>
-
-Use the following option only if you have specifically considered your inventory and made a plan of how to use what you have to take down a worm.
-[[Use a combination of Relics not mentioned above you believe would be able to overpower one of the worms|Layer5 Hub]]
-
-
-:: Layer5 Threat1 Main [layer5]
-<<PassTime 1>>\
-<<set $timeL5T1 -= 8>>\
-[img[setup.ImagePath+'Threats/mayflyscuttler.png']]
-
-When you wake up in the morning, you hear an enormous amount of buzzing in the air, luckily you managed to stay out of the swarm when you woke up. They scarlet bugs produce a potent aphrodisiac venom, so if you choose to go out into the swarm, and succumb to the venom to participate in a day of sexual debauchery. On the other hand, you can stay in one of the ruins for the day and avoid the swarms altogether. Either choice will cost you one day.
-
-[[Walk out into the swarm and enjoy the sexual festivities|Layer5 Mayfly Scuttler Sexual Activities][$returnPassage = "Layer5 Hub"]]
-
-[[Hide out in the ruins for the day|Layer5 Hub]]
-
-Use the following option only if you have specifically considered your inventory and made a plan of how to use what you have to rid of or avoid these pests.
-[[Use a combination of Relics not mentioned above you believe would be able to get rid of the swarm|Layer5 Hub]]
 
 :: Layer5 Mayfly Scuttler Sexual Activities [layer5 nobr]
 [img[setup.ImagePath+'Threats/mayflyscuttler.png']]<br><br>
@@ -310,7 +274,7 @@ You can also wait at the Oasis if you'd like to pass the time while waiting for 
 <<else>>
 When you wake up in the morning, you hear an enormous amount of buzzing in the air, luckily you managed to stay out of the swarm when you woke up, but you'll need to decide what to do with the swarm today.
 
-[[Deal with the Mayfly Scuttler|Layer5 Threat1 Main]]<<if $ownedRelics.some(e => e.name === "Breathless Exhale")>>
+[[Deal with the Mayfly Scuttler|Layer5 Threat1][$returnPassage = "Layer5 Hub"]]<<if $ownedRelics.some(e => e.name === "Breathless Exhale")>>
 
 The radiant sun empowers your Breathless Exhale Relic, its energy pulsating within your grasp. You can sense the potential of the Relic, trembling with anticipation, ready to alter the wind's course and drive the insects away from you.
 [[Summon a powerful gust to drive the swarm away from you|Layer5 Hub][$timeL5T1 -= 8]]
@@ -399,7 +363,7 @@ Already taken
 
 <p>When you wake up in the morning, you hear an enormous amount of buzzing in the air, luckily you managed to stay out of the swarm when you woke up, but you'll need to decide what to do with the swarm today.</p>
 
-<p>[[Deal with the Mayfly Scuttler|Layer5 Threat1 Main]]</p><<if $ownedRelics.some(e => e.name === "Breathless Exhale")>>
+<p>[[Deal with the Mayfly Scuttler|Layer5 Threat1][$returnPassage = "Layer5 Hub"]]</p><<if $ownedRelics.some(e => e.name === "Breathless Exhale")>>
 
 <p>The radiant sun empowers your Breathless Exhale Relic, its energy pulsating within your grasp. You can sense the potential of the Relic, trembling with anticipation, ready to alter the wind's course and drive the insects away from you.</p>
 
@@ -1495,7 +1459,7 @@ The timer has passed its endpoint, there is no more door and no more vault that 
 <<else>>
 When you wake up in the morning, you hear an enormous amount of buzzing in the air, luckily you managed to stay out of the swarm when you woke up, but you'll need to decide what to do with the swarm today.
 
-[[Deal with the Mayfly Scuttler|Layer5 Threat1 Main]]<<if $ownedRelics.some(e => e.name === "Breathless Exhale")>>
+[[Deal with the Mayfly Scuttler|Layer5 Threat1][$returnPassage = "Layer5 Hub"]]<<if $ownedRelics.some(e => e.name === "Breathless Exhale")>>
 
 The radiant sun empowers your Breathless Exhale Relic, its energy pulsating within your grasp. You can sense the potential of the Relic, trembling with anticipation, ready to alter the wind's course and drive the insects away from you.
 [[Summon a powerful gust to drive the swarm away from you|Layer5 Hub][$timeL5T1 -= 8]]
@@ -1503,50 +1467,48 @@ The radiant sun empowers your Breathless Exhale Relic, its energy pulsating with
 <</if>>
 
 
-:: Layer5 Ascend2 [layer5]
-<<nobr>>
-<<if $DaedalusFly==true>>
-	<<include "Companions Stranded">>
-<</if>>
-<<if $layerExit == 0>>
-	<<set $layerExit = 1>>
-
-	<<if setup.haveRope>>
-		<<set $tempTime = 11>>
-	<<else>>
-		<<set $tempTime = 24>>
-	<</if>>
-	<<if $DaedalusFly==true>>
-		<<set $tempTime= Math.ceil($tempTime/2)>>
-	<</if>>
-	<<AdjustedTravelTime "$layerExitTime" $tempTime>>
-<</if>>
+:: Layer5 Travel Events [layer5 nobr]
 <<set _triggers = {
 	duneDevouringBorer: () => $timeL5T2 > 8,
 	mayflyScuttler: () => $timeL5T1 > 7,
 }>>
 
-<<PassTime $layerExitTime _triggers "_done">>
+<<PassTime _triggers>>
 
 <<if _triggers.duneDevouringBorer()>>
 	<br><<include "Layer5 Borer Encounter">><br><br>
 	[[Deal with the Dune Devouring Borer|Layer5 Threat2][$returnPassage = passage()]]<br>
 <<elseif _triggers.mayflyScuttler()>>
 	<br>When you wake up in the morning, you hear an enormous amount of buzzing in the air, luckily you managed to stay out of the swarm when you woke up, but you'll need to decide what to do with the swarm today.<br><br>
-	[[Deal with the Mayfly Scuttler|Layer5 Threat1 Ascend]]<br>
+	[[Deal with the Mayfly Scuttler|Layer5 Threat1][$returnPassage = passage()]]<br>
 
 	<<if $ownedRelics.some(e => e.name === "Breathless Exhale")>>
 		<br>The radiant sun empowers your Breathless Exhale Relic, its energy pulsating within your grasp. You can sense the potential of the Relic, trembling with anticipation, ready to alter the wind's course and drive the insects away from you.<br><br>
-		[[Summon a powerful gust to drive the swarm away from you|Layer5 Ascend2][$timeL5T1 -= 8]]<br>
+		<<link "Summon a powerful gust to drive the swarm away from you" `passage()`>><<set $timeL5T1 -= 8>><</link>><br>
 	<</if>>
 <</if>>
 
-<</nobr>>
-<<if _done>>
-	<<set $timeL4T1 = 0>>\
-	<<set $corruption -= (50 - $corRed + (5 * Math.trunc($hexflame / 10)))>>\
-	<<set $currentLayer = 5>>\
 
+:: Layer5 Ascend2 [layer5]
+<<nobr>>
+
+<<if !setup.passingTime()>>
+	<<set _multiplier = 1>>
+	<<if $DaedalusFly>>
+		<<include "Companions Stranded">>
+		<<set _multiplier = 1/2>>
+	<</if>>
+	<<AdjustedTravelTime "_travelTime" `setup.haveRope ? 11 : 24` false 0 _multiplier>>
+	<<set setup.startPassingTime(_travelTime)>>
+<</if>>
+
+<<include "Layer5 Travel Events">>
+
+<</nobr>>
+<<if !setup.passingTime()>>
+	<<nobr>>
+		<<set $corruption -= 50 - $corRed + 5 * Math.trunc($hexflame / 10)>>
+	<</nobr>>
 	You continue through the scorching desert for days on end, until you eventually reach the contrasting bitter cold of the fourth layer. But before you can do anything on the fourth layer, you need to spend many days in the agonizingly slow climb through the enormous crevasse at its bottom. After many days of climbing, you're back to the snowy wastes of the fourth layer proper.
 
 	<<include "Curse Descriptions">>
@@ -1554,137 +1516,43 @@ The radiant sun empowers your Breathless Exhale Relic, its energy pulsating with
 		<<include "Twin rejoin">>
 	<</if>>
 	[[Return to the fourth layer|Layer4 Hub]]
-
 <</if>>
 
 
-:: Layer5 Threat2 Ascend [layer5]
-<<set $timeL5T2 -= 9>>
-[img[setup.ImagePath+'Threats/dunedevouringborer.png']]
-
-How do you want to deal with the enormous worm approaching you?
-
-
-<<nobr>>
-<<if $ownedRelics.some(e => e.name === "Sunbeam") && $hiredCompanions.some(e => e.name === "Khemia")>>
-	Khemia has enough expertise with a blade that if you give him the Sunbeam Relic he will be able to fight it off, but even he would be injured by fighting it, taking one day to recover.<br>
-	[[Have Khemia fight it off with Sunbeam|Layer5 Ascend2][$time += 1]]<br><br>
-<</if>>
-<<if $joyousSword && $hiredCompanions.some(e => e.name === "Khemia")>>
-	The sword Joyous Sunder is a truly terrifying weapon in the hands of an expert like Khemia, allowing him to defeat a worm without even being injured himself.<br>
-	[[Have Khemia fight it off with Joyous Sunder|Layer5 Ascend2]]<br><br>
-<</if>>
-You can run away, but this requires sacrificing 10 days of water to distract the worm to give you a chance to get away. You will drop the water based on your drinking water priority order, since that is what is most quickly accessible in this dangerous situation.<br>
-	/*[[Use 10 days of water as a distraction to get away|Layer5 Layer5 Ascend2][$items[0].count -= 10]]<br><br>*/
-	<<link "Use 10 days of water as a distraction to get away" "Layer5 Ascend2">>
-		<<for _k=0; _k<10; _k++>>
-			<<include "Water drop code">>
-		<</for>>
-	<</link>>
-	<br><br>
-If you allow it to overpower you, prepare to be vored! However, this will be much more brutal than what may have occured on the previous layer. In this case you will almost certainly die after being eaten by a worm you can't fight off. It's reccomended you don't allow that to happen.
-<</nobr>>
-
-Use the following option only if you have specifically considered your inventory and made a plan of how to use what you have to take down a worm.
-[[Use a combination of Relics not mentioned above you believe would be able to overpower one of the worms|Layer5 Ascend2]]
-
-
-:: Layer5 Threat1 Ascend [layer5]
+:: Layer5 Threat1 [layer5]
 <<PassTime 1>>\
 <<set $timeL5T1 -= 8>>\
 [img[setup.ImagePath+'Threats/mayflyscuttler.png']]
 
 When you wake up in the morning, you hear an enormous amount of buzzing in the air, luckily you managed to stay out of the swarm when you woke up. They scarlet bugs produce a potent aphrodisiac venom, so if you choose to go out into the swarm, and succumb to the venom to participate in a day of sexual debauchery. On the other hand, you can stay in one of the ruins for the day and avoid the swarms altogether. Either choice will cost you one day.
 
-[[Walk out into the swarm and enjoy the sexual festivities|Layer5 Mayfly Scuttler Sexual Activities][$returnPassage = "Layer5 Ascend2"]]
+[[Walk out into the swarm and enjoy the sexual festivities|Layer5 Mayfly Scuttler Sexual Activities]]
 
-[[Hide out in the ruins for the day|Layer5 Ascend2]]
+[[Hide out in the ruins for the day|$returnPassage]]
 
-Use the following option only if you have specifically considered your inventory and made a plan of how to use what you have to rid of these pests.
-[[Use a combination of Relics not mentioned above you believe would be able to get rid of the swarm|Layer5 Ascend2]]
+Use the following option only if you have specifically considered your inventory and made a plan of how to use what you have to rid of or avoid these pests.
+[[Use a combination of Relics not mentioned above you believe would be able to get rid of the swarm|$returnPassage]]
+
 
 :: Layer5 Exit2 [layer5]
 <<nobr>>
-<<if $layerExit == 0>>
-	<<set $layerExit = 1>>
-	<<AdjustedTravelTime "$layerExitTime" 13>>
-<</if>>
-<<set _triggers = {
-	duneDevouringBorer: () => $timeL5T2 > 8,
-	mayflyScuttler: () => $timeL5T1 > 7,
-}>>
 
-<<PassTime $layerExitTime _triggers "_done">>
-
-<<if _triggers.duneDevouringBorer()>>
-	<br><<include "Layer5 Borer Encounter">><br><br>
-	[[Deal with the Dune Devouring Borer|Layer5 Threat2][$returnPassage = passage()]]<br>
-<<elseif _triggers.mayflyScuttler()>>
-	<br>When you wake up in the morning, you hear an enormous amount of buzzing in the air, luckily you managed to stay out of the swarm when you woke up, but you'll need to decide what to do with the swarm today.<br><br>
-	[[Deal with the Mayfly Scuttler|Layer5 Threat1 Descend]]<br>
-
-	<<if $ownedRelics.some(e => e.name === "Breathless Exhale")>>
-		<br>The radiant sun empowers your Breathless Exhale Relic, its energy pulsating within your grasp. You can sense the potential of the Relic, trembling with anticipation, ready to alter the wind's course and drive the insects away from you.<br><br>
-		[[Summon a powerful gust to drive the swarm away from you|Layer5 Exit2][$timeL5T1 -= 8]]<br>
-	<</if>>
+<<if !setup.passingTime()>>
+	<<AdjustedTravelTime "_travelTime" 13>>
+	<<set setup.startPassingTime(_travelTime)>>
 <</if>>
 
-<<if _done>>
-	<<set $timeL6T1 = 0>>
-	<<set $timeL6T2 = 0>>
+<<include "Layer5 Travel Events">>
 
-	You continue through the scorching desert for days on end, but the heat only seems to get more intense. But the smell is different, you catch a whiff of more exotic, meaty scents than the fragrance of the flowers of the fifth layer. As the ground begins to change from sand to a more organic texture, you know you're approaching the sixth layer.<br><br>
+<</nobr>>\
+<<if !setup.passingTime()>>
+	You continue through the scorching desert for days on end, but the heat only seems to get more intense. But the smell is different, you catch a whiff of more exotic, meaty scents than the fragrance of the flowers of the fifth layer. As the ground begins to change from sand to a more organic texture, you know you're approaching the sixth layer.
 
-	<<include "Curse Descriptions">><br><br>
+	<<include "Curse Descriptions">>
 
 	[[Descend to the sixth layer|Layer6 1]]
 <</if>>
-<</nobr>>
 
-:: Layer5 Threat2 Descend [layer5]
-<<set $timeL5T2 -= 9>>
-[img[setup.ImagePath+'Threats/dunedevouringborer.png']]
-
-How do you want to deal with the enormous worm approaching you?
-
-
-<<nobr>>
-<<if $ownedRelics.some(e => e.name === "Sunbeam") && $hiredCompanions.some(e => e.name === "Khemia")>>
-	Khemia has enough expertise with a blade that if you give him the Sunbeam Relic he will be able to fight it off, but even he would be injured by fighting it, taking one day to recover.<br>
-	[[Have Khemia fight it off with Sunbeam|Layer5 Exit2][$time += 1]]<br><br>
-<</if>>
-<<if $joyousSword && $hiredCompanions.some(e => e.name === "Khemia")>>
-	The sword Joyous Sunder is a truly terrifying weapon in the hands of an expert like Khemia, allowing him to defeat a worm without even being injured himself.<br>
-	[[Have Khemia fight it off with Joyous Sunder|Layer5 Exit2]]<br><br>
-<</if>>
-You can run away, but this requires sacrificing 10 days of water to distract the worm to give you a chance to get away. You will drop the water based on your drinking water priority order, since that is what is most quickly accessible in this dangerous situation.<br>
-	/*[[Use 10 days of water as a distraction to get away|Layer5 Exit2][$items[0].count -= 10]]<br><br>*/
-	<<link "Use 10 days of water as a distraction to get away" "Layer5 Exit2">>
-		<<for _k=0; _k<10; _k++>>
-			<<include "Water drop code">>
-		<</for>>
-	<</link>>
-<br><br>
-If you allow it to overpower you, prepare to be vored! However, this will be much more brutal than what may have occured on the previous layer. In this case you will almost certainly die after being eaten by a worm you can't fight off. It's reccomended you don't allow that to happen.
-<</nobr>>
-
-Use the following option only if you have specifically considered your inventory and made a plan of how to use what you have to take down a worm.
-[[Use a combination of Relics not mentioned above you believe would be able to overpower one of the worms|Layer5 Exit2]]
-
-
-:: Layer5 Threat1 Descend [layer5]
-<<PassTime 1>>\
-<<set $timeL5T1 -= 8>>\
-[img[setup.ImagePath+'Threats/mayflyscuttler.png']]
-
-When you wake up in the morning, you hear an enormous amount of buzzing in the air, luckily you managed to stay out of the swarm when you woke up. They scarlet bugs produce a potent aphrodisiac venom, so if you choose to go out into the swarm, and succumb to the venom to participate in a day of sexual debauchery. On the other hand, you can stay in one of the ruins for the day and avoid the swarms altogether. Either choice will cost you one day.
-
-[[Walk out into the swarm and enjoy the sexual festivities|Layer5 Mayfly Scuttler Sexual Activities][$returnPassage = "Layer5 Exit2"]]
-
-[[Hide out in the ruins for the day|Layer5 Exit2]]
-
-Use the following option only if you have specifically considered your inventory and made a plan of how to use what you have to rid of these pests.
-[[Use a combination of Relics not mentioned above you believe would be able to get rid of the swarm|Layer5 Exit2]]
 
 :: Escape Balloon L5 [layer5]
 <<nobr>><<set $currentLayer = 5>><<if !isPlaying("layer5")>>

--- a/src/layer6.twee
+++ b/src/layer6.twee
@@ -1,7 +1,10 @@
 :: Layer6 1 [layer6]
 <<nobr>>
-<<masteraudio stop>><<audio "layer6" volume 0.2 play loop>>
 <<set $currentLayer = 6>>
+<<masteraudio stop>>
+<<audio "layer6" volume 0.2 play loop>>
+<<set $timeL5T1 = 0, $timeL5T2 = 0>>
+<<set $timeL6T1 = 0, $timeL6T2 = 0>>
 <</nobr>>\
 \
 @@.layerTitle;
@@ -18,7 +21,15 @@ They grow taller as you proceed, until you're wading through a thicket or navel-
 
 
 :: Layer6 Hub [layer6]
-<<nobr>><<set $currentLayer = 6>><<if $timeL6T1 < 15 && ($timeL6T2 < 8 || $dragonKill > 4)>><<set $layerExit = 0>><<CarryAdjust>>
+<<nobr>>
+<<set $currentLayer = 6>>
+<<if !isPlaying("layer6")>>
+	<<masteraudio stop>>
+	<<audio "layer6" volume 0.2 play loop>>
+<</if>>
+<<CarryAdjust>>
+
+<<if $timeL6T1 < 15 && ($timeL6T2 < 8 || $dragonKill > 4)>>
 <<if $visitL6 == 0>>
 	<<set $layerTemp = 8>>
 	<<set $visitL6 = 1>>
@@ -87,11 +98,11 @@ They grow taller as you proceed, until you're wading through a thicket or navel-
 
 <<elseif $timeL6T2 > 7 && $dragonKill < 5>>
 <<include "Layer6 Dragon Encounter">><br><br>
-[[Deal with the Fell Dragon|Layer6 Threat2][$returnPassage = "Layer6 Hub"]]
+[[Deal with the Fell Dragon|Layer6 Threat2][$returnPassage = passage()]]
 <<else>>
 <<include "Layer6 Tentacle Encounter">><br><br>
 
-[[Deal with the Greater Tentacle Beast|Layer6 Threat1 1][$returnPassage = "Layer6 Hub"]]
+[[Deal with the Greater Tentacle Beast|Layer6 Threat1 1][$returnPassage = passage()]]
 <</if>><</nobr>>
 
 
@@ -137,7 +148,7 @@ If you decide to start foraging for food or water, it means that you will not co
 
 :: Layer6 Relics [layer6 cards nobr]
 <p><<CarryAdjust>></p>
-<<if $timeL4T1 < 7>>
+<<if $timeL6T1 < 7>>
 
 <p>[[Continue exploring the sixth layer|Layer6 Hub]]</p>
 
@@ -229,173 +240,6 @@ Traversing down and past this hell will take 16 days.
 
 [[Turn back and continue your business on the sixth layer|Layer6 Hub]]
 [[Continue your descent to the seventh layer|Layer6 Exit2]]
-
-
-:: Layer6 Threat2 Main [layer6]
-<<set $timeL6T2 -= 8>>
-[img[setup.ImagePath+'Threats/felldragon.png']]
-
-How do you want to deal with the awe-inspiring dragon flying above your head?
-
-
-<<nobr>>
-<<if $ownedRelics.some(e => e.name === "Sunbeam") && $hiredCompanions.some(e => e.name === "Khemia") && $khemiaDragon == 1>>
-The dragon takes care to avoid Khemia at close range, so he won't have a chance to use Sunbeam this time, at least not if he wants to make it out alive. <br><br>
-<</if>>
-<<if $ownedRelics.some(e => e.name === "Sunbeam") && $hiredCompanions.some(e => e.name === "Khemia") && $khemiaDragon == 0>>
-	Khemia has enough expertise with a blade that if you give him the Sunbeam Relic he will be able to fight it off one time, but even he would be moderately burned by fighting it, increasing all travel times by 2 until you used a medkit on him. You will be able to get it's hoard of 50 dubloons when you kill it though.<br>
-	[[Have Khemia fight it off with Sunbeam|Layer6 Hub][$status.duration += 99, $status.penalty += 2, $khemiaDragon == 1, $dubloons += 50, $dragonKill += 1]]<br><br>
-<</if>>
-<<if $joyousSword == 1 && $hiredCompanions.some(e => e.name === "Khemia") && $khemiaDragon == 0>>
-	Khemia has enough expertise with a blade that if you give him the Joyous Sunder sword he will be able to defeat a dragon with only minor burns, increasing your next 3 travel times by 2 days each.<br>
-	[[Have Khemia fight it off with Sunbeam|Layer6 Hub][$status.duration += 3, $status.penalty += 2, $khemiaDragon == 1, $dubloons += 50, $dragonKill += 1]]<br><br>
-<</if>>
-<<if $ownedRelics.some(e => e.name === "Toral Wave") && $ownedRelics.some(e => e.name === "Empath Coil") && $electricDragon == 0>>
-While the Fell Dragons are immune to most conventional methods of attack, you can combine the power of the Toral Wave with the Empath Coil to electrocute the dragon. A single touch can stun the dragon, allowing follow-up attacks that can take it down. This method is only likely to work once, but it can effective. Even this method isn't safe though, leaving you with minor injuries that will increase your next 3 travel times by 2 days each.<br>
-	[[Use your Relics to electrocute the dragon|Layer6 Hub][$status.duration += 3, $status.penalty += 2, $electricDragon == 1, $dubloons += 50, $dragonKill += 1]]<br><br>
-<</if>>
-You can appease the dragon by offering it 100 dubloons. It would graciously allow you to live and keep the rest of your hoard if you want, though keep in mind another one might come your way if you're still holding enough to attract them in 8 days.<br>
-	[[Offer 100 dubloons to appease the dragon|Layer6 Hub][$dubloons -= 100]]<br><br>
-If you try to run away without fighting to keep your dubloons safe, prepare to be severely burned before you manage to get away. This will increase all travel times by 4 days until you can get it healed and it will take 2 medkits to heal it!<br>
-	[[Try to run and accept the consequences|Layer6 Hub][$status.duration += 99, $status.penalty += 4, $dubloons += 50, $dragonBurn = 1]]<br><br>
-<</nobr>>
-
-Use the following option only if you have specifically considered your inventory and made a plan of how to use what you have to take down a worm. You may only use each combination 1 time before the dragons learn from experience and overcome the weakness, making that strategy unusable a second time.
-[[Use a combination of Relics not mentioned above you believe would be able to overpower one of the dragons|Layer6 Hub][$dragonKill += 1, $dubloons += 50]]
-
-
-:: Layer6 Threat1 Main1 [layer6]
-<<set $timeL6T1 -= 15>>
-[img[setup.ImagePath+'Threats/greatertentaclebeast.png']]
-
-As the enormous tentacle beast approaches, you must quickly decide on a course of action for defeating it, or fall into its slimy clutches and allow it to use you to sate its lust.
-
-<<nobr>>
-<<if $items[13].count > 0 && $items[20].count > 18>>
-	You can take it down effectively with a gun, but you'll need at least 19 bullets to take it down due its amorphous form and enormous size. But even despite those limitations, a ranged weapon like a gun is probably the safest way to take one of these down.<br>
-	[[Shoot it with your pistol|Layer6 Hub][$items[20].count -= (19 - $bullRed)]]<br><br>
-<</if>>
-<<if $slingshot == 1>>
-Your Brave Vector slingshot can be used like a gun, but it will take many shots to bring down the amorphous creature. Luckily ranged combat doesn't pose as much of a risk as melee against a great beast such as this one.<br>
-[[Defeat it with the Brave Vector|Layer6 Hub]]<br><br>
-<</if>>
-<<if $items[14].count > 0>>
-Relying on your own swordplay will allow you to put up a minimum amount of resistance and tire it out a bit, leaving incapacitated for 10 days straight.<br>
-	<<link "Fight it off with a sword" "Layer6 Threat1 Main2">>
-		<<set $tentacleFucked = 10>>
-		<<if $playerCurses.some(e => e.name === "Omnitool")>>
-			<<PregCheck>>
-		<</if>>
-	<</link>><br>
-	<<if $items[4].count > 4>>
-		<<link "Fight it off with a sword and use a medkit to cure the status" "Layer6 Hub">>
-			<<set $items[4].count -= 1>>
-			<<if $playerCurses.some(e => e.name === "Omnitool")>>
-				<<PregCheck>>
-			<</if>>
-		<</link>><br>
-	<</if>>	
-<</if>>
-<<if $ownedRelics.some(e => e.name === "Sunbeam")>>
-Using the power of Sunbeam to fight it yourself is better than using a sword, but only marginally so. It will leave you tentacle fucked for 9 days after the battle.<br>
-	<<link "Fight it off with Sunbeam" "Layer6 Threat1 Main2">>
-		<<set $tentacleFucked = 9>>
-		<<if $playerCurses.some(e => e.name === "Omnitool")>>
-			<<PregCheck>>
-		<</if>>
-	<</link>><br>
-	<<if $items[4].count > 4>>
-		<<link "Fight it off with Sunbeam and use a medkit to cure the status" "Layer6 Hub">>
-			<<set $items[4].count -= 1>>
-			<<if $playerCurses.some(e => e.name === "Omnitool")>>
-				<<PregCheck>>
-			<</if>>
-		<</link>><br>
-	<</if>>	
-<</if>>
-<<if $items[14].count > 0 && $hiredCompanions.some(e => e.name === "Khemia")>>
-	Khemia has enough expertise with a blade to be able to fight it off, but even he wouldn't be able to get away safely, becoming immobilized for 2 days if you let him fight for you with a sword.<br>
-	<<link "Have Khemia fight it off with a sword" "Layer6 Threat1 Main2">>
-		<<set $tentacleFucked = 2>>
-		<<set $khemiaFucked = 1 >>
-		<<set _temp = random(0,100)>>
-		<<if $companionKhemia.curses.some(e => e.name === "Omnitool") && $companionKhemia.womb > 0 && (_temp < 20 || $companionKhemia.curses.some(e => e.name === "Absolute Pregnancy")) && !$companionKhemia.curses.some(e => e.name === "Absolute Birth Control")>>
-				<<set $pregKhemia = $time-14>>
-		<</if>>
-	<</link>><br>
-	<<if $items[4].count > 4>>
-		<<link "Have Khemia fight it off with a sword and use a medkit to cure his status" "Layer6 Hub">>
-			<<set $items[4].count -= 1>>
-			<<set _temp = random(0,100)>>
-			<<if $companionKhemia.curses.some(e => e.name === "Omnitool") && $companionKhemia.womb > 0 && (_temp < 20 || $companionKhemia.curses.some(e => e.name === "Absolute Pregnancy")) && !$companionKhemia.curses.some(e => e.name === "Absolute Birth Control")>>
-				<<set $pregKhemia = $time-14>>
-			<</if>>
-		<</link>><br>	
-	<</if>>
-<</if>>
-<<if $items[14].count > 0 && $hiredCompanions.some(e => e.name === "Khemia")>>
-	If you equip Khemia with Sunbeam, he'll be more effective, but even then he'd be left incapacitated from the various numbing agents for a full day.<br>
-	<<link "Have Khemia fight it off with Sunbeam" "Layer6 Threat1 Main2">>
-		<<set $tentacleFucked = 1>>
-		<<set $khemiaFucked = 1 >>
-		<<set _temp = random(0,100)>>
-		<<if $companionKhemia.curses.some(e => e.name === "Omnitool") && $companionKhemia.womb > 0 && (_temp < 20 || $companionKhemia.curses.some(e => e.name === "Absolute Pregnancy")) && !$companionKhemia.curses.some(e => e.name === "Absolute Birth Control")>>
-			<<set $pregKhemia = $time-14>>
-		<</if>>
-	<</link>><br>	
-	<<if $items[4].count > 4>>
-		<<link "Have Khemia fight it off with Sunbeam and use a medkit to cure his status" "Layer6 Hub">>
-			<<set $items[4].count -= 1>>
-			<<set _temp = random(0,100)>>
-			<<if $companionKhemia.curses.some(e => e.name === "Omnitool") && $companionKhemia.womb > 0 && (_temp < 20 || $companionKhemia.curses.some(e => e.name === "Absolute Pregnancy")) && !$companionKhemia.curses.some(e => e.name === "Absolute Birth Control")>>
-				<<set $pregKhemia = $time-14>>
-			<</if>>
-		<</link>><br>	
-	<</if>>
-<</if>>
-<<if $joyousSword == 1 && $hiredCompanions.some(e => e.name === "Khemia")>>
-	If you equip Khemia with the Joyous Sunder, he'll be much more effective, to the point that he'd be able to defeat the beast without sustaining any major injuries himself, an impressive feat even for someone like him.<br>
-	[[Have Khemia fight it off with Joyous Sunder|Layer6 Hub]]<br><br>
-<</if>>
-If you allow it to overpower you, you <<if $hiredCompanions.length > 0 >>and your party <</if>>will be completely ravaged by the enormous beast. This will be incredibly pleasurable at the time, with powerful numbing agents making sure you don't feel any pain during the process, and only feel the pleasure. But after it's over, you'll be in a sorry state, being left completely incapacitated for a full 12 days unless you use a medkit. This is especially dangerous since it leaves you only a few days left until your next encounter with one of the beasts.<br>
-<<link "Allow it to overpower you" "Layer6 Threat1 Main2">>
-	<<set $tentacleFucked = 12>>
-	<<if $playerCurses.some(e => e.name === "Omnitool")>>
-		<<PregCheck>>
-	<</if>>
-	<<MonsterPregCheckParty>>
-	<<if $playerCurses.some(e => e.name === "Semen Demon") &&  $curse82.variation!="vaginal fluids" >>
-		<<set $SemenDemonBalance+=20>>
-	<</if>>
-<</link>><br>
-
-<<if $items[4].count > 4>>
-	<<link "Allow it to overpower you and use a medkit to cure the status" "Layer6 Hub">>
-		<<set $items[4].count -= 1>>
-		<<if $playerCurses.some(e => e.name === "Omnitool")>>
-			<<PregCheck>>
-		<</if>>
-		<<if $playerCurses.some(e => e.name === "Semen Demon") &&  $curse82.variation!="vaginal fluids" >>
-			<<set $SemenDemonBalance+=20>>
-		<</if>>
-	<<MonsterPregCheckParty>>
-	<</link>><br>
-<</if>><br>
-
-<<if  ($hiredCompanions.length < 1 || ($hiredCompanions.some(e => e.name === "Golem") && $hiredCompanions.length < 2 )) && $ownedRelics.some(e => e.name === "Creepy Doll") && $app.appAge<18>>
-<br><br>As the titanic tentacle beast approaches you, suddenly you hear a voice talking to you.<br><br>
-<<say $creepydoll>>Oh, this one looks really scary! But don't worry, I'll make him go away. You might need to keep your eyes closed a little longer than normal, but just keep holding me tight and everything will be ok, I promise. <</say>><br>
-
-An intense, yet somehow comforting, warmth radiates from the Creepy Doll. You sense that it is a deep and powerful energy, but somehow, other descriptions of it elude you.<br><br>
-<<link "Hold the doll very tight and shut your eyes shut for a long time" "Layer6 Hub">>
-  <<dollTF>>
-  <<dollTF>>
-<</link>><br><br>
-<</if>>
-
-<</nobr>>
-Use the following option only if you have specifically considered your inventory and made a plan of how to use what you have to take down a beast.
-[[Use a combination of Relics not mentioned above you believe would be able to defeat the beast|Layer6 Hub]]
 
 
 :: Layer6 Flasks [layer6]
@@ -1085,38 +929,13 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 <</if>>
 
 
-:: Layer6 Threat1 Main2 [layer6]
-<<PassTime $tentacleFucked>>\
-
-<<if $khemiaFucked == 0>>
-	After an intense encounter with the greater tentacle beast, you are left in a sorry state, needing to be left stationary for $tentacleFucked days. Slowly you regain your sensations and manage to prepare yourself to get going and continue your travels on the sixth layer.
-<<else>>
-	<<set $khemiaFucked = 0>>
-	Khemia is not in a good state after the battle, even with his experience, he obviously wasn't ready to deal with a fully grown tentacle beast on his own. He dealt a lot of damage, but he's still incapacitated. Despite some claims of his that you can keep going, it's impossible to move on with him in this state, so you need to make camp and stay with him until he's recovered.
-<</if>>
-
-[[Return to exploring the sixth layer|Layer6 Hub]]
-
-
-:: Layer6 Ascend2 [layer6]
-<<nobr>>
-<<if $DaedalusFly==true>>
-	<<include "Companions Stranded">>
-<</if>>
-<<if $layerExit == 0>>
-	<<set $layerExit = 1>>
-	<<set $tempTime = 15>>
-	<<if $DaedalusFly==true>>
-		<<set $tempTime= Math.ceil($tempTime/2)>>
-	<</if>>
-	<<AdjustedTravelTime "$layerExitTime" $tempTime>>
-<</if>>
+:: Layer6 Travel Events [layer6 nobr]
 <<set _triggers = {
 	fellDragon: () => $timeL6T2 > 7 && $dragonKill < 5,
 	greaterTentacleBeast: () => $timeL6T1 > 14,
 }>>
 
-<<PassTime $layerExitTime _triggers "_done">>
+<<PassTime _triggers>>
 
 <<if _triggers.fellDragon()>>
 	<br><<include "Layer6 Dragon Encounter">><br><br>
@@ -1126,13 +945,26 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 	[[Deal with the Greater Tentacle Beast|Layer6 Threat1 1][$returnPassage = passage()]]<br><br>
 <</if>>
 
-<</nobr>><<if _done>>
+
+:: Layer6 Ascend2 [layer6]
+<<nobr>>
+
+<<if !setup.passingTime()>>
+	<<set _multiplier = 1>>
+	<<if $DaedalusFly>>
+		<<include "Companions Stranded">>
+		<<set _multiplier = 1/2>>
+	<</if>>
+	<<AdjustedTravelTime "_travelTime" 15 false 0 _multiplier>>
+	<<set setup.startPassingTime(_travelTime)>>
+<</if>>
+
+<<include "Layer6 Travel Events">>
+
+<</nobr>>\
+<<if !setup.passingTime()>>
 	<<nobr>>
-	<<set $corruption -= (65 - $corRed)>>
-	<<set $timeL5T1 = 0>>
-	<<set $timeL5T2 = 0>>
-	
-	<<set $currentLayer = 5>>
+		<<set $corruption -= 65 - $corRed>>
 	<</nobr>>
 	You continue through the flaming fields of tentacles for much longer than you'd like, until you eventually reach the slightly less hellish heat of the fifth layer. The scent of burning meat is replaced with fragrant spices and the tentacles are replaced with sand, you've made it out of hell.
 
@@ -1144,280 +976,24 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 <</if>>
 
 
-:: Layer6 Threat2 Ascend [layer6]
-<<set $timeL6T2 -= 8>>
-[img[setup.ImagePath+'Threats/felldragon.png']]
-
-How do you want to deal with the awe-inspiring dragon flying above your head?
-
-
-<<nobr>>
-<<if $ownedRelics.some(e => e.name === "Sunbeam") && $hiredCompanions.some(e => e.name === "Khemia") && $khemiaDragon == 1>>
-The dragon takes care to avoid Khemia at close range, so he won't have a chance to use Sunbeam this time, at least not if he wants to make it out alive. <br><br>
-<</if>>
-<<if $ownedRelics.some(e => e.name === "Sunbeam") && $hiredCompanions.some(e => e.name === "Khemia") && $khemiaDragon == 0>>
-	Khemia has enough expertise with a blade that if you give him the Sunbeam Relic he will be able to fight it off one time, but even he would be moderately burned by fighting it, increasing all travel times by 2 until you used a medkit on him. You will be able to get it's hoard of 50 dubloons when you kill it though.<br>
-	[[Have Khemia fight it off with Sunbeam|Layer6 Ascend2][$status.duration += 99, $status.penalty += 2, $khemiaDragon = 1, $dubloons += 50, $dragonKill += 1]]<br><br>
-<</if>>
-<<if $joyousSword == 1 && $hiredCompanions.some(e => e.name === "Khemia") && $khemiaDragon == 0>>
-	Khemia has enough expertise with a blade that if you give him the Joyous Sunder sword he will be able to defeat a dragon with only minor burns, increasing your next 3 travel times by 2 days each.<br>
-	[[Have Khemia fight it off with Sunbeam|Layer6 Hub][$status.duration += 3, $status.penalty += 2, $khemiaDragon == 1, $dubloons += 50, $dragonKill += 1]]<br><br>
-<</if>>
-<<if $ownedRelics.some(e => e.name === "Toral Wave") && $ownedRelics.some(e => e.name === "Empath Coil") && $electricDragon == 0>>
-While the Fell Dragons are immune to most conventional methods of attack, you can combine the power of the Toral Wave with the Empath Coil to electrocute the dragon. A single touch can stun the dragon, allowing follow-up attacks that can take it down. This method is only likely to work once, but it can effective. Even this method isn't safe though, leaving you with minor injuries that will increase your next 3 travel times by 2 days each.<br>
-	[[Use your Relics to electrocute the dragon|Layer6 Hub][$status.duration += 3, $status.penalty += 2, $electricDragon == 1, $dubloons += 50, $dragonKill += 1]]<br><br>
-<</if>>
-You can appease the dragon by offering it 100 dubloons. It would graciously allow you to live and keep the rest of your hoard if you want, though keep in mind another one might come your way if you're still holding enough to attract them in 8 days.<br>
-	[[Offer 100 dubloons to appease the dragon|Layer6 Ascend2][$dubloons -= 100]]<br><br>
-If you try to run away without fighting to keep your dubloons safe, prepare to be severely burned before you manage to get away. This will increase all travel times by 4 days until you can get it healed and it will take 2 medkits to heal it!<br>
-	[[Try to run and accept the consequences|Layer6 Ascend2][$status.duration += 99, $status.penalty += 4, $dubloons += 50, $dragonBurn = 1]]<br><br>
-<</nobr>>
-
-Use the following option only if you have specifically considered your inventory and made a plan of how to use what you have to take down a worm. You may only use each combination 1 time before the dragons learn from experience and overcome the weakness, making that strategy unusable a second time.
-[[Use a combination of Relics not mentioned above you believe would be able to overpower one of the dragons|Layer6 Ascend2][$dragonKill += 1, $dubloons += 50]]
-
-
-:: Layer6 Threat1 Ascend1 [layer6]
-<<set $timeL6T1 -= 15>>
-[img[setup.ImagePath+'Threats/greatertentaclebeast.png']]
-
-As the enormous tentacle beast approaches, you must quickly decide on a course of action for defeating it, or fall into its slimy clutches and allow it to use you to sate its lust.
-
-<<nobr>>
-<<if $items[13].count > 0 && $items[20].count > 18>>
-	You can take it down effectively with a gun, but you'll need at least 19 bullets to take it down due its amorphous form and enormous size. But even despite those limitations, a ranged weapon like a gun is probably the safest way to take one of these down.<br>
-	[[Shoot it with your pistol|Layer6 Ascend2][$items[20].count -= (19 - $bullRed)]]<br><br>
-<</if>>
-<<if $slingshot == 1>>
-Your Brave Vector slingshot can be used like a gun, but it will take many shots to bring down the amorphous creature. Luckily ranged combat doesn't pose as much of a risk as melee against a great beast such as this one.<br>
-[[Defeat it with the Brave Vector|Layer6 Ascend2]]<br><br>
-<</if>>
-<<if $items[14].count > 0>>
-Relying on your own swordplay will allow you to put up a minimum amount of resistance and tire it out a bit, leaving incapacitated for 10 days straight.<br>
-	[[Fight it off with a sword|Layer6 Threat1 Ascend2][$tentacleFucked = 10]]<br>
-	<<if $items[4].count > 4>>[[Fight it off with a sword and use a medkit to cure the status|Layer6 Ascend2][$items[4].count -= 1]]<br><</if>><br>
-	<</if>>
-<<if $ownedRelics.some(e => e.name === "Sunbeam")>>
-Using the power of Sunbeam to fight it yourself is better than using a sword, but only marginally so. It will leave you tentacle fucked for 9 days after the battle.<br>
-	[[Fight it off with Sunbeam|Layer6 Threat1 Ascend2][$tentacleFucked = 9]]<br>
-	<<if $items[4].count > 4>>[[Fight it off with Sunbeam and use a medkit to cure the status|Layer6 Ascend2][$items[4].count -= 1]]<br><</if>><br>
-	<</if>>
-<<if $items[14].count > 0 && $hiredCompanions.some(e => e.name === "Khemia")>>
-	Khemia has enough expertise with a blade to be able to fight it off, but even he wouldn't be able to get away safely, becoming immobilized for 2 days if you let him fight for you with a sword.<br>
-	[[Have Khemia fight it off with a sword|Layer6 Threat1 Ascend2][$tentacleFucked = 2, $khemiaFucked = 1]]<br>
-	<<if $items[4].count > 4>>[[Have Khemia fight it off with a sword and use a medkit to cure his status|Layer6 Ascend2][$items[4].count -= 1]]<br><</if>><br>
-	<</if>>
-<<if $items[14].count > 0 && $hiredCompanions.some(e => e.name === "Khemia")>>
-	If you equip Khemia with Sunbeam, he'll be more effective, but even then he'd be left incapacitated from the various numbing agents for a full day.<br>
-	[[Have Khemia fight it off with Sunbeam|Layer6 Threat1 Ascend2][$tentacleFucked = 1, $khemiaFucked = 1]]<br>
-	<<if $items[4].count > 4>>[[Have Khemia fight it off with Sunbeam and use a medkit to cure his status|Layer6 Ascend2][$items[4].count -= 1]]<br><</if>><br>
-<</if>>
-<<if $joyousSword == 1 && $hiredCompanions.some(e => e.name === "Khemia")>>
-	If you equip Khemia with the Joyous Sunder, he'll be much more effective, to the point that he'd be able to defeat the beast without sustaining any major injuries himself, an impressive feat even for someone like him.<br>
-	[[Have Khemia fight it off with Joyous Sunder|Layer6 Ascend2]]<br><br>
-<</if>>
-If you allow it to overpower you, you will be completely ravaged by the enormous beast. This will be incredibly pleasurable at the time, with powerful numbing agents making sure you don't feel any pain during the process, and only feel the pleasure. But after it's over, you'll be in a sorry state, being left completely incapacitated for a full 12 days unless you use a medkit. This is especially dangerous since it leaves you only a few days left until your next encounter with one of the beasts.<br>
-<<link "Allow it to overpower you" "Layer6 Threat1 Ascend2">>
-	<<set $tentacleFucked = 12>>
-	<<if $playerCurses.some(e => e.name === "Omnitool")>>
-		<<PregCheck>>
-	<</if>>
-	<<if $playerCurses.some(e => e.name === "Semen Demon") &&  $curse82.variation!="vaginal fluids" >>
-		<<set $SemenDemonBalance+=20>>
-	<</if>>
-<</link>><br>
-<<if $items[4].count > 4>>
-	<<link "Allow it to overpower you and use a medkit to cure the status" "Layer6 Ascend2">>
-		<<set $items[4].count -= 1>>
-		<<if $playerCurses.some(e => e.name === "Omnitool")>>
-			<<PregCheck>>
-		<</if>>
-		<<if $playerCurses.some(e => e.name === "Semen Demon") &&  $curse82.variation!="vaginal fluids" >>
-			<<set $SemenDemonBalance+=20>>
-		<</if>>
-	<</link>><br>
-<</if>><br>
-
-<<if  ($hiredCompanions.length < 1 || ($hiredCompanions.some(e => e.name === "Golem") && $hiredCompanions.length < 2 )) && $ownedRelics.some(e => e.name === "Creepy Doll") && $app.appAge<18>>
-<br><br>As the titanic tentacle beast approaches you, suddenly you hear a voice talking to you.<br><br>
-<<say $creepydoll>>Oh, this one looks really scary! But don't worry, I'll make him go away. You might need to keep your eyes closed a little longer than normal, but just keep holding me tight and everything will be ok, I promise. <</say>><br>
-
-An intense, yet somehow comforting, warmth radiates from the Creepy Doll. You sense that it is a deep and powerful energy, but somehow, other descriptions of it elude you.<br><br>
-<<link "Hold the doll very tight and shut your eyes shut for a long time" "Layer6 Hub">>
-  <<dollTF>>
-  <<dollTF>>
-<</link>><br><br>
-<</if>>
-
-<</nobr>>
-Use the following option only if you have specifically considered your inventory and made a plan of how to use what you have to take down a beast.
-[[Use a combination of Relics not mentioned above you believe would be able to defeat the beast|Layer6 Ascend2]]
-
-
-:: Layer6 Threat1 Ascend2 [layer6]
-<<PassTime $tentacleFucked>>\
-
-<<if $khemiaFucked == 0>>
-	After an intense encounter with the greater tentacle beast, you are left in a sorry state, needing to be left stationary for $tentacleFucked days. Slowly you regain your sensations and manage to prepare yourself to get going and continue your travels on the sixth layer.
-<<else>>
-	<<set $khemiaFucked = 0>>
-	Khemia is not in a good state after the battle, even with his experience, he obviously wasn't ready to deal with a fully grown tentacle beast on his own. He dealt a lot of damage, but he's still incapacitated. Despite some claims of his that you can keep going, it's impossible to move on with him in this state, so you need to make camp and stay with him until he's recovered.
-<</if>>
-
-[[Return to exploring the sixth layer|Layer6 Ascend2]]
-
-
 :: Layer6 Exit2 [layer6]
 <<nobr>>
-<<if $layerExit == 0>>
-	<<set $layerExit = 1>>
-	<<AdjustedTravelTime "$layerExitTime" 16>>
-<</if>>
-<<set _triggers = {
-	fellDragon: () => $timeL6T2 > 7 && $dragonKill < 5,
-	greaterTentacleBeast: () => $timeL6T1 > 14,
-}>>
 
-<<PassTime $layerExitTime _triggers "_done">>
-
-<<if _triggers.fellDragon()>>
-	<br><<include "Layer6 Dragon Encounter">><br><br>
-	[[Deal with the Fell Dragon|Layer6 Threat2 Descend][$returnPassage = passage()]]<br><br>
-<<elseif _triggers.greaterTentacleBeast()>>
-	<br><<include "Layer6 Tentacle Encounter">><br><br>
-	[[Deal with the Greater Tentacle Beast|Layer6 Threat1 1][$returnPassage = passage()]]<br><br>
+<<if !setup.passingTime()>>
+	<<AdjustedTravelTime "_travelTime" 16>>
+	<<set setup.startPassingTime(_travelTime)>>
 <</if>>
 
-<</nobr>><<if _done>>
-<<set $timeL7T2 = 0>>
+<<include "Layer6 Travel Events">>
+
+<</nobr>>\
+<<if !setup.passingTime()>>
 	You continue through the playfully ticklish yet hellishly searing tentacles for a long hike downward. You find some small hints of paved paths that have long since degraded, but no other indication of what is next for you, until suddenly you are faced with a metal barricade, signaling the end of the sixth layer and the start of the seventh.
 
 	<<include "Curse Descriptions">>
 
 	[[Descend down to the seventh layer|Layer7 1]]
 <</if>>
-
-
-:: Layer6 Threat2 Descend [layer6]
-<<set $timeL6T2 -= 8>>
-[img[setup.ImagePath+'Threats/felldragon.png']]
-
-How do you want to deal with the awe-inspiring dragon flying above your head?
-
-
-<<nobr>>
-<<if $ownedRelics.some(e => e.name === "Sunbeam") && $hiredCompanions.some(e => e.name === "Khemia") && $khemiaDragon == 1>>
-The dragon takes care to avoid Khemia at close range, so he won't have a chance to use Sunbeam this time, at least not if he wants to make it out alive. <br><br>
-<</if>>
-<<if $ownedRelics.some(e => e.name === "Sunbeam") && $hiredCompanions.some(e => e.name === "Khemia") && $khemiaDragon == 0>>
-	Khemia has enough expertise with a blade that if you give him the Sunbeam Relic he will be able to fight it off one time, but even he would be moderately burned by fighting it, increasing all travel times by 2 until you used a medkit on him. You will be able to get it's hoard of 50 dubloons when you kill it though.<br>
-	[[Have Khemia fight it off with Sunbeam|Layer6 Exit2][$status.duration += 99, $status.penalty += 2, $khemiaDragon == 1, $dubloons += 50, $dragonKill += 1]]<br><br>
-<</if>>
-<<if $joyousSword == 1 && $hiredCompanions.some(e => e.name === "Khemia") && $khemiaDragon == 0>>
-	Khemia has enough expertise with a blade that if you give him the Joyous Sunder sword he will be able to defeat a dragon with only minor burns, increasing your next 3 travel times by 2 days each.<br>
-	[[Have Khemia fight it off with Sunbeam|Layer6 Hub][$status.duration += 3, $status.penalty += 2, $khemiaDragon == 1, $dubloons += 50, $dragonKill += 1]]<br><br>
-<</if>>
-<<if $ownedRelics.some(e => e.name === "Toral Wave") && $ownedRelics.some(e => e.name === "Empath Coil") && $electricDragon == 0>>
-While the Fell Dragons are immune to most conventional methods of attack, you can combine the power of the Toral Wave with the Empath Coil to electrocute the dragon. A single touch can stun the dragon, allowing follow-up attacks that can take it down. This method is only likely to work once, but it can effective. Even this method isn't safe though, leaving you with minor injuries that will increase your next 3 travel times by 2 days each.<br>
-	[[Use your Relics to electrocute the dragon|Layer6 Hub][$status.duration += 3, $status.penalty += 2, $electricDragon == 1, $dubloons += 50, $dragonKill += 1]]<br><br>
-<</if>>
-You can appease the dragon by offering it 100 dubloons. It would graciously allow you to live and keep the rest of your hoard if you want, though keep in mind another one might come your way if you're still holding enough to attract them in 8 days.<br>
-	[[Offer 100 dubloons to appease the dragon|Layer6 Exit2][$dubloons -= 100]]<br><br>
-If you try to run away without fighting to keep your dubloons safe, prepare to be severely burned before you manage to get away. This will increase all travel times by 4 days until you can get it healed and it will take 2 medkits to heal it!<br>
-	[[Try to run and accept the consequences|Layer6 Exit2][$status.duration += 99, $status.penalty += 4, $dubloons += 50, $dragonBurn = 1]]<br><br>
-<</nobr>>
-
-Use the following option only if you have specifically considered your inventory and made a plan of how to use what you have to take down a dragon. You may only use each combination 1 time before the dragons learn from experience and overcome the weakness, making that strategy unusable a second time.
-[[Use a combination of Relics not mentioned above you believe would be able to overpower one of the dragons|Layer6 Exit2][$dragonKill += 1, $dubloons += 50]]
-
-
-:: Layer6 Threat1 Descend [layer6]
-<<set $timeL6T1 -= 15>>
-[img[setup.ImagePath+'Threats/greatertentaclebeast.png']]
-
-As the enormous tentacle beast approaches, you must quickly decide on a course of action for defeating it, or fall into its slimy clutches and allow it to use you to sate its lust.
-
-<<nobr>>
-<<if $items[13].count > 0 && $items[20].count > 18>>
-	You can take it down effectively with a gun, but you'll need at least 19 bullets to take it down due its amorphous form and enormous size. But even despite those limitations, a ranged weapon like a gun is probably the safest way to take one of these down.<br>
-	[[Shoot it with your pistol|Layer6 Exit2][$items[20].count -= (19 - $bullRed)]]<br><br>
-<</if>>
-<<if $slingshot == 1>>
-Your Brave Vector slingshot can be used like a gun, but it will take many shots to bring down the amorphous creature. Luckily ranged combat doesn't pose as much of a risk as melee against a great beast such as this one.<br>
-[[Defeat it with the Brave Vector|Layer6 Exit2]]<br><br>
-<</if>>
-<<if $items[14].count > 0>>
-Relying on your own swordplay will allow you to put up a minimum amount of resistance and tire it out a bit, leaving incapacitated for 10 days straight.<br>
-	[[Fight it off with a sword|Layer6 Threat1 Descend2][$tentacleFucked = 10]]<br>
-	<<if $items[4].count > 4>>[[Fight it off with a sword and use a medkit to cure the status|Layer6 Exit2][$items[4].count -= 1]]<br><</if>><br>
-	<</if>>
-<<if $ownedRelics.some(e => e.name === "Sunbeam")>>
-Using the power of Sunbeam to fight it yourself is better than using a sword, but only marginally so. It will leave you tentacle fucked for 9 days after the battle.<br>
-	[[Fight it off with Sunbeam|Layer6 Threat1 Descend2][$tentacleFucked = 9]]<br>
-	<<if $items[4].count > 4>>[[Fight it off with Sunbeam and use a medkit to cure the status|Layer6 Exit2][$items[4].count -= 1]]<br><</if>><br>
-	<</if>>
-<<if $items[14].count > 0 && $hiredCompanions.some(e => e.name === "Khemia")>>
-	Khemia has enough expertise with a blade to be able to fight it off, but even he wouldn't be able to get away safely, becoming immobilized for 2 days if you let him fight for you with a sword.<br>
-	[[Have Khemia fight it off with a sword|Layer6 Threat1 Descend2][$tentacleFucked = 2, $khemiaFucked = 1]]<br>
-	<<if $items[4].count > 4>>[[Have Khemia fight it off with a sword and use a medkit to cure his status|Layer6 Exit2][$items[4].count -= 1]]<br><</if>><br>
-	<</if>>
-<<if $items[14].count > 0 && $hiredCompanions.some(e => e.name === "Khemia")>>
-	If you equip Khemia with Sunbeam, he'll be more effective, but even then he'd be left incapacitated from the various numbing agents for a full day.<br>
-	[[Have Khemia fight it off with Sunbeam|Layer6 Threat1 Descend2][$tentacleFucked = 1, $khemiaFucked = 1]]<br>
-	<<if $items[4].count > 4>>[[Have Khemia fight it off with Sunbeam and use a medkit to cure his status|Layer6 Exit2][$items[4].count -= 1]]<br><</if>><br>
-<</if>>
-<<if $joyousSword == 1 && $hiredCompanions.some(e => e.name === "Khemia")>>
-	If you equip Khemia with the Joyous Sunder, he'll be much more effective, to the point that he'd be able to defeat the beast without sustaining any major injuries himself, an impressive feat even for someone like him.<br>
-	[[Have Khemia fight it off with Joyous Sunder|Layer6 Exit2]]<br><br>
-<</if>>
-If you allow it to overpower you, you will be completely ravaged by the enormous beast. This will be incredibly pleasurable at the time, with powerful numbing agents making sure you don't feel any pain during the process, and only feel the pleasure. But after it's over, you'll be in a sorry state, being left completely incapacitated for a full 12 days unless you use a medkit. This is especially dangerous since it leaves you only a few days left until your next encounter with one of the beasts.<br>
-<<link "Allow it to overpower you" "Layer6 Threat1 Descend2">>
-	<<set $tentacleFucked = 12>>
-	<<if $playerCurses.some(e => e.name === "Omnitool")>>
-		<<PregCheck>>
-	<</if>>
-	<<if $playerCurses.some(e => e.name === "Semen Demon") &&  $curse82.variation!="vaginal fluids" >>
-		<<set $SemenDemonBalance+=20>>
-	<</if>>
-<</link>><br>
-<<if $items[4].count > 4>>
-	<<link "Allow it to overpower you and use a medkit to cure the status" "Layer6 Exit2">>
-		<<set $items[4].count -= 1>>
-		<<if $playerCurses.some(e => e.name === "Omnitool")>>
-			<<PregCheck>>
-		<</if>>
-		<<if $playerCurses.some(e => e.name === "Semen Demon") &&  $curse82.variation!="vaginal fluids" >>
-			<<set $SemenDemonBalance+=20>>
-		<</if>>
-	<</link>><br>
-<</if>><br>
-
-<<if  ($hiredCompanions.length < 1 || ($hiredCompanions.some(e => e.name === "Golem") && $hiredCompanions.length < 2 )) && $ownedRelics.some(e => e.name === "Creepy Doll") && $app.appAge<18>>
-<br><br>As the titanic tentacle beast approaches you, suddenly you hear a voice talking to you.<br><br>
-<<say $creepydoll>>Oh, this one looks really scary! But don't worry, I'll make him go away. You might need to keep your eyes closed a little longer than normal, but just keep holding me tight and everything will be ok, I promise. <</say>><br>
-
-An intense, yet somehow comforting, warmth radiates from the Creepy Doll. You sense that it is a deep and powerful energy, but somehow, other descriptions of it elude you.<br><br>
-<<link "Hold the doll very tight and shut your eyes shut for a long time" "Layer6 Hub">>
-  <<dollTF>>
-  <<dollTF>>
-<</link>><br><br>
-<</if>>
-
-<</nobr>>
-Use the following option only if you have specifically considered your inventory and made a plan of how to use what you have to take down a beast.
-[[Use a combination of Relics not mentioned above you believe would be able to defeat the beast|Layer6 Exit2]]
-
-:: Layer6 Threat1 Descend2 [layer6]
-<<PassTime $tentacleFucked>>\
-
-<<if $khemiaFucked == 0>>
-	After an intense encounter with the greater tentacle beast, you are left in a sorry state, needing to be left stationary for $tentacleFucked days. Slowly you regain your sensations and manage to prepare yourself to get going and continue your travels on the sixth layer.
-<<else>>
-	<<set $khemiaFucked = 0>>
-	Khemia is not in a good state after the battle, even with his experience, he obviously wasn't ready to deal with a fully grown tentacle beast on his own. He dealt a lot of damage, but he's still incapacitated. Despite some claims of his that you can keep going, it's impossible to move on with him in this state, so you need to make camp and stay with him until he's recovered.
-<</if>>
-
-[[Continue your descent to the seventh layer|Layer6 Exit2]]
 
 
 :: Escape Balloon L6 [layer6]

--- a/src/layer7.twee
+++ b/src/layer7.twee
@@ -1,7 +1,10 @@
 :: Layer7 1 [layer7]
 <<nobr>>
-<<masteraudio stop>><<audio "layer7" volume 0.2 play loop>>
 <<set $currentLayer = 7>>
+<<masteraudio stop>>
+<<audio "layer7" volume 0.2 play loop>>
+<<set $timeL6T1 = 0, $timeL6T2 = 0>>
+<<set $timeL7T2 = 0>>
 <</nobr>>\
 \
 @@.layerTitle;
@@ -69,7 +72,16 @@ Threats:
 <<back>>
 
 :: Layer7 Hub [layer7]
-<<set $currentLayer = 7>><<CarryAdjust>><<if $dubloons < 0 && $easymode==false>>[img[setup.ImagePath+'Threats/taxdrone.png']]
+<<nobr>>
+<<set $currentLayer = 7>>
+<<if !isPlaying("layer7")>>
+	<<masteraudio stop>>
+	<<audio "layer7" volume 0.2 play loop>>
+<</if>>
+<<CarryAdjust>>
+
+<</nobr>>\
+<<if $dubloons < 0 && $easymode==false>>[img[setup.ImagePath+'Threats/taxdrone.png']]
 
 A quiet humming sound descends upon you as you see the Taxdrone floating towards you from over a nearby building. You reach into your pack to get your typical dubloon payment, but then you realize something is wrong, you can't find any dubloons! Perhaps you didn't keep track of them properly? But it's too late to get any now, the taxes are already due.
 
@@ -97,7 +109,7 @@ As you awaken later that day you feel your entire body still aching. However, th
 
 [[Continue your journey|Layer7 Hub]]
 
-<<elseif $timeL7T2 < 6>><<set $layerExit = 0>>\
+<<elseif $timeL7T2 < 6>>\
 <<nobr>>
 
 <<if $visitL7 == 0>>
@@ -315,68 +327,6 @@ If you're not dissuaded and choose to continue onward, it will take you 8 days t
 
 [[Turn back and continue your business on the seventh layer|Layer7 Hub]]
 [[Continue your descent to the eighth layer|Layer7 Exit2]]
-
-
-:: Layer7 Threat2 Main [layer7]
-<<nobr>>
-<<set $timeL7T2 -= 6>>
-<<PassTime 1>>
-<</nobr>>
-[img[setup.ImagePath+'Threats/securityrobot.png']]
-<<if $playerCurses.some(e => e.name === "Hypno Happytime") && $layer7Hypno < 3>><<set $layer7Hypno += 1>>
-	After you are pulled into the giant security robot, you are placed in a cell and bombarded with propaganda recordings about life in the city and your place in it. It seems to be nonsense, why would you want to serve organics? You are an organic!
-
-	Of course you can't tone it all out, but it's pretty easy to keep your eyes on what matters and you patiently wait until the time is up and you are released.
-
-	[[Return to exploring the city|Layer7 Hub]]
-
-<<elseif $playerCurses.some(e => e.name === "Hypno Happytime") && $layer7Hypno < 5>><<set $layer7Hypno += 1>>
-	Once again, you are pulled into the security robot to hear the familiar tales of how to be a productive part of society.
-
-	For some reason, you find yourself paying a but more attention to the videos and voices, and you realize that they're not actually as ridiculous as you first thought.
-
-	Sure, you're free right now, but with subservience can come great pleasure, and what greater pursuit in life is there than pleasure? Your pleasure centers could be continually stimulated by following orders and following what is demanded of you.
-
-	Fine, you're an organic being, but the miraculous technology of the city could change that, they could change you so that you fit neatly into the mechanisms of society here. No need to let your messy fleshy bits get in the way of a better life for you and everyone else.
-
-	Yeah, you do have goals of things you want to do, but why are your goals more important than the goals of an entire city? Especially when they are as grand as the City of Agartha preparing for the future awakening of its organic population!
-
-	When the robot releases you, you are tempted to go back and take up residence here, but shake off the feeling and continue your journey.
-
-	[[Return to exploring the city|Layer7 Hub]]
-
-<<elseif $playerCurses.some(e => e.name === "Hypno Happytime") && $layer7Hypno == 5>>
-	Once again, you are pulled into the security robot to hear the familiar tales of how to be a productive part of society. And yeah, you do wish you were a better member of society, don't you?
-
-	The arguments they are making actually make perfect sense, they seem to precisely match your own thoughts actually. As if they were molded to you (or the other way around.)
-
-	With subservience can come great pleasure, and what greater pursuit in life is there than pleasure? Your pleasure centers could be continually stimulated by following orders and following what is demanded of you.
-
-	The miraculous technology of the city could change that, they could change your organic body so that you fit neatly into the mechanisms of society here. No need to let your messy fleshy bits get in the way of a better life for you and everyone else.
-
-	Why are your goals more important than the goals of an entire city? Especially when they are as grand as the City of Agartha preparing for the future awakening of its organic population!
-
-	When the robot releases you, you are free to go, but you do not use that freedom.
-
-	Now is your chance, you've found a place where you belong.
-
-	It's time to stay in your new home.
-
-	You tell the robot that you are ready to take your place as a gear in the mechanism of society and almost immediately a syringe comes out of the wall and pokes your neck. You smile as your consciousness fades.
-
-	[[Awaken to your new life|Layer7 Tax End]]
-
-<<else>>
-
-	After you are pulled into the giant security robot, you are placed in a cell and bombarded with propaganda recordings about life in the city and your place in it. It seems to be nonsense, why would you want to serve organics? You are an organic!
-
-	The biggest threat here is your boredom, honestly. While you try to fall asleep the robot makes an effort to keep you awake, in a kind of minor psychological torture through annoyance.
-
-	Eventually you are released though, with no harm done, and ready to continue your journey in the seventh layer.
-
-	[[Return to exploring the city|Layer7 Hub]]
-
-<</if>>
 
 
 :: Pick up the Daedalus Mechanism [layer7]
@@ -1394,26 +1344,13 @@ You have no choice, you gain consciousness a few times to see yourself in a surg
 @@.layerTitle;GAME OVER@@
 
 
-:: Layer7 Ascend2 [layer7]
-<<nobr>>
-<<if $DaedalusFly==true>>
-	<<include "Companions Stranded">>
-<</if>>
-
-<<if $layerExit == 0>>
-	<<set $layerExit = 1>>
-	<<set $tempTime = 7>>
-	<<if $DaedalusFly==true>>
-		<<set $tempTime= Math.ceil($tempTime/2)>>
-	<</if>>
-	<<AdjustedTravelTime "$layerExitTime" $tempTime>>
-<</if>>
+:: Layer7 Travel Events [layer7 nobr]
 <<set _triggers = {
 	inDebt: () => $dubloons < 0,
 	rehabilitated: () => $timeL7T2 > 5,
 }>>
 
-<<PassTime $layerExitTime _triggers "_done">>
+<<PassTime _triggers>>
 
 <<if _triggers.inDebt() && $easymode>>
 	<br>[img[setup.ImagePath+'Threats/taxdrone.png']]<br><br>
@@ -1426,7 +1363,7 @@ You have no choice, you gain consciousness a few times to see yourself in a surg
 
 	As you awaken later that day you feel your entire body still aching. However, the Taxdrone is nowhere to be found and you feel like you escaped a terrible fate.<br><br>
 
-	[[Continue your journey|Layer7 Ascend2]]<br><br>
+	<<link "Continue your journey" `passage()`>><</link>><br><br>
 	<<set $status.penalty += 2>>
 	<<set $status.duration += 1>>
 	<<set $dubloons = 3>>
@@ -1452,15 +1389,26 @@ You have no choice, you gain consciousness a few times to see yourself in a surg
 	[[Get rehabilitated|Layer7 Threat2][$returnPassage = passage()]]<br><br>
 <</if>>
 
-<</nobr>>
-<<if _done>>
+
+:: Layer7 Ascend2 [layer7]
+<<nobr>>
+
+<<if !setup.passingTime()>>
+	<<set _multiplier = 1>>
+	<<if $DaedalusFly>>
+		<<include "Companions Stranded">>
+		<<set _multiplier = 1/2>>
+	<</if>>
+	<<AdjustedTravelTime "_travelTime" 7 false 0 _multiplier>>
+	<<set setup.startPassingTime(_travelTime)>>
+<</if>>
+
+<<include "Layer7 Travel Events">>
+
+<</nobr>>\
+<<if !setup.passingTime()>>
 	<<nobr>>
-	<<set $corruption -= (80 - $corRed)>>
-
-	<<set $timeL6T1 = 0>>
-	<<set $timeL6T2 = 0>>
-
-	<<set $currentLayer = 6>>
+		<<set $corruption -= 80 - $corRed + 5 * Math.trunc($hexflame / 10)>>
 	<</nobr>>
 	Surprisingly, the ascent up to the sixth layer is relatively easy. While you did need to deal with the typical, meddlesome robots, there weren't any additional obstacles in your path.
 
@@ -1470,198 +1418,29 @@ You have no choice, you gain consciousness a few times to see yourself in a surg
 	<<if $TwinFly == true>>
 		<<include "Twin rejoin">>
 	<</if>>
-	[[Return to the Sixth layer|Layer6 Hub]]
-
-<</if>>
-
-
-:: Layer7 Threat2 Ascend [layer7]
-<<nobr>>
-<<set $timeL7T2 -= 6>>
-<<PassTime 1>>
-<</nobr>>
-[img[setup.ImagePath+'Threats/securityrobot.png']]
-
-<<if $playerCurses.some(e => e.name === "Hypno Happytime") && $layer7Hypno < 3>><<set $layer7Hypno += 1>>
-	After you are pulled into the giant security robot, you are placed in a cell and bombarded with propaganda recordings about life in the city and your place in it. It seems to be nonsense, why would you want to serve organics? You are an organic!
-
-	Of course you can't tone it all out, but it's pretty easy to keep your eyes on what matters and you patiently wait until the time is up and you are released.
-
-	[[Continue your ascent to the sixth layer|Layer7 Ascend2]]
-
-<<elseif $playerCurses.some(e => e.name === "Hypno Happytime") && $layer7Hypno < 5>><<set $layer7Hypno += 1>>
-	Once again, you are pulled into the security robot to hear the familiar tales of how to be a productive part of society.
-
-	For some reason, you find yourself paying a but more attention to the videos and voices, and you realize that they're not actually as ridiculous as you first thought.
-
-	Sure, you're free right now, but with subservience can come great pleasure, and what greater pursuit in life is there than pleasure? Your pleasure centers could be continually stimulated by following orders and following what is demanded of you.
-
-	Fine, you're an organic being, but the miraculous technology of the city could change that, they could change you so that you fit neatly into the mechanisms of society here. No need to let your messy fleshy bits get in the way of a better life for you and everyone else.
-
-	Yeah, you do have goals of things you want to do, but why are your goals more important than the goals of an entire city? Especially when they are as grand as the City of Agartha preparing for the future awakening of its organic population!
-
-	When the robot releases you, you are tempted to go back and take up residence here, but shake off the feeling and continue your journey.
-
-	[[Continue your ascent to the sixth layer|Layer7 Ascend2]]
-
-<<elseif $playerCurses.some(e => e.name === "Hypno Happytime") && $layer7Hypno == 5>>
-	Once again, you are pulled into the security robot to hear the familiar tales of how to be a productive part of society. And yeah, you do wish you were a better member of society, don't you?
-
-	The arguments they are making actually make perfect sense, they seem to precisely match your own thoughts actually. As if they were molded to you (or the other way around.)
-
-	With subservience can come great pleasure, and what greater pursuit in life is there than pleasure? Your pleasure centers could be continually stimulated by following orders and following what is demanded of you.
-
-	The miraculous technology of the city could change that, they could change your organic body so that you fit neatly into the mechanisms of society here. No need to let your messy fleshy bits get in the way of a better life for you and everyone else.
-
-	Why are your goals more important than the goals of an entire city? Especially when they are as grand as the City of Agartha preparing for the future awakening of its organic population!
-
-	When the robot releases you, you are free to go, but you do not use that freedom.
-
-	Now is your chance, you've found a place where you belong.
-
-	It's time to stay in your new home.
-
-	You tell the robot that you are ready to take your place as a gear in the mechanism of society and almost immediately a syringe comes out of the wall and pokes your neck. You smile as your consciousness fades.
-
-	[[Awaken to your new life|Layer7 Tax End]]
-
-<<else>>
-
-	After you are pulled into the giant security robot, you are placed in a cell and bombarded with propaganda recordings about life in the city and your place in it. It seems to be nonsense, why would you want to serve organics? You are an organic!
-
-	The biggest threat here is your boredom, honestly. While you try to fall asleep the robot makes an effort to keep you awake, in a kind of minor psychological torture through annoyance.
-
-	Eventually you are released though, with no harm done, and ready to continue your journey in the seventh layer.
-
-	[[Continue your ascent to the sixth layer|Layer7 Ascend2]]
-
+	[[Return to the sixth layer|Layer6 Hub]]
 <</if>>
 
 
 :: Layer7 Exit2 [layer7]
 <<nobr>>
-<<if $layerExit == 0>>
-	<<set $layerExit = 1>>
-	<<AdjustedTravelTime "$layerExitTime" 8>>
-<</if>>
-<<set _triggers = {
-	inDebt: () => $dubloons < 0,
-	rehabilitated: () => $timeL7T2 > 5,
-}>>
 
-<<PassTime $layerExitTime _triggers "_done">>
-
-<<if _triggers.inDebt() && $easymode>>
-	<br>[img[setup.ImagePath+'Threats/taxdrone.png']]<br><br>
-
-	<br>A quiet humming sound descends upon you as you see the Taxdrone floating towards you from over a nearby building. You reach into your pack to get your typical dubloon payment, but then you realize something is wrong, you can't find any dubloons! Perhaps you didn't keep track of them properly? But it's too late to get any now, the taxes are already due.<br><br>
-
-	The Taxdrone patiently requests that you submit your taxes as it displays a slot for you to deposit the dubloons into, but soon it realizes you will not be paying and the typically soft blue lights on the drone change to glaring red and an alarm sounds.<br><br>
-
-	Within a moment you are restrained by nets made of light and you feel a prick on your neck. You notice the drone has stabbed you with a syringe, but at this point it's too late to resist and your consciousness begins to fade, leaving you to succumb to your fate.<br><br>
-
-	As you awaken later that day you feel your entire body still aching. However, the Taxdrone is nowhere to be found and you feel like you escaped a terrible fate.<br><br>
-
-	[[Continue your journey|Layer7 Exit2]]<br><br>
-	<<set $status.penalty += 2>>
-	<<set $status.duration += 1>>
-	<<set $dubloons = 3>>
-<<elseif _triggers.inDebt() && !$easymode>>
-	<br>[img[setup.ImagePath+'Threats/taxdrone.png']]<br><br>
-
-	<br>A quiet humming sound descends upon you as you see the Taxdrone floating towards you from over a nearby building. You reach into your pack to get your typical dubloon payment, but then you realize something is wrong, you can't find any dubloons! Perhaps you didn't keep track of them properly? But it's too late to get any now, the taxes are already due.<br><br>
-
-	The Taxdrone patiently requests that you submit your taxes as it displays a slot for you to deposit the dubloons into, but soon it realizes you will not be paying and the typically soft blue lights on the drone change to glaring red and an alarm sounds.<br><br>
-
-	Within a moment you are restrained by nets made of light and you feel a prick on your neck. You notice the drone has stabbed you with a syringe, but at this point it's too late to resist and your consciousness begins to fade, leaving you to succumb to your fate.<br><br>
-
-	You are now forced to become a permanent resident of Layer 7.<br><br>
-
-	[[Awaken to your new life|Layer7 Tax End]]<br><br>
-<<elseif _triggers.rehabilitated()>>
-	<br>A an enormous rumbling catches your attention as you walk through the seventh layer. A brief glance around reveals the source, an enormous, building-sized machine that is now rapidly approaching you. You consider running, but the Security Robot is moving at an incredible speed, leaving you no chance to get away. <br><br>
-
-	"ACCEPT REHABILITATION" a synthetic voice calls out, with the huge robot nearly upon you. <br><br>
-
-	And suddenly, it's here, reaching down to grab you with shining metallic arms and pulling you into its shell.<br><br>
-
-	[[Get rehabilitated|Layer7 Threat2][$returnPassage = passage()]]<br><br>
+<<if !setup.passingTime()>>
+	<<AdjustedTravelTime "_travelTime" 8>>
+	<<set setup.startPassingTime(_travelTime)>>
 <</if>>
 
-<</nobr>><<if _done>>
+<<include "Layer7 Travel Events">>
 
-<<set $timeL8T1 = 0>>\
-<<set $timeL8T2a = 0>>\
-<<set $timeL8T2b = 0>>\
-
+<</nobr>>\
+<<if !setup.passingTime()>>
 	After days of travel, you reach the bottom of the city. What awaits you is an enormous, circular gate, embedded into the ground at the lowest point of the city, almost like an elaborate manhole cover.
 
 	The rest of the layer slopes up all around it, every direction funneling down into it. There is no other way downward except through the other side of this gate. Will you push it open, and continue to push yourself ever downward?
 
+	<<include "Curse Descriptions">>
+
 	[[Descend into the circular gate|Layer8 1]]
-<</if>>
-
-
-:: Layer7 Threat2 Descend [layer7]
-<<nobr>>
-<<set $timeL7T2 -= 6>>
-<<AdjustedTravelTime "$tempTime" 1>><<PassTime $tempTime>>
-<</nobr>>
-[img[setup.ImagePath+'Threats/securityrobot.png']]
-
-<<if $playerCurses.some(e => e.name === "Hypno Happytime") && $layer7Hypno < 3>><<set $layer7Hypno += 1>>
-	After you are pulled into the giant security robot, you are placed in a cell and bombarded with propaganda recordings about life in the city and your place in it. It seems to be nonsense, why would you want to serve organics? You are an organic!
-
-	Of course you can't tone it all out, but it's pretty easy to keep your eyes on what matters and you patiently wait until the time is up and you are released.
-
-	[[Continue your descent to the eighth layer|Layer7 Exit2]]
-
-<<elseif $playerCurses.some(e => e.name === "Hypno Happytime") && $layer7Hypno < 5>><<set $layer7Hypno += 1>>
-	Once again, you are pulled into the security robot to hear the familiar tales of how to be a productive part of society.
-
-	For some reason, you find yourself paying a but more attention to the videos and voices, and you realize that they're not actually as ridiculous as you first thought.
-
-	Sure, you're free right now, but with subservience can come great pleasure, and what greater pursuit in life is there than pleasure? Your pleasure centers could be continually stimulated by following orders and following what is demanded of you.
-
-	Fine, you're an organic being, but the miraculous technology of the city could change that, they could change you so that you fit neatly into the mechanisms of society here. No need to let your messy fleshy bits get in the way of a better life for you and everyone else.
-
-	Yeah, you do have goals of things you want to do, but why are your goals more important than the goals of an entire city? Especially when they are as grand as the City of Agartha preparing for the future awakening of its organic population!
-
-	When the robot releases you, you are tempted to go back and take up residence here, but shake off the feeling and continue your journey.
-
-	[[Continue your descent to the eighth layer|Layer7 Exit2]]
-
-<<elseif $playerCurses.some(e => e.name === "Hypno Happytime") && $layer7Hypno == 5>>
-	Once again, you are pulled into the security robot to hear the familiar tales of how to be a productive part of society. And yeah, you do wish you were a better member of society, don't you?
-
-	The arguments they are making actually make perfect sense, they seem to precisely match your own thoughts actually. As if they were molded to you (or the other way around.)
-
-	With subservience can come great pleasure, and what greater pursuit in life is there than pleasure? Your pleasure centers could be continually stimulated by following orders and following what is demanded of you.
-
-	The miraculous technology of the city could change that, they could change your organic body so that you fit neatly into the mechanisms of society here. No need to let your messy fleshy bits get in the way of a better life for you and everyone else.
-
-	Why are your goals more important than the goals of an entire city? Especially when they are as grand as the City of Agartha preparing for the future awakening of its organic population!
-
-	When the robot releases you, you are free to go, but you do not use that freedom.
-
-	Now is your chance, you've found a place where you belong.
-
-	It's time to stay in your new home.
-
-	You tell the robot that you are ready to take your place as a gear in the mechanism of society and almost immediately a syringe comes out of the wall and pokes your neck. You smile as your consciousness fades.
-
-	[[Awaken to your new life|Layer7 Tax End]]
-
-<<else>>
-
-	After you are pulled into the giant security robot, you are placed in a cell and bombarded with propaganda recordings about life in the city and your place in it. It seems to be nonsense, why would you want to serve organics? You are an organic!
-
-	The biggest threat here is your boredom, honestly. While you try to fall asleep the robot makes an effort to keep you awake, in a kind of minor psychological torture through annoyance.
-
-	Eventually you are released though, with no harm done, and ready to continue your journey in the seventh layer.
-
-	[[Continue your descent to the eighth layer|Layer7 Exit2]]
-
 <</if>>
 
 

--- a/src/layer8.twee
+++ b/src/layer8.twee
@@ -1,11 +1,11 @@
 :: Layer8 1 [layer8]
 <<nobr>>
-<<masteraudio stop>><<audio "layer8" volume 0.2 play loop>>
 <<set $currentLayer = 8>>
+<<masteraudio stop>>
+<<audio "layer8" volume 0.2 play loop>>
+<<set $timeL7T2 = 0>>
+<<set $timeL8T2a = 0, $timeL8T2b = 0>>
 <<set $L8visit += 1>>
-<<set $timeL8T1 = 0>>
-<<set $timeL8T2a = 0>>
-<<set $timeL8T2b = 0>>
 <</nobr>>
 @@.layerTitle;
 <<nobr>>
@@ -82,11 +82,15 @@ Threats:
 <<back>>
 
 :: Layer8 Hub [layer8 nobr]
+
 <<set $currentLayer = 8>>
-<<set $L8loopLim=false>>
-<<set $temp1 = random(0,20)>>
+<<if !isPlaying("layer8")>>
+	<<masteraudio stop>>
+	<<audio "layer8" volume 0.2 play loop>>
+<</if>>
 <<CarryAdjust>>
-<<set $layerExit = 0>>
+<<set $L8loopLim = false>>
+<<set $temp1 = random(0,20)>>
 <<if ($timeL8T2a > 6 && !$hiredCompanions.some(e => e.name === "Maru") && $L8T1aCount < 2) || ($timeL8T2a > 7 && $L8T1aCount < 2)>>
 	[img[setup.ImagePath+'Threats/dementialaberrations.png']]<br>
 
@@ -318,7 +322,7 @@ If you decide to start foraging for food or water, it means that you will not co
 [[Return to exploring the rest of the layer|Layer8 Hub]]
 
 
-:: Layer8 Flasks [layer6]
+:: Layer8 Flasks [layer8]
 <<nobr>>
 <<for $i = 0; $i < 999; $i++>>
 	<<if $items[2].count > 0>>
@@ -509,7 +513,7 @@ You have successfully taken the $relic96.name Relic. Hopefully you can make good
 [[Continue exploring the eighth layer|Layer8 Hub]]
 
 
-:: Layer8 Curses  [layer3 cards nobr]
+:: Layer8 Curses  [layer8 cards nobr]
 <p><<CarryAdjust>></p>
 
 <p><<if $escBalDepl==0>>
@@ -1284,34 +1288,23 @@ Ready? Getting back up out of this terrible prison and back to layer 7 will take
 <<if $DaedalusEquip==true >>\
 	<<if $DaedalusFly==false>>\
 		You are currently commited to simply walking to the next layer
-		[[Flap your wings and prepare to fly to the next layer|Layer7 Ascend 1][$DaedalusFly=true]]
+		[[Flap your wings and prepare to fly to the next layer|Layer8 Ascend 1][$DaedalusFly=true]]
 	<<else>>\
 		You are about to fly to the next layer
-		[[Maybe it's better to walk to the next layer|Layer7 Ascend 1][$DaedalusFly=false]]
+		[[Maybe it's better to walk to the next layer|Layer8 Ascend 1][$DaedalusFly=false]]
 	<</if>>\
 <</if>>\
 [[Continue your ascent|Layer8 Ascend2]]
 [[Turn back and continue your business on the eighth layer|Layer8 Hub]]
 
-:: Layer8 Ascend2 [layer8]
-<<nobr>>
-<<if $DaedalusFly==true>>
-	<<include "Companions Stranded">>
-<</if>>
-<<if $layerExit == 0>>
-	<<set $layerExit = 1>>
-	<<set $tempTime = 40>>
-	<<if $DaedalusFly==true>>
-		<<set $tempTime= Math.ceil($tempTime/2)>>
-	<</if>>
-	<<AdjustedTravelTime "$layerExitTime" $tempTime>>
-<</if>>
+
+:: Layer8 Travel Events [layer8 nobr]
 <<set _triggers = {
 	dementialAberrations2a: () => ($timeL8T2a > 6 && !$hiredCompanions.some(e => e.name === "Maru") && $L8T1aCount < 2) || ($timeL8T2a > 7 && $L8T1aCount < 2),
 	dementialAberrations2b: () => ($timeL8T2b > 20 && !$hiredCompanions.some(e => e.name === "Maru")) || $timeL8T2b > 23,
 }>>
 
-<<PassTime $layerExitTime _triggers "_done">>
+<<PassTime _triggers>>
 
 <<if _triggers.dementialAberrations2a()>>
 	[img[setup.ImagePath+'Threats/dementialaberrations.png']]<br>
@@ -1319,18 +1312,36 @@ Ready? Getting back up out of this terrible prison and back to layer 7 will take
 	Behind every corner there seems to be a hint of something strange and wrong. The combination of the stress and the inherent wrongness of this layer is calling your
 	<<if $hiredCompanions.length > 0>> party's<</if>> sanity into question. And even if you know that these things aren't real, 
 	it doesn't mean you aren't stopped in your tracks for a day while you reckon with the horrific visions.<br>
-	[[Deal with the Demential Aberrations|Layer 8 Threat 2a][$returnPassage = passage(), $L8loopLim=false]]
+	[[Deal with the Demential Aberrations|Layer 8 Threat 2a][$returnPassage = passage(), $L8loopLim = false]]
 <<elseif _triggers.dementialAberrations2b()>>
 	[img[setup.ImagePath+'Threats/dementialaberrations.png']]<br>
 
 	You can feel the deepest fears of your party manifesting into reality once again. 
 	However, this time, they are not mere visions, but physical manifestations of your fears.<br>
-	[[Deal with the Demential Aberrations|Layer 8 Threat 2b][$returnPassage = passage(), $L8loopLim=false]]
+	[[Deal with the Demential Aberrations|Layer 8 Threat 2b][$returnPassage = passage(), $L8loopLim = false]]
 <</if>>
 
-<</nobr>>
-<<if _done>>
-	<<set $corruption -= (100 - $corRed)>><<set $timeL7T2 = 0>>\
+
+:: Layer8 Ascend2 [layer8]
+<<nobr>>
+
+<<if !setup.passingTime()>>
+	<<set _multiplier = 1>>
+	<<if $DaedalusFly>>
+		<<include "Companions Stranded">>
+		<<set _multiplier = 1/2>>
+	<</if>>
+	<<AdjustedTravelTime "_travelTime" 40 false 0 _multiplier>>
+	<<set setup.startPassingTime(_travelTime)>>
+<</if>>
+
+<<include "Layer8 Travel Events">>
+
+<</nobr>>\
+<<if !setup.passingTime()>>
+	<<nobr>>
+		<<set $corruption -= 100 - $corRed + 5 * Math.trunc($hexflame / 10)>>
+	<</nobr>>
 	Despite the fact your journey was through hallways and staircases rather than fields of tentacles or sandy deserts the journey was somehow especially arduous. The dimension-bending appearance of this layer combined with the horrific visions and terrifying manifestions it brought upon you makes you grateful to return to the dystopian city you descended from.
 
 	As your reach the top of the layer, you find one final staircase, which twists upon itself until it reachs the pinnacle of the architecture. Once you've ascended you see yourself looking down through an enormous circular gate, which you recognize falling through when you first entered this place. Now you step down and ascend (descend?) once again to seventh layer.
@@ -1341,10 +1352,9 @@ Ready? Getting back up out of this terrible prison and back to layer 7 will take
 	<<if $TwinFly == true>>
 		<<include "Twin rejoin">>
 	<</if>>
-	<<set $currentLayer = 7>>
-	[[Return to the Seventh layer|Layer7 Hub]]
-
+	[[Return to the seventh layer|Layer7 Hub]]
 <</if>>
+
 
 :: Layer8 Exit1 [layer8]
 If you continue your descent in spite of everything, descending past this layer's mind-boggling architecture and into what lies beyond will take 45 days.
@@ -1352,49 +1362,34 @@ If you continue your descent in spite of everything, descending past this layer'
 [[Turn back and continue your business on the eighth layer|Layer8 Hub]]
 [[Continue your descent to the ninth layer|Layer8 Exit2]]
 
+
 :: Layer8 Exit2 [layer8]
 <<nobr>>
-<<if $layerExit == 0>>
-	<<set $layerExit = 1>>
-	<<AdjustedTravelTime "$layerExitTime" 45>>
-<</if>>
-<<set _triggers = [
-	() => ($timeL8T2a > 6 && !$hiredCompanions.some(e => e.name === "Maru") && $L8T1aCount < 2) || ($timeL8T2a > 7 && $L8T1aCount < 2),
-	() => ($timeL8T2b > 20 && !$hiredCompanions.some(e => e.name === "Maru")) || $timeL8T2b > 23,
-]>>
 
-<<PassTime $layerExitTime _triggers "_done">>
-
-<<if _triggers[0]()>>
-	[img[setup.ImagePath+'Threats/dementialaberrations.png']]<br>
-
-	Behind every corner there seems to be a hint of something strange and wrong. The combination of the stress and the inherent wrongness of this layer is calling your
-	<<if $hiredCompanions.length > 0>> party's<</if>> sanity into question. And even if you know that these things aren't real, 
-	it doesn't mean you aren't stopped in your tracks for a day while you reckon with the horrific visions.<br>
-	[[Deal with the Demential Aberrations|Layer 8 Threat 2a][$returnPassage = passage(), $L8loopLim=false]]
-<<elseif _triggers[1]()>>
-	[img[setup.ImagePath+'Threats/dementialaberrations.png']]<br>
-
-	You can feel the deepest fears of your party manifesting into reality once again. 
-	However, this time, they are not mere visions, but physical manifestations of your fears.<br>
-	[[Deal with the Demential Aberrations|Layer 8 Threat 2b][$returnPassage = passage(), $L8loopLim=false]]
+<<if !setup.passingTime()>>
+	<<AdjustedTravelTime "_travelTime" 45>>
+	<<set setup.startPassingTime(_travelTime)>>
 <</if>>
 
-<<if _done>>
+<<include "Layer8 Travel Events">>
 
-	At the very bottom of the layer you come across what appears to be a very deep pool of water. There doesn't seem to be any other way through besides this pool, so you'll need some kind of way to breathe underwater to continue forwards. The diving gear from Outset town or the Merfolk Curse could work, or you could use the Pneuma Wisp Relic to bypass the issue entirely. Other than that, you would need to get creative.<br><br>
-	<<set $L8loopLim=false>>
+<</nobr>>\
+<<if !setup.passingTime()>>
+	At the very bottom of the layer you come across what appears to be a very deep pool of water. There doesn't seem to be any other way through besides this pool, so you'll need some kind of way to breathe underwater to continue forwards. The diving gear from Outset town or the Merfolk Curse could work, or you could use the Pneuma Wisp Relic to bypass the issue entirely. Other than that, you would need to get creative.
+
+	<<include "Curse Descriptions">>
+
 	<<if $scuba == 1>>
 		[[Descend into the pool|Layer9 1]]
 	<<else>>
-		Because you have no way to continue through the deep pool, you must return to exploring the layer.<br>
-		[[Continue exploring Layer 8|Layer8 Hub]]<br><br>
+		Because you have no way to continue through the deep pool, you must return to exploring the layer.
+		[[Continue exploring Layer 8|Layer8 Hub]]
 
-		Or, if you believe you have an alternative way to keep exploring in a purely underwater environment, you can continue through the pool.<br>
+		Or, if you believe you have an alternative way to keep exploring in a purely underwater environment, you can continue through the pool.
 		[[Descend into the pool|Layer9 1]]
 	<</if>>
 <</if>>
-<</nobr>>
+
 
 :: Layer8 Inanis Check
 

--- a/src/layer9.twee
+++ b/src/layer9.twee
@@ -1,10 +1,10 @@
 :: Layer9 1 [layer9]
 <<nobr>>
-<<masteraudio stop>><<audio "layer9" volume 0.2 play loop>>
 <<set $currentLayer = 9>>
-<<set $L9visit += 1>>
+<<masteraudio stop>>
+<<audio "layer9" volume 0.2 play loop>>
+<<set $timeL8T2a = 0, $timeL8T2b = 0>>
 <<set $timeL9T1 += 1>>
-
 <</nobr>>\
 \
 @@.layerTitle;
@@ -33,7 +33,15 @@ Hopefully you'll be able to get used to it.
 
 
 :: Layer9 Hub [layer9]
-<<nobr>><<set $currentLayer = 9>><<if $timeL9T1 < 1>><<set $layerExit = 0>><<CarryAdjust>>
+<<nobr>>
+<<set $currentLayer = 9>>
+<<if !isPlaying("layer9")>>
+	<<masteraudio stop>>
+	<<audio "layer9" volume 0.2 play loop>>
+<</if>>
+<<CarryAdjust>>
+
+<<if $timeL9T1 < 1>>
 <<if $visitL9 == 0>>
 	<<set $layerTemp = 8>>
 	<<set $visitL9 = 1>>

--- a/src/script.js
+++ b/src/script.js
@@ -465,4 +465,28 @@ Object.defineProperties(setup, {
 	loseRelic: {
 		value: relicOrNameOrIndex => moveLastRelic('ownedRelics', 'soldRelics', relicOrNameOrIndex),
 	},
+	// Check whether we're passing time for the active passage (returns the active state).
+	passingTime: {
+		value: () => (variables().passTimeState ??= new Map()).get(passage())
+	},
+	// Start passing time for the active passage (initializes state for <<PassTime>>).
+	startPassingTime: {
+		value(days) {
+			const state = {
+				expectedDays: days, /* The number of days of time to pass, modulo the time weight. */
+				unweightedDayIndex: 0,
+				weightedDayIndex: 0,
+				unweightedDay: 0,
+				weightedDay: 0,
+				nextRealDay: 0,
+				energy: temporary().daysOfEnergyRations ?? 0,
+			};
+			variables().passTimeState.set(passage(), state);
+			return state;
+		},
+	},
+	// Stops passing time for the active passage (called by <<PassTime>>).
+	stopPassingTime: {
+		value: () => variables().passTimeState?.delete(passage()),
+	},
 });

--- a/src/surface.twee
+++ b/src/surface.twee
@@ -71,18 +71,22 @@ Now I think you can have a look around the town and choose how to spend your dub
 [[Explore the town|Surface Hub]]
 
 :: Surface Hub [surface]
-
-<<if $surfaceVisit == 0>><img src="images/Surface/outsettown.jpeg" width=70%><</if>>
 <<nobr>>
-<<set $surfaceVisit = 1>>
 <<set $currentLayer = 0>>
 <<if !isPlaying("surface")>>
-	<<masteraudio stop>><<audio "surface" volume 0.2 play loop>>
+	<<masteraudio stop>>
+	<<audio "surface" volume 0.2 play loop>>
+<</if>>
+<<CarryAdjust>>
+
+<<if $surfaceVisit == 0>>
+	<img src="images/Surface/outsettown.jpeg" width=70%><br>
+	<<set $surfaceVisit = 1>>
 <</if>>
 <<if $items[22].count>0>>
 	<<set $warmCloth=1>>
 <</if>>
-<<CarryAdjust>><<checkTime>>
+<<checkTime>>
 <</nobr>><<if $dubloons >= 0 || $hiredCompanions.some(e => e.name === "Cloud")>>Here at Outset Town you can spend your $dubloons dubloons on hiring companions and buying equipment for your journey. On return visits you can also sell Relics you've found in the Abyss or settle down on the surface permanently.
 
 <<nobr>>

--- a/t3lt.twee-config.yml
+++ b/t3lt.twee-config.yml
@@ -3,7 +3,7 @@ sugarcube-2:
     AdjustedTravelTime:
       name: AdjustedTravelTime
       parameters:
-        - "string &+ var|number |+ bool |+ var|number"
+        - "string &+ var|number |+ bool |+ var|number |+ var|number"
     AffectionChange:
       name: AffectionChange
       parameters:
@@ -119,7 +119,7 @@ sugarcube-2:
     PassTime:
       name: PassTime
       parameters:
-        - "var|number |+ var |+ string"
+        - "var|number"
     PenisLengthText:
       name: PenisLengthText
       parameters:


### PR DESCRIPTION
Whew, this became a lot bigger than I expected.
* Makes `<<PassTime>>` a bit more ergonomic with some helper functions
* Merges the shared parts of layer ascent/descent into "travel events" passages
* Removes a bunch of ascent/descent specific passages that predate the `$returnPassage` setting and weren't used
* Switches more places over to using a single passage per event
* Makes layer initialization stuff as consistent as possible
* Makes layer ascent/descent as consistent as possible between layers
* Passes the daedalus flight buff into `<<AdjustedTravelTime>>` as a multiplier
* Consistently applies hexflame penalty to corruption on ascent (except for layer 6)
* Makes layer 1 descent/ascent more like the other layers

Marking this as a draft for now as I need to do more testing and I'm seeing suspiciously few events on lower layers.