### PR TITLE
Timed events for relic hunting and camping

### DIFF
--- a/src/companionConversations.twee
+++ b/src/companionConversations.twee
@@ -1702,7 +1702,7 @@ He flashes a wide grin, but the ensuing silence seems to dampen his enthusiasm.
 <<elseif $CherryConvo3==0 && $companionCherry.affec>20 && $app.appGender<6 && $app.subdom <= 0 && $CherryConvo2 >>
 [[Chat with Cherry|Cherry Convo3][$CherryConvo3=true]]<br>
 <</if>>
-<<if $app.lactation > 0 & (($companionCherry.curses.some(e => e.name === "Fluffy Ears") && $curse17.variation == "furry cat" ) || ( $companionCherry.curses.some(e => e.name === "Fluffy Tail") && $curse18.variation=="flowing cat" )) && !$CherryConvoLac && $companionCherry.affec>16>>
+<<if $app.lactation > 0 && (($companionCherry.curses.some(e => e.name === "Fluffy Ears") && $curse17.variation == "furry cat" ) || ( $companionCherry.curses.some(e => e.name === "Fluffy Tail") && $curse18.variation=="flowing cat" )) && !$CherryConvoLac && $companionCherry.affec>16>>
 	[[While trying to milk your breasts you spot Cherry staring at you|Cherry ConvoLac]]<br>
 <</if>>
 <<if $CherryFluffy==false && ($playerCurses.some(e => e.name === "Fluffy Ears") || $playerCurses.some(e => e.name === "Fluffy Tail")) && !($companionCherry.curses.some(e => e.name === "Fluffy Ears") || $companionCherry.curses.some(e => e.name === "Fluffy Tail"))>>
@@ -4831,7 +4831,7 @@ Maru jumps up and down with excitement at the sight of the small, sweet fruits. 
  <<say $companionLily>>And down here, absolutely everything is wet.<</say>>
  She casually flicks a drop of water out of your hair, then she steps backwards and does a cartwheel over a large root jutting into the path. Unconcerned that her hands just got covered in mud, she runs them through the vegetation on either side of the narrow path you're following, cleaning them off, mostly. You pause for a second, then ask 
 
-<<if ~($ConvoHandicapSmall || $ConvoHandicapLarge)>>\
+<<if !($ConvoHandicapSmall || $ConvoHandicapLarge)>>\
 	<<say $mc>>Who maintains this path anyway?<</say>>
 	She laughs at the question for a moment before she answers. 
 
@@ -5092,7 +5092,7 @@ You try to cheer him up a bit, but he just shakes his head.
 :: Cherry Layer 7
 
 <<say $companionCherry>>It's frozen.<</say>>
-<<if ~($ConvoHandicapSmall || $ConvoHandicapLarge)>>\
+<<if !($ConvoHandicapSmall || $ConvoHandicapLarge)>>\
 	<<say $mc>>What?<</say>>
 <<else>>\
 	You try to make clear you don't understand what she means.
@@ -5184,14 +5184,14 @@ She giggles as you continue to drink your fill, her nourishing milk flowing free
 :: CherryConvoLac Rep
 Cherry is hovering around you again, as if she is anticipating something. The fact she is actually approaching you likely means something, and you suspect you know what it is.
 
-<<if ~($ConvoHandicapSmall || $ConvoHandicapLarge)>>\
+<<if !($ConvoHandicapSmall || $ConvoHandicapLarge)>>\
 	<<say $mc>>Give me a moment.<</say>>
 <<else>>\
 	You smile gently and nod to her, giving a signal to get closer to you.
 <</if>>\
 You pull out a dish and fill it with your breastmilk, then present it to her.
 
-<<if ~($ConvoHandicapSmall || $ConvoHandicapLarge)>>\
+<<if !($ConvoHandicapSmall || $ConvoHandicapLarge)>>\
 	<<say $mc>>Here, kitty!<</say>>
 <<else>>\
 	You whistle to get her attention and she slowly approaches.

--- a/src/companionSetup.twee
+++ b/src/companionSetup.twee
@@ -827,13 +827,13 @@ Overall the world would probably see <<if _companion.sex=="male">>him<<else>>her
 [img[setup.ImagePath+$companionMaru.image]]
 <<include "Maru Introduction">>
 <<if $time - $companionMaru.pregnantT > 0 >>\
-	<<if $time - $companionMaru.pregnantT< 60 & $time - $companionMaru.pregnantT>= 30 >>\
+	<<if $time - $companionMaru.pregnantT< 60 && $time - $companionMaru.pregnantT>= 30 >>\
 	Maru has seemed a little sick recently. Nothing too serious, but it's not like when you first came down here.
-	<<elseif $time - $companionMaru.pregnantT< 180 & $time - $companionMaru.pregnantT>= 120 && $MaruConvoPreg==false >>\
+	<<elseif $time - $companionMaru.pregnantT< 180 && $time - $companionMaru.pregnantT>= 120 && $MaruConvoPreg==false >>\
 		Maru was never that fit, but he has been falling behind a lot recently. He also seems to have put on some weight. Perhaps you should discuss his eating habits with him?
-	<<elseif $time - $companionMaru.pregnantT< 180 & $time - $companionMaru.pregnantT>= 120 && $MaruConvoPreg==true>>\
+	<<elseif $time - $companionMaru.pregnantT< 180 && $time - $companionMaru.pregnantT>= 120 && $MaruConvoPreg==true>>\
 		Maru has a small, but obvious bulge for his pregnant belly.
-	<<elseif $time - $companionMaru.pregnantT< 240 & $time - $companionMaru.pregnantT>=180 >>\
+	<<elseif $time - $companionMaru.pregnantT< 240 && $time - $companionMaru.pregnantT>=180 >>\
 		Maru's belly is huge and bulging forward in a way that obviously identifies him as pregnant. 
 	<<elseif $time - $companionMaru.pregnantT>=240>>\
 		Maru has a very large and very obvious pregnant belly. He's probably due soon, though it's hard to know exactly when.
@@ -847,13 +847,13 @@ Overall the world would probably see <<if _companion.sex=="male">>him<<else>>her
 [img[setup.ImagePath+$companionLily.image]]
 <<include "Lily Introduction">>
 <<if $time - $companionLily.pregnantT > 0 >>\
-	<<if $time - $companionLily.pregnantT< 60 & $time - $companionLily.pregnantT>= 30 >>\
+	<<if $time - $companionLily.pregnantT< 60 && $time - $companionLily.pregnantT>= 30 >>\
 	Lily hasn't been as much of her energetic self lately, she looks rather tired a lot of the time.
-	<<elseif $time - $companionLily.pregnantT< 180 & $time - $companionLily.pregnantT>= 120 && $LilyConvoPreg==false >>\
+	<<elseif $time - $companionLily.pregnantT< 180 && $time - $companionLily.pregnantT>= 120 && $LilyConvoPreg==false >>\
 		Lily has been having some kind of mood swings, going back and forth between very energetic to completely exhausted. She even seems to have put on some weight, has she stopped exercising as much as she used to? Maybe you should have a talk with her about it.
-	<<elseif $time - $companionLily.pregnantT< 180 & $time - $companionLily.pregnantT>= 120 && $LilyConvoPreg==true>>\
+	<<elseif $time - $companionLily.pregnantT< 180 && $time - $companionLily.pregnantT>= 120 && $LilyConvoPreg==true>>\
 		Lily has a small, but obvious bulge for her pregnant belly.
-	<<elseif $time - $companionLily.pregnantT< 240 & $time - $companionLily.pregnantT>=180 >>\
+	<<elseif $time - $companionLily.pregnantT< 240 && $time - $companionLily.pregnantT>=180 >>\
 		Lily's belly is huge and bulging forward in a way that obviously identifies her as pregnant. 
 	<<elseif $time - $companionLily.pregnantT>=240>>\
 		Lily has a very large and very obvious pregnant belly. She's probably due soon, though it's hard to know exactly when.
@@ -867,13 +867,13 @@ Overall the world would probably see <<if _companion.sex=="male">>him<<else>>her
 [img[setup.ImagePath+$companionKhemia.image]]
 <<include "Khemia Introduction">>
 <<if $time - $companionKhemia.pregnantT > 0 >>\
-	<<if $time - $companionKhemia.pregnantT< 60 & $time - $companionKhemia.pregnantT>= 30 >>\
+	<<if $time - $companionKhemia.pregnantT< 60 && $time - $companionKhemia.pregnantT>= 30 >>\
 	Khemia seems to have contracted some stomach illness, as he is frequently vomiting in the morning after you wake up. Hopefully he's able to recover soon.
-	<<elseif $time - $companionKhemia.pregnantT< 180 & $time - $companionKhemia.pregnantT>= 120 >>\
+	<<elseif $time - $companionKhemia.pregnantT< 180 && $time - $companionKhemia.pregnantT>= 120 >>\
 		Khemia has developed somewhat of pot belly. It's not too much of a problem, as he was always a quite a bit more fit than everyone else, but it seems uncharacteristic of him to secretly snack so much. 
-	<<elseif $time - $companionKhemia.pregnantT< 240 & $time - $companionKhemia.pregnantT>= 180 && $KhemiaConvoPreg==false>>\
+	<<elseif $time - $companionKhemia.pregnantT< 240 && $time - $companionKhemia.pregnantT>= 180 && $KhemiaConvoPreg==false>>\
 		This is getting ridiculous, Khemia's belly has become quite large. His chest, his ass everything seems to collect fat, but it's nothing compared to his belly. This is no longer normal and honestly worrysome, maybe you should have a talk to see what's going on with him.
-	<<elseif $time - $companionKhemia.pregnantT< 240 & $time - $companionKhemia.pregnantT>=180 && $KhemiaConvoPreg==true>>\
+	<<elseif $time - $companionKhemia.pregnantT< 240 && $time - $companionKhemia.pregnantT>=180 && $KhemiaConvoPreg==true>>\
 		Khemia belly is huge and bulging forward in a way that obviously identifies him as pregnant. 
 	<<elseif $time - $companionKhemia.pregnantT>=240>>\
 		Khemia has a very large and very obvious pregnant belly. He's probably due soon, though it's hard to know exactly when.
@@ -887,13 +887,13 @@ Overall the world would probably see <<if _companion.sex=="male">>him<<else>>her
 [img[setup.ImagePath+$companionCherry.image]]
 <<include "Cherry Introduction">>
 <<if $time - $companionCherry.pregnantT > 0 >>\
-	<<if $time - $companionCherry.pregnantT< 60 & $time - $companionCherry.pregnantT>= 30 >>\
+	<<if $time - $companionCherry.pregnantT< 60 && $time - $companionCherry.pregnantT>= 30 >>\
 	Cherry seems to have contracted some stomach illness, as she is frequently vomiting in the morning after you wake up. Hopefully she's able to recover soon.
-	<<elseif $time - $companionCherry.pregnantT< 180 & $time - $companionCherry.pregnantT>= 120 && $CherryConvoPreg==false >>\
+	<<elseif $time - $companionCherry.pregnantT< 180 && $time - $companionCherry.pregnantT>= 120 && $CherryConvoPreg==false >>\
 		Cherry has been distancing herself from social contact even more than usual. She seems to avoid everyone and trails the group by a significant amount. Perhaps you should have a talk with her to see what's going on.
-	<<elseif $time - $companionCherry.pregnantT< 180 & $time - $companionCherry.pregnantT>= 120 && $CherryConvoPreg==true>>\
+	<<elseif $time - $companionCherry.pregnantT< 180 && $time - $companionCherry.pregnantT>= 120 && $CherryConvoPreg==true>>\
 		Cherry has a small, but obvious bulge for her pregnant belly.
-	<<elseif $time - $companionCherry.pregnantT< 240 & $time - $companionCherry.pregnantT>=180 >>\
+	<<elseif $time - $companionCherry.pregnantT< 240 && $time - $companionCherry.pregnantT>=180 >>\
 		Cherry's belly is huge and bulging forward in a way that obviously identifies her as pregnant. 
 	<<elseif $time - $companionCherry.pregnantT>=240>>\
 		Cherry has a very large and very obvious pregnant belly. She's probably due soon, though it's hard to know exactly when.
@@ -907,13 +907,13 @@ Overall the world would probably see <<if _companion.sex=="male">>him<<else>>her
 [img[setup.ImagePath+$companionCloud.image]]
 <<include "Cloud Introduction">>
 <<if $time - $companionCloud.pregnantT > 0 >>\
-	<<if $time - $companionCloud.pregnantT< 60 & $time - $companionCloud.pregnantT>= 30 >>\
+	<<if $time - $companionCloud.pregnantT< 60 && $time - $companionCloud.pregnantT>= 30 >>\
 	Cloud hasn't been pulling his weight as much he should recently. He pitches his own tent, then immediately goes to sleep most nights. It's strange he isn't helping as much as he used to.
-	<<elseif $time - $companionCloud.pregnantT< 180 & $time - $companionCloud.pregnantT>= 120 && $CloudConvoPreg==false >>\
+	<<elseif $time - $companionCloud.pregnantT< 180 && $time - $companionCloud.pregnantT>= 120 && $CloudConvoPreg==false >>\
 		Cloud seems to be avoiding chores and lounges around quite a bit more than usual. He's even become a little pudgy recently and put on some fat on his belly. Perhaps you should have a talk with him to see what's going on.
-	<<elseif $time - $companionCloud.pregnantT< 180 & $time - $companionCloud.pregnantT>= 120 && $CloudConvoPreg==true>>\
+	<<elseif $time - $companionCloud.pregnantT< 180 && $time - $companionCloud.pregnantT>= 120 && $CloudConvoPreg==true>>\
 		Cloud hhas a small, but obvious bulge for his pregnant belly.
-	<<elseif $time - $companionCloud.pregnantT< 240 & $time - $companionCloud.pregnantT>=180 >>\
+	<<elseif $time - $companionCloud.pregnantT< 240 && $time - $companionCloud.pregnantT>=180 >>\
 		Cloud's belly is huge and bulging forward in a way that obviously identifies him as pregnant. 
 	<<elseif $time - $companionCloud.pregnantT>=240>>\
 		Cloud has a very large and very obvious pregnant belly. He's probably due soon, though it's hard to know exactly when.
@@ -927,13 +927,13 @@ Overall the world would probably see <<if _companion.sex=="male">>him<<else>>her
 [img[setup.ImagePath+$companionSaeko.image]]
 <<include "Saeko Introduction">>
 <<if $time - $companionSaeko.pregnantT > 0 >>\
-	<<if $time - $companionSaeko.pregnantT< 60 & $time - $companionSaeko.pregnantT>= 30 >>\
+	<<if $time - $companionSaeko.pregnantT< 60 && $time - $companionSaeko.pregnantT>= 30 >>\
 	Saeko has been sneaking off and seems sick, has she been testing something on herself?
-	<<elseif $time - $companionSaeko.pregnantT< 180 & $time - $companionSaeko.pregnantT>= 120 && $SaekoConvoPreg==false >>\
+	<<elseif $time - $companionSaeko.pregnantT< 180 && $time - $companionSaeko.pregnantT>= 120 && $SaekoConvoPreg==false >>\
 		Saeko is being evasive about something. And whatever it is, it doesn't seem to be good for her health, as she is frequently tired and seems bloated. Perhaps you should have a talk with her to see what's going on.
-	<<elseif $time - $companionSaeko.pregnantT< 180 & $time - $companionSaeko.pregnantT>= 120 && $SaekoConvoPreg==true>>\
+	<<elseif $time - $companionSaeko.pregnantT< 180 && $time - $companionSaeko.pregnantT>= 120 && $SaekoConvoPreg==true>>\
 		Saeko has a small, but obvious bulge for her pregnant belly.
-	<<elseif $time - $companionSaeko.pregnantT< 240 & $time - $companionSaeko.pregnantT>=180 >>\
+	<<elseif $time - $companionSaeko.pregnantT< 240 && $time - $companionSaeko.pregnantT>=180 >>\
 		Saeko's belly is huge and bulging forward in a way that obviously identifies her as pregnant. 
 	<<elseif $time - $companionSaeko.pregnantT>=240>>\
 		Saeko has a very large and very obvious pregnant belly. She's probably due soon, though it's hard to know exactly when.
@@ -947,13 +947,13 @@ Overall the world would probably see <<if _companion.sex=="male">>him<<else>>her
 [img[setup.ImagePath+$companionTwin.image]]
 <<include "Twin Introduction">>
 <<if $time - $companionTwin.pregnantT > 0 >>\
-	<<if $time - $companionTwin.pregnantT< 60 & $time - $companionTwin.pregnantT>= 30 >>\
+	<<if $time - $companionTwin.pregnantT< 60 && $time - $companionTwin.pregnantT>= 30 >>\
 	Lately your twin has been sick quite frequently. Is this a side effect of being conjured by a Curse?
-	<<elseif $time - $companionTwin.pregnantT< 180 & $time - $companionTwin.pregnantT>= 120 && $TwinConvoPreg==false >>\
+	<<elseif $time - $companionTwin.pregnantT< 180 && $time - $companionTwin.pregnantT>= 120 && $TwinConvoPreg==false >>\
 		Your twin has really gotten out of shape recently. She's been lagging behind the group more and more frequently with her breaks. She also seems to have put on some weight. Perhaps you should have a talk with her to see what's going on.
-	<<elseif $time - $companionTwin.pregnantT< 180 & $time - $companionTwin.pregnantT>= 120 && $TwinConvoPreg==true>>\
+	<<elseif $time - $companionTwin.pregnantT< 180 && $time - $companionTwin.pregnantT>= 120 && $TwinConvoPreg==true>>\
 		Your twin has a small, but obvious bulge for her pregnant belly.
-	<<elseif $time - $companionTwin.pregnantT< 240 & $time - $companionTwin.pregnantT>=180 >>\
+	<<elseif $time - $companionTwin.pregnantT< 240 && $time - $companionTwin.pregnantT>=180 >>\
 		Your twin's belly is huge and bulging forward in a way that obviously identifies her as pregnant. 
 	<<elseif $time - $companionTwin.pregnantT>=240>>\
 		Your twin has a very large and very obvious pregnant belly. She's probably due soon, though it's hard to know exactly when.
@@ -989,7 +989,7 @@ Overall the world would probably see <<if _companion.sex=="male">>him<<else>>her
 
 :: Companion Layer Interaction
 <<nobr>>
-<<if ~$ConvoHandicapLarge>>
+<<if !$ConvoHandicapLarge>>
 	<<if $hiredCompanions.length > 0>>
 		<<set _temp1 = random(0,$hiredCompanions.length - 1)>>
 		<<if $hiredCompanions[_temp1].name != ($companionTwin.name || $companionGolem.name)>>

--- a/src/global.twee
+++ b/src/global.twee
@@ -2477,14 +2477,22 @@ $flaskMatrixLabel[$flaskPref] ($flaskMatrix[$flaskPref] remaining)
 <<return>>
 
 
-:: CampCode
-You can set up camp and rest here for a while before continuing your journey. You still need to eat and drink and the layer's threats continue to loom over you even as you rest. This won't accomplish much on its own, but if you'd like to spend some time sampling the local cuisine or studying this layer's threats, then this could be a good way to do that. 
+:: CampCode [nobr]
+<<if setup.passingTime()>>
+	<<include `"Layer" + $currentLayer + " Travel Events"`>>
+<</if>>
+<<if !setup.passingTime()>>
+	You can set up camp and rest here for a while before continuing your journey. You still need to eat and drink and the layer's threats continue to loom over you even as you rest. This won't accomplish much on its own, but if you'd like to spend some time sampling the local cuisine or studying this layer's threats, then this could be a good way to do that.<br><br>
 
-How many days would you like to rest here?
-<<textbox "_temp" "0">>
-<<nobr>><<link "Set up camp and wait" `"Layer" + $currentLayer + " Hub"`>>
-	<<PassTime `parseInt(_temp, 10)`>>
-<</link>><</nobr>>
+	How many days would you like to rest here?<br>
+	<<textbox "_campTime" "0">><br>
+	<<link "Set up camp and wait" `passage()`>>
+		<<set setup.startPassingTime(parseInt(_campTime, 10) || 0)>>
+	<</link>><br><br>
+
+	<<link "Return to exploring the layer without waiting" `"Layer" + $currentLayer + " Hub"`>><</link>>
+<</if>>
+
 
 :: Curse Descriptions
 <<nobr>>

--- a/src/global.twee
+++ b/src/global.twee
@@ -1994,7 +1994,11 @@ How many dubloons would you like to pay back?
 	/* If we aren't passing time yet, assume that the number of days was passed in the first argument. */
 	<<set _state = setup.startPassingTime(_args[0])>>
 <</if>>
-<<if _state.expectedDays && !_state.unweightedDayIndex>>
+
+/* Check event triggers. */
+<<set _breakForEvent = Object.values(_triggers).some(trigger => trigger())>>
+
+<<if !_breakForEvent && _state.expectedDays && !_state.unweightedDayIndex>>
 	/* Temporarily use the weighted day index to store the weighted expected number of days. */
 	<<set _state.weightedDayIndex = Math.round(_timeWeight * _state.expectedDays)>>
 	/* Check for wetting events. */
@@ -2020,8 +2024,7 @@ How many dubloons would you like to pay back?
 	<<set _state.weightedDayIndex = 0>>
 <</if>>
 
-<<set _breakForEvent = false>>
-<<for _state.unweightedDayIndex < _state.expectedDays>>
+<<for !_breakForEvent && _state.unweightedDayIndex < _state.expectedDays>>
 	/* Increment the day index. We only break out of the inner loop because we're sated, can't eat/drink or */
 	/* because an event is about to happen. An event might interrupt our attempts to decrease starvation or */
 	/* dehydration, but that's okay - we'll try again during the next trip. */
@@ -2346,14 +2349,10 @@ How many dubloons would you like to pay back?
 			/* Increment the next real day. */
 			<<set _state.nextRealDay += 1>>
 			/* Check event triggers. */
-			<<if Object.values(_triggers).some(trigger => trigger())>>
-				<<set _breakForEvent = true>>
-			<</if>>
+			<<set _breakForEvent = Object.values(_triggers).some(trigger => trigger())>>
 		<</if>>
 		<<if !_drank || !_ate || _breakForEvent>><<break>><</if>>
 	<</for>>
-	/* Check if we need to stop to let an event happen. */
-	<<if _breakForEvent>><<break>><</if>>
 <</for>>
 
 <<if !_breakForEvent>>

--- a/src/global.twee
+++ b/src/global.twee
@@ -2244,7 +2244,7 @@ How many dubloons would you like to pay back?
 					<<set $foodL5 += 1>>
 					<<set $crumbleFluid += 1>>
 				<<case 6>>
-					<<if $slingshot == 1>>
+					<<if $slingshot>>
 						<<set $foodL6 += 1>>
 					<<elseif $items[13].count && $items[20].count >= Math.max(3 - $bullRed, 1)>>
 						<<set $foodL6 += 1>>

--- a/src/global.twee
+++ b/src/global.twee
@@ -465,7 +465,7 @@ Your R cup breasts are truly magnificent, but be cautious of the potential for v
 <<elseif $app.breastsCor >= 20>>
 Boasting an incredible S cup size, you must always be vigilant for the risk of extremely serious back pain.
 <</if>>
-<<if $time-$menCycleT-$menCycleVar>20 & $menCycleFlag==true>>
+<<if $time-$menCycleT-$menCycleVar>20 && $menCycleFlag==true>>
 They are a bit sore at the moment.
 <</if>>
 <<if $app.lactation > 1 >>
@@ -546,13 +546,13 @@ Your body appears rather out of shape, and you could certainly benefit from some
 <</if>>
 <<if $AegisWear>>Although imperceptible to an outside observer, your natural skeleton has been seamlessly replaced with a lightweight and resilient orichalcum framework.<br><br><</if>>
 
-<<if $time - $app.pregnantT < 180 & $time - $app.pregnantT >= 120 & $menFirstCycle == false>>
+<<if $time - $app.pregnantT < 180 && $time - $app.pregnantT >= 120 && $menFirstCycle == false>>
 	Your pregnancy is now visibly noticeable, with your belly round and growing. You occasionally feel a gentle flutter within, a reminder of the life blossoming inside you.<br><br>
-<<elseif $time - $app.pregnantT < 180 & $time - $app.pregnantT >= 120 & $menFirstCycle == true>>
+<<elseif $time - $app.pregnantT < 180 && $time - $app.pregnantT >= 120 && $menFirstCycle == true>>
 	You've gained some weight, and your belly has become rounder. Every so often, you experience ticklish spasms from within, possibly a sign of your baby's movements.<br><br>
-<<elseif $time - $app.pregnantT < 240 & $time - $app.pregnantT >= 180 & $menFirstCycle == false>>
+<<elseif $time - $app.pregnantT < 240 && $time - $app.pregnantT >= 180 && $menFirstCycle == false>>
 	Your belly is now large and unmistakably that of a pregnant person. Your child's movements within your womb are frequent, and at times, the intensity of the sensations surprises you.<br><br>
-<<elseif $time - $app.pregnantT < $due & $time - $app.pregnantT >= 240>>
+<<elseif $time - $app.pregnantT < $due && $time - $app.pregnantT >= 240>>
 	Your belly is sizable and clearly pregnant. Your child often tries to move and kick within your womb, but space is becoming limited. The sensations can be quite intense, but you sense that your pregnancy is nearing its end.<br><br>
 <</if>>
 
@@ -1217,7 +1217,7 @@ If you are over 18, please go back and enter an age above 18 to continue.
 <<if $ownedRelics.some(e => e.name === "Blind Divine")>>
 	<<if $BDwear>>
 		<br>You are currently wearing the Blind Divine, 
-		<<if $eyeCount<2 && ~$BionicEye>>
+		<<if $eyeCount<2 && !$BionicEye>>
 			it feels you can perceive even more than when you still had both your eyes. The limited range of the Relic still makes it feel a little more awkward than when you had your normal vision.
 		<<else>>
 			which allows you to perceive your immediate surroundings to a precise level you could never hope to achieve with your eyes.
@@ -3085,9 +3085,9 @@ Items:<br>
 				<<print "[[$ownedRelics[_i].name|Relic Info][$temp = _i]] $ownedRelics[_i].weight kg | [[Drop|Drop Items Menu][$BDwear = false, $ownedRelics.deleteAt(_i)]]">><br>
 			<<elseif $ownedRelics[_i].name=="Heavy is the Head">>
 				<<print "[[$ownedRelics[_i].name|Relic Info][$temp = _i]] $ownedRelics[_i].weight kg | [[Drop|Drop Items Menu][$HeavyHeadwear= false, $ownedRelics.deleteAt(_i)]]">><br>
-			<<elseif $ownedRelics[_i].name=="Moonwatcher" & $BionicEye >>
+			<<elseif $ownedRelics[_i].name=="Moonwatcher" && $BionicEye >>
 				<<print $ownedRelics[_i].name>> You can not drop Relics that have become part of your body.<br>
-			<<elseif $ownedRelics[_i].name=="Glory's Grasp" & $BionicArm >>
+			<<elseif $ownedRelics[_i].name=="Glory's Grasp" && $BionicArm >>
 				<<print $ownedRelics[_i].name>> You can not drop Relics that have become part of your body.<br>
 			<<else>>
 				<<print "[[$ownedRelics[_i].name|Relic Info][$temp = _i]] $ownedRelics[_i].weight kg | [[Drop|Drop Items Menu][$ownedRelics.deleteAt(_i)]]">><br>

--- a/src/layer1.twee
+++ b/src/layer1.twee
@@ -513,7 +513,8 @@ Choose the Curse you wish to remove:
 
 
 :: Pick up the Star Compass [layer1]
-<<CollectRelic $relic1>>
+<<CollectRelic $relic1>>\
+<<if !setup.passingTime()>>
 
 The journey to this Relic takes you over undulating hills covered in grasses which sway gently in the wind. Night falls, but you press onwards, knowing that you're almost at your destination. It's peaceful out here, and the stars are out, giving you just enough light to keep moving.
 
@@ -525,10 +526,12 @@ This may not be very useful in most circumstances, but perhaps at some point in 
 
 [[Continue searching for the Relics of layer 1|Layer1 Relics]]
 [[Continue exploring the first layer|Layer1 Hub]]
+<</if>>
 
 
 :: Pick up the Rømer Stones [layer1]
-<<CollectRelic $relic2>>
+<<CollectRelic $relic2>>\
+<<if !setup.passingTime()>>
 
 The Relic you're looking for is in the deeper parts of the layer. The rain from countless clouds runs down in tributaries, and eventually into rivers. Down this far there are many ponds and lakes that slowly flow into rivers and then deeper into the next layer of the Abyss. Some denser vegetation and lots of fungi slow your progress, but they make the journey quite beautiful.
 
@@ -542,10 +545,12 @@ While they aren't useful on their own, perhaps you can take these stones back to
 
 [[Continue searching for the Relics of layer 1|Layer1 Relics]]
 [[Continue exploring the first layer|Layer1 Hub]]
+<</if>>
 
 
 :: Pick up the Creepy Doll [layer1]
-<<CollectRelic $relic3>>
+<<CollectRelic $relic3>>\
+<<if !setup.passingTime()>>
 
 <<if $app.appAge > 13>><<if $hiredCompanions.some(e => e.name === "Maru")>>
 As you and Maru search for an interesting doll you've heard about, you come across the decaying jusk of a house. It looks as if someone once lived here, but it has been long since abandoned to be degraded by the forces of the Abyss.
@@ -601,10 +606,12 @@ Recognizing the doll's mysterious properties and potential value, you overcome y
 
 [[Continue searching for the Relics of layer 1|Layer1 Relics]]
 [[Continue exploring the first layer|Layer1 Hub]]
+<</if>>
 
 
 :: Pick up the Giddy Reaper [layer1]
-<<CollectRelic $relic4>>
+<<CollectRelic $relic4>>\
+<<if !setup.passingTime()>>
 
 The gradual slopes and sweeping grasslands of this layer of the Abyss are occassionally broken up by small streams and clumps of more robust vegetation. Your quest for this latest Relic sends you across the landscape until you reach a particularly verdant thicket. No paths exist through it, but many shrieks and squaks from birds inhabiting the many branches of the short trees here greet you as you find a space between trees and slowly make your way inside.
 
@@ -620,10 +627,12 @@ On the way back, you decide to test your prize, and you swipe it through some of
 
 [[Continue searching for the Relics of layer 1|Layer1 Relics]]
 [[Continue exploring the first layer|Layer1 Hub]]
+<</if>>
 
 
 :: Pick up the Silk Twister [layer1]
-<<CollectRelic $relic5>>
+<<CollectRelic $relic5>>\
+<<if !setup.passingTime()>>
 
 You set out after a Relic that's a bit higher up in a nearby canyon. The vegetation along your path isn't too thick, but you soon find yourself traveling along a small river. Miasma laden mist clings to the surface of the water, thrown up by small rapids. There are some large trees along the watercourse, and above it are flocks of birds that are either native to this layer of the Abyss, or that have flown down here. Your path takes you up a tributary into the river, and you move through dappled light from a low canopy.
 
@@ -637,10 +646,12 @@ The creature has no interest in preying upon things that do not fly, an odd pecu
 
 [[Continue searching for the Relics of layer 1|Layer1 Relics]]
 [[Continue exploring the first layer|Layer1 Hub]]
+<</if>>
 
 
 :: Pick up the Vertebra Key [layer1]
-<<CollectRelic $relic6>>
+<<CollectRelic $relic6>>\
+<<if !setup.passingTime()>>
 
 The Relic you're pursuing takes you off the beaten path. You leave the plains and rivers behind, climbing down a rocky ravine. You struggle as you climb down narrow ledges, large boulders, and dusty rocks. Everything is dry here, compared to the verdant sanctuary that is the rest of the layer.
 
@@ -660,10 +671,12 @@ Something clicks in your brain, and you have a sudden instinct. This is your cel
 
 [[Continue searching for the Relics of layer 1|Layer1 Relics]]
 [[Continue exploring the first layer|Layer1 Hub]]
+<</if>>
 
 
 :: Pick up the Chain of Lorelei [layer1]
-<<CollectRelic $relic7>>
+<<CollectRelic $relic7>>\
+<<if !setup.passingTime()>>
 
 Long-term erosion is evident throughout this layer of the Abyss. Yet in every landscape, some things resist erosion better than others. To the southeast there is a butte that rises well above the surrounding landscape. You journey towards it. Far to the north you can see a crimson kite dragon briefly arc above the horizon before gliding back down below it.
 
@@ -683,10 +696,12 @@ You can wear this choker to change your voice, which may influence how some peop
 
 [[Continue searching for the Relics of layer 1|Layer1 Relics]]
 [[Continue exploring the first layer|Layer1 Hub]]
+<</if>>
 
 
 :: Pick up the Hive Tassel [layer1]
-<<CollectRelic $relic8>>
+<<CollectRelic $relic8>>\
+<<if !setup.passingTime()>>
 
 As you wander through a grove of trees in search of the mysterious tassel that's somehow connected to the bees, you notice something new. A constant buzzing surrounds you all at once, as if you were swallowed by a swarm of bees. And in fact, when you glance at the trees, you can see that their bark is now impossible to make out, instead covered in layers of yellow and black insects moving over each other.
 
@@ -700,10 +715,12 @@ As you investigate the new sound, you spot a tree with a few branches vibrating 
 
 [[Continue searching for the Relics of layer 1|Layer1 Relics]]
 [[Continue exploring the first layer|Layer1 Hub]]
+<</if>>
 
 
 :: Pick up the Smitten Mitt [layer1]
-<<CollectRelic $relic9>>
+<<CollectRelic $relic9>>\
+<<if !setup.passingTime()>>
 
 There are many beautiful things in this layer of the Abyss, but also lots of places that are slightly monotonous. Your Relic expedition sets you out through vast grasslands. In places the grasses are sparse and intermixed with other types of vegetation. In other places they rise high, thick, and dominant.
 
@@ -717,6 +734,7 @@ You realize the fabric is in fact some kind of long glove. You stick your hand i
 
 [[Continue searching for the Relics of layer 1|Layer1 Relics]]
 [[Continue exploring the first layer|Layer1 Hub]]
+<</if>>
 
 
 :: Take on Libido Reinforcement A [layer1]

--- a/src/layer1.twee
+++ b/src/layer1.twee
@@ -1364,5 +1364,3 @@ Sometimes you get a feeling like you lost something. Somethin precious to you th
 
 <<include 'CampCode'>>
 
-[[Return to exploring the layer without waiting|Layer1 Hub]]
-

--- a/src/layer1.twee
+++ b/src/layer1.twee
@@ -1122,7 +1122,7 @@ Use the following option only if you have specifically considered your inventory
 
 Nervously, you begin going trough your bag, attempting to decide which Relics to surrender and which to keep.
 
-<<if $ownedRelics.some(e => e.name === "Moonwatcher") & $BionicEye>>
+<<if $ownedRelics.some(e => e.name === "Moonwatcher") && $BionicEye>>
 	<<set _temp = 145-95>>
 <<else>>
 	<<set _temp = 145>>

--- a/src/layer2.twee
+++ b/src/layer2.twee
@@ -1086,7 +1086,8 @@ Despite the anxiety and uncertainty that grips you, you press on, trying to focu
 
 
 :: Pick up the Firmament Pigment [layer2]
-<<CollectRelic $relic10>>
+<<CollectRelic $relic10>>\
+<<if !setup.passingTime()>>
 
 After many hours of trudging through the second layer of the Abyss, you feel a change in the atmosphere. A notable quietness falls upon the dense thicket, only broken by the pitter-patter of water droplets falling from the canopy above. You pause, taking a moment to wipe the dampness from your forehead. As you straighten, your gaze falls on a vine-wrapped entrance to a cavern, nestled snugly in the base of an enormous tree. The cavern, made visible by a stray beam of light breaking through the thick foliage, promises a departure from the oppressive density of the jungle.
 
@@ -1102,10 +1103,12 @@ Suddenly, the whole cavern is bathed in starlight, as if you've brought the heav
 
 [[Continue searching for the Relics of layer 2|Layer2 Relics]]
 [[Continue exploring the second layer|Layer2 Hub]]
+<</if>>
 
 
 :: Pick up the Pearly Gates [layer2]
-<<CollectRelic $relic11>>
+<<CollectRelic $relic11>>\
+<<if !setup.passingTime()>>
 
 The thorny path ahead of you is shadowed, sunlight filtering down through the thick overhead foliage in small, scattered patches. It seems as though the jungle pulsates with a rhythm of its own, a chorus of croaks, chirps, and distant growls setting a primeval symphony. The path narrows even further and the undergrowth gives way to a large, formidable tree, its bark weathered and gnarled with time. Puzzlingly, a natural archway is formed by the tree's roots, reminiscent of a gateway into another world.
 
@@ -1121,10 +1124,12 @@ Pulling away from the now silent tree gateway, you embark back on your journey, 
 
 [[Continue searching for the Relics of layer 2|Layer2 Relics]]
 [[Continue exploring the second layer|Layer2 Hub]]
+<</if>>
 
 
 :: Pick up the World Stone [layer2]
-<<CollectRelic $relic12>>
+<<CollectRelic $relic12>>\
+<<if !setup.passingTime()>>
 
 You traverse deeper into the dense labyrinth of the second layer of the Abyss. Your heart pounds, the rhythmic beat echoed by the symphony of raindrops cascading from the thicket above.
 
@@ -1144,10 +1149,12 @@ You can try working out with this Relic. It can both improve your muscle tone an
 
 [[Continue searching for the Relics of layer 2|Layer2 Relics]]
 [[Continue exploring the second layer|Layer2 Hub]]
+<</if>>
 
 
 :: Pick up the Forest's Gift [layer2]
-<<CollectRelic $relic13>>
+<<CollectRelic $relic13>>\
+<<if !setup.passingTime()>>
 
 You descend deeper into the wild, verdant undergrowth of the second layer of the Abyss. Thick bramble of gnarled trunks and tangled vines are slick with the constant drizzle from above. Large eyes blink at you from within the darkness of the foliage, the Abyss's curious critters observing your progress with cautious intrigue.
 
@@ -1167,10 +1174,12 @@ The beast seems to pause, its eyes softening ever so slightly. Slowly, it steps 
 
 [[Continue searching for the Relics of layer 2|Layer2 Relics]]
 [[Continue exploring the second layer|Layer2 Hub]]
+<</if>>
 
 
 :: Pick up the Harmless Harmony [layer2]
-<<CollectRelic $relic14>>
+<<CollectRelic $relic14>>\
+<<if !setup.passingTime()>>
 
 As you cautiously tread through the eerie, dense foliage, the ambient sounds of this enchanted forest echo around you, an orchestra of nature humming a haunting symphony. This second layer of the Abyss, though treacherous, is full of life. The rhythmic dripping of dew from the flora overhead enhances the ambiance, merging with the symphony of the Abyss to create an unusual melody.
 
@@ -1190,10 +1199,12 @@ With the Relic in your possession, you turn back to the dense path you've just c
 
 [[Continue searching for the Relics of layer 2|Layer2 Relics]]
 [[Continue exploring the second layer|Layer2 Hub]]
+<</if>>
 
 
 :: Pick up the Umbra Trident [layer2]
-<<CollectRelic $relic15>>
+<<CollectRelic $relic15>>\
+<<if !setup.passingTime()>>
 
 Your eyes catch something peculiar ahead; a pocket of unnatural darkness amidst the verdant chaos, a stark contrast to the vibrant hues of the thicket. An unassuming, shadowy cavern lays tucked away, concealed within a gnarled tree's enormous roots.
 
@@ -1215,10 +1226,12 @@ The Umbra Trident - a golden fork, deceptively simple, and yet, brimming with un
 
 [[Continue searching for the Relics of layer 2|Layer2 Relics]]
 [[Continue exploring the second layer|Layer2 Hub]]
+<</if>>
 
 
 :: Pick up the Event Horizon [layer2]
-<<CollectRelic $relic16>>
+<<CollectRelic $relic16>>\
+<<if !setup.passingTime()>>
 
 All around you is the incessant dripping of water from the verdant canopy above, the droplets refracting the faint light that filters down from the upper layer. The gentle drizzle slowly intensifies, culminating in a downpour akin to a monsoon shower.
 
@@ -1236,10 +1249,12 @@ As you withdraw your hand, the vapor subsides, and the orchids return to their r
 
 [[Continue searching for the Relics of layer 2|Layer2 Relics]]
 [[Continue exploring the second layer|Layer2 Hub]]
+<</if>>
 
 
 :: Pick up the Heart-stealing Stole [layer2]
-<<CollectRelic $relic17>>
+<<CollectRelic $relic17>>\
+<<if !setup.passingTime()>>
 
 The air is thick with the moisture from the never-ending rain of dewdrops, the foliage overhead a vibrant, pulsing canopy of green that blots out any sign of the layer above. The ground underfoot is uneven, pitted with hidden roots and strewn with fallen leaves. With every step, you can feel the mulch yield beneath your weight, a constant reminder of the life that thrives, unseen, under your feet.
 
@@ -1259,10 +1274,12 @@ You may want to start wearing this Relic regularly, it can significantly speed u
 
 [[Continue searching for the Relics of layer 2|Layer2 Relics]]
 [[Continue exploring the second layer|Layer2 Hub]]
+<</if>>
 
 
 :: Pick up the Effacing Asperity [layer2]
-<<CollectRelic $relic18>>
+<<CollectRelic $relic18>>\
+<<if !setup.passingTime()>>
 
 You arrive at a peculiar section of the second layer. A great archway of entwined ivy branches marks the entrance, beyond which the vegetation is an even denser, almost impenetrable maze. The undergrowth here is not just dense; it appears unnaturally slick, as if coated in a thick sheen of oil. The typically verdant plant-life glows an iridescent purple, evoking the lilac hue associated with the Effacing Asperity.
 
@@ -1274,10 +1291,12 @@ With a mix of awe and anticipation, you reach out and take hold of the Relic. It
 
 [[Continue searching for the Relics of layer 2|Layer2 Relics]]
 [[Continue exploring the second layer|Layer2 Hub]]
+<</if>>
 
 
 :: Pick up the Wholly Ale [layer2]
-<<CollectRelic $relic19>>
+<<CollectRelic $relic19>>\
+<<if !setup.passingTime()>>
 
 As you navigate through the labyrinthine tangle of dense vegetation, the damp dewdrop drizzle that had been your constant companion begins to wane. A hush falls over the Abyss, as if you've entered a sanctum untouched by time. The dense foliage yields to a clearing; an expansive grotto within the heart of the thicket. Sunlight seeping through the canopy above reveals a verdant oasis; the air around you hums with a palpable serenity, untouched by the relentless clamor of the jungle.
 
@@ -1295,10 +1314,12 @@ This grotto, an oasis within the tumultuous Abyss, feels more like a shrine; a s
 
 [[Continue searching for the Relics of layer 2|Layer2 Relics]]
 [[Continue exploring the second layer|Layer2 Hub]]
+<</if>>
 
 
 :: Pick up the Memoir Remnant [layer2]
-<<CollectRelic $relic20>>
+<<CollectRelic $relic20>>\
+<<if !setup.passingTime()>>
 
 Through this green maze, you begin to notice peculiar formations in the distance, jutting out and parting the thorny thicket in a manner reminiscent of human construction.
 
@@ -1316,10 +1337,12 @@ This seemingly ordinary bookshelf, now a living testament of your journey, gradu
 
 [[Continue searching for the Relics of layer 2|Layer2 Relics]]
 [[Continue exploring the second layer|Layer2 Hub]]
+<</if>>
 
 
 :: Pick up the Gleam Dazer [layer2]
-<<CollectRelic $relic21>>
+<<CollectRelic $relic21>>\
+<<if !setup.passingTime()>>
 
 As you delve further into the second layer of the Abyss, the twisted maze of vegetation towers above you, casting an ever-deepening shadow on the path ahead. The atmosphere is humid, an everlasting mist of dew droplets cascading from the leaves overhead, merging into heavier droplets before pattering onto the emerald carpet below. The air is heavy with the fragrance of moss and wet bark, mingled with the exotic scent of unidentifiable flowers. Each step is slow and deliberate, as navigating this densely woven plant world demands patience and caution.
 
@@ -1333,6 +1356,7 @@ You can use this Relic to see into your future and see what awaits you on the la
 
 [[Continue searching for the Relics of layer 2|Layer2 Relics]]
 [[Continue exploring the second layer|Layer2 Hub]]
+<</if>>
 
 
 :: Layer2 Flasks [layer2]

--- a/src/layer2.twee
+++ b/src/layer2.twee
@@ -1744,5 +1744,3 @@ Your limp after this rough encounter will increase your next <<print (4 - $statR
 :: Layer2 Camp
 
 <<include 'CampCode'>>
-
-[[Return to exploring the layer without waiting|Layer2 Hub]]

--- a/src/layer3.twee
+++ b/src/layer3.twee
@@ -1089,7 +1089,8 @@ Please enter your new skin/eye color:
 
 
 :: Pick up the Sibyl Blend [layer3]
-<<CollectRelic $relic22>>
+<<CollectRelic $relic22>>\
+<<if !setup.passingTime()>>
 
 You've been wandering these oppressive tunnels for hours, and the darkness, while not total, is becoming monotonous.
 
@@ -1111,10 +1112,12 @@ You can choose to start using this Relic to reduce the travel times to all futur
 
 [[Continue searching for the Relics of layer 3|Layer3 Relics]]
 [[Continue exploring the third layer|Layer3 Hub]]
+<</if>>
 
 
 :: Pick up the Pangea Shaker [layer3]
-<<CollectRelic $relic23>>
+<<CollectRelic $relic23>>\
+<<if !setup.passingTime()>>
 
 After what feels like hours, your eye catches a glimpse of an unusual glow, different from the typical bioluminescent life around you. The glow originates from a wide chamber up ahead. As you approach, the glow brightens, revealing a cavernous expanse filled with towering columns of crystal jutting from the ground and ceiling, casting refracted light in all directions, a kaleidoscope of colors, very much like a rainbow.
 
@@ -1128,10 +1131,12 @@ And so, holding the Relic firmly in hand, you continue your descent into the Aby
 
 [[Continue searching for the Relics of layer 3|Layer3 Relics]]
 [[Continue exploring the third layer|Layer3 Hub]]
+<</if>>
 
 
 :: Pick up the From Seafoam [layer3]
-<<CollectRelic $relic24>>
+<<CollectRelic $relic24>>\
+<<if !setup.passingTime()>>
 
 As you wander through the caverns of the third layer, a feeling of something different, something special, tugs at your curiosity. Turning a corner, you find yourself facing a wide, domed cavern. It's filled with light, its intensity rivaling that of the noonday sun. Unbelievably, the cavern is filled with water, as clear as crystal, illuminated by bioluminescent organisms. Tiny jellyfish-like creatures hover just beneath the surface, casting a soothing, sea-green glow that illuminates the cavern.
 
@@ -1151,10 +1156,12 @@ You can use this Relic to change your scent so that people perceive you as eithe
 
 [[Continue searching for the Relics of layer 3|Layer3 Relics]]
 [[Continue exploring the third layer|Layer3 Hub]]
+<</if>>
 
 
 :: Pick up the Orbweaver [layer3]
-<<CollectRelic $relic25>>
+<<CollectRelic $relic25>>\
+<<if !setup.passingTime()>>
 
 Your touch glides over the cold, wet surface of the rocks as you traverse the narrow pathway, the echoes of your footsteps fading in the depth of the Abyss. The eerie glow from the moss and mushrooms casts an alien luminescence on your path, their pale greens and blues seeming out of place in the otherwise desolate darkness. They grow in clusters, their light pulsating like the heartbeat of the Abyss. As you delve deeper, their numbers dwindle, their gentle glow replaced by a starker darkness.
 
@@ -1176,10 +1183,12 @@ This Relic possesses the ability to function as a substitute for a rope. Althoug
 
 [[Continue searching for the Relics of layer 3|Layer3 Relics]]
 [[Continue exploring the third layer|Layer3 Hub]]
+<</if>>
 
 
 :: Pick up the Soulseeker [layer3]
-<<CollectRelic $relic26>>
+<<CollectRelic $relic26>>\
+<<if !setup.passingTime()>>
 
 After traversing the network of tunnels for what feels like an eternity, you arrive at a peculiar sight—an enormous, hanging stalactite, its surface smooth and glowing gently. This natural cathedral is steeped in silence, except for the soft dripping of water somewhere in the distance. There's a stillness to this place that feels different, as if the Abyss itself is holding its breath in anticipation.
 
@@ -1193,10 +1202,12 @@ You feel a hum emanating from the rods, a silent resonance matching the rhythm o
 
 [[Continue searching for the Relics of layer 3|Layer3 Relics]]
 [[Continue exploring the third layer|Layer3 Hub]]
+<</if>>
 
 
 :: Pick up the Tranquility Knell [layer3]
-<<CollectRelic $relic27>>
+<<CollectRelic $relic27>>\
+<<if !setup.passingTime()>>
 
 The winding, serpentine tunnels echo with the sounds of your footfalls and the faint rustling of unseen organisms. Every so often, the chime of trickling water resonates through the rocky labyrinth, hinting at hidden underground waterways. The path before you dips down sharply into an inky darkness where the moss fails to illuminate.
 
@@ -1218,10 +1229,12 @@ Perhaps this Relic could be useful to evade a predator that senses its prey thro
 
 [[Continue searching for the Relics of layer 3|Layer3 Relics]]
 [[Continue exploring the third layer|Layer3 Hub]]
+<</if>>
 
 
 :: Pick up the Lightning Rook [layer3]
-<<CollectRelic $relic28>>
+<<CollectRelic $relic28>>\
+<<if !setup.passingTime()>>
 
 A sense of foreboding surrounds you as you delve deeper into the cavernous labyrinth before you. The stone walls are now adorned with intricate, glass-like formations, their transparent surfaces reflecting the glow of the nearby flora. This new environment resonates with the very essence of your goal - Lightning Rook.
 
@@ -1237,10 +1250,12 @@ When this Relic is kept in close proximity, it can be used to enhance your comba
 
 [[Continue searching for the Relics of layer 3|Layer3 Relics]]
 [[Continue exploring the third layer|Layer3 Hub]]
+<</if>>
 
 
 :: Pick up the Acrobatic Accord [layer3]
-<<CollectRelic $relic29>>
+<<CollectRelic $relic29>>\
+<<if !setup.passingTime()>>
 
 Taking a deep breath, you check your scuba gear and adjust the oxygen levels before taking the plunge into the chilly water. The tunnel is darker than the rest of the Abyss, so dark it feels almost tangible, wrapping around you like a tangible shroud. The bioluminescent moss begins to thin out, replaced by pulsing jellyfish that glow a surreal, ghostly blue. Their soft glow serves as your beacon, guiding you through the twisting maze of the underwater tunnel.
 
@@ -1254,10 +1269,12 @@ As you emerge from the underwater tunnel, back into the cavernous expanse of the
 
 [[Continue searching for the Relics of layer 3|Layer3 Relics]]
 [[Continue exploring the third layer|Layer3 Hub]]
+<</if>>
 
 
 :: Pick up the Managed Misfortune [layer3]
-<<CollectRelic $relic30>>
+<<CollectRelic $relic30>>\
+<<if !setup.passingTime()>>
 
 Suddenly, you detect a distinct gleam, an alien radiance unlike the glow of the Abyss's flora. It pulses with a vibrant energy, a color shifting between shades of green, blue, and purple. It's coming from a cavern off the main path, an opening guarded by sharp stalactites and stalagmites. An inexplicable pull draws you towards it, as if the source of the light beckons to you.
 
@@ -1271,9 +1288,11 @@ You can use this Relic to temporarily store any Curses you pick up.
 
 [[Continue searching for the Relics of layer 3|Layer3 Relics]]
 [[Continue exploring the third layer|Layer3 Hub]]
+<</if>>
 
 :: Pick up the Breathless Exhale [layer3]
-<<CollectRelic $relic31>>
+<<CollectRelic $relic31>>\
+<<if !setup.passingTime()>>
 
 In the distance, you hear a faint whooshing sound, like the sigh of a sleeping giant. Your heart pounds in your chest as you follow the noise. The passage narrows, forcing you to crawl on your hands and knees. Sharp stalactites and stalagmites threaten to pierce your protective gear, but you press on. The whooshing sound grows louder, rhythmic and steady, like the pulse of the Abyss itself.
 
@@ -1291,10 +1310,12 @@ Harnessing the energy of this Relic, you may be able to ward off potential threa
 
 [[Continue searching for the Relics of layer 3|Layer3 Relics]]
 [[Continue exploring the third layer|Layer3 Hub]]
+<</if>>
 
 
 :: Pick up the Sharing Shears [layer3]
-<<CollectRelic $relic32>>
+<<CollectRelic $relic32>>\
+<<if !setup.passingTime()>>
 
 As you carefully negotiate your way through the darkened tunnels of the third layer of the Abyss, you feel a change in the air. There is a certain tangibility, a prickling sensation on your skin, hinting that you might be close to your objective.
 
@@ -1314,10 +1335,12 @@ The porcelain stalagmite remains split in two, the halves still glowing with an 
 
 [[Continue searching for the Relics of layer 3|Layer3 Relics]]
 [[Continue exploring the third layer|Layer3 Hub]]
+<</if>>
 
 
 :: Pick up the Rose-tinted Spectacles [layer3]
-<<CollectRelic $relic33>>
+<<CollectRelic $relic33>>\
+<<if !setup.passingTime()>>
 
 As you continue down the spiraling path you're headed down, you come to a large cavern. The ceiling arches high above you, disappearing into an inky abyss. At the center of this cavern lies an unusual structure, one that stands in stark contrast to the natural formations of the cave. It's an immense circular platform made of polished obsidian, set into the floor of the cave. A complex network of lines etched into its surface glows with the same luminescence as the moss and fungi surrounding it. Razor-sharp obsidian shards seem to move and protrude from the glowing lines in a seemingly random pattern, leaving nearly no room to move without injuring yourself.
 
@@ -1333,6 +1356,7 @@ This Relic can be used to avoid future traps you may encounter in the Abyss.
 
 [[Continue searching for the Relics of layer 3|Layer3 Relics]]
 [[Continue exploring the third layer|Layer3 Hub]]
+<</if>>
 
 
 :: Layer3 Curses Random [nobr]

--- a/src/layer3.twee
+++ b/src/layer3.twee
@@ -1429,8 +1429,6 @@ Threats:
 
 <<include 'CampCode'>>
 
-[[Return to exploring the layer without waiting|Layer3 Hub]]
-
 :: Layer3 Threat1 [layer3]
 <<set $timeL3T1 -= 6>><<set $variation = random(0,1)>>
 [img[setup.ImagePath+'Threats/lessertentaclebeast.png']]

--- a/src/layer4.twee
+++ b/src/layer4.twee
@@ -902,7 +902,8 @@ The magic of the shrine wisps through the air menacingly as your victim struggle
 [[Continue with your journey|Layer4 Hub]]
 
 :: Pick up the Ghost-righter Writing Down [layer4]
-<<CollectRelic $relic34>>
+<<CollectRelic $relic34>>\
+<<if !setup.passingTime()>>
 
 As your eyes adjust to the swirling, icy fog, you notice something peculiar - an odd, crystalline formation that stands out amid the snow and ice. It's a colossal glacier, perfectly clear and shining with a strange light through its blue glacial ice. What catches your attention are the countless, intricate carvings etched into its surface. Scenes of forgotten tales, narratives of ages past, and cryptic symbols intertwine, their elaborate designs shimmering and dancing under the dim, diffused light.
 
@@ -916,10 +917,12 @@ Retrieving the Relic was just the beginning of the adventure. Holding the feathe
 
 [[Continue searching for the Relics of layer 4|Layer4 Relics]]
 [[Continue exploring the fourth layer|Layer4 Hub]]
+<</if>>
 
 
 :: Pick up the Gilded Prison [layer4]
-<<CollectRelic $relic35>>
+<<CollectRelic $relic35>>\
+<<if !setup.passingTime()>>
 
 The biting winds occasionally loosen icy chunks from the overhead canopy, which then tumble to the ground as snow or hail. Amidst this icy wilderness, you notice sparse, hardy shrubs huddling for warmth, their struggle for survival a stark contrast to the layer's serene beauty.
 
@@ -933,10 +936,12 @@ You retrieve the cage, taking care not to jostle it too much. It's surprisingly 
 
 [[Continue searching for the Relics of layer 4|Layer4 Relics]]
 [[Continue exploring the fourth layer|Layer4 Hub]]
+<</if>>
 
 
 :: Pick up the Omoikane Circuit [layer4]
-<<CollectRelic $relic36>>
+<<CollectRelic $relic36>>\
+<<if !setup.passingTime()>>
 
 Up ahead, you see a sudden break in the icy monotony of the fourth layer. A massive glacier, towering into the foggy abyss above and buried deep into the frost-laden ground below. In its frozen heart, the faint outline of a structure, half buried and time-forgotten. A technological hub, perhaps once bristling with activity, now silenced by the inexorable march of time and ice. You approach, your curiosity piqued.
 
@@ -954,10 +959,12 @@ You stand there, in the heart of this icy ruin, holding the ultimate symbol of p
 
 [[Continue searching for the Relics of layer 4|Layer4 Relics]]
 [[Continue exploring the fourth layer|Layer4 Hub]]
+<</if>>
 
 
 :: Pick up the Afar Wanderer [layer4]
-<<CollectRelic $relic37>>
+<<CollectRelic $relic37>>\
+<<if !setup.passingTime()>>
 
 Ahead, a peculiar sight breaks the endless white: an unusual, frosted structure that resembles a spiral staircase, formed by twisted, tortured ice formations. You approach cautiously, noticing a faint indigo glow emanating from the heart of the structure, buried deep within the coiled ice.
 
@@ -971,10 +978,12 @@ With the Afar Wanderer secured, you make your way back, leaving the silent, icy 
 
 [[Continue searching for the Relics of layer 4|Layer4 Relics]]
 [[Continue exploring the fourth layer|Layer4 Hub]]
+<</if>>
 
 
 :: Pick up the Kin Shifter [layer4]
-<<CollectRelic $relic38>>
+<<CollectRelic $relic38>>\
+<<if !setup.passingTime()>>
 
 As you delve deeper into the fourth layer, the landscape subtly morphs. The snow-blanketed expanse is punctuated by small glacial mountains. You notice a peculiar cluster of icicles suspended from a protruding ledge, refracting the dim ambient light, providing just enough illumination to pierce through the fog. It appears like a gateway, an entrance to somewhere yet unexplored.
 
@@ -990,10 +999,12 @@ You can use this Relic to copy other Relics you have to get more uses out of the
 
 [[Continue searching for the Relics of layer 4|Layer4 Relics]]
 [[Continue exploring the fourth layer|Layer4 Hub]]
+<</if>>
 
 
 :: Pick up the Brave Vector [layer4]
-<<CollectRelic $relic39>>
+<<CollectRelic $relic39>>\
+<<if !setup.passingTime()>>
 
 Your heart races as you approach the icy monolith, a hulking structure of metal and gears embedded in the snowy mountainside. The entrance, a yawning gateway with intricately interlocking cogwork, beckons you into its mechanical maw. As you draw closer, the relentless bitter cold seeping through your insulating gear seems to dissipate, replaced by an eerie warmth emanating from the mechanical fortress. You rub your frosted gloves together, relishing the momentary reprieve from the cold as you cross the threshold into the unknown.
 
@@ -1011,10 +1022,12 @@ While this Relic may not be very functional in its current form as a bent pipe, 
 
 [[Continue searching for the Relics of layer 4|Layer4 Relics]]
 [[Continue exploring the fourth layer|Layer4 Hub]]
+<</if>>
 
 
 :: Pick up the Devil's Own [layer4]
-<<CollectRelic $relic40>>
+<<CollectRelic $relic40>>\
+<<if !setup.passingTime()>>
 
 As you move through the frosty expanse of the fourth layer, the chill seeping through your heavy clothing is almost unbearable. Each breath you draw is laced with the biting cold, making your lungs ache. Despite the layers of gear you donned before your descent, the miasma-enhanced cold pierces through, making your teeth chatter in an unending cadence. Small patches of stubborn vegetation peep out from under the snow, brittle from the relentless cold.
 
@@ -1030,10 +1043,12 @@ If you have Cherry, this Relic will provide the useful boon of a single use rero
 
 [[Continue searching for the Relics of layer 4|Layer4 Relics]]
 [[Continue exploring the fourth layer|Layer4 Hub]]
+<</if>>
 
 
 :: Pick up the Verve Cell [layer4]
-<<CollectRelic $relic41>>
+<<CollectRelic $relic41>>\
+<<if !setup.passingTime()>>
 
 You trudge onward through the biting cold, every step crunching beneath your feet on the snow-laden ground. The fourth layer of the Abyss, an icy wasteland, is as beautiful as it is deadly. Small glacial mountains, crystalline in their sheen, rise like the backbones of ancient leviathans around you.
 
@@ -1049,10 +1064,12 @@ As you secure the Verve Cell into your satchel, you can't help but marvel at the
 
 [[Continue searching for the Relics of layer 4|Layer4 Relics]]
 [[Continue exploring the fourth layer|Layer4 Hub]]
+<</if>>
 
 
 :: Pick up the Vessel Vivisector [layer4]
-<<CollectRelic $relic42>>
+<<CollectRelic $relic42>>\
+<<if !setup.passingTime()>>
 
 Your instincts lead you towards a tall, glacier-topped mountain. Your eyes squint through the snowfall and you can see the mountain's icy apex, an ominous and daunting silhouette.
 
@@ -1068,10 +1085,12 @@ Looking around, you decide to use the Vivisector on one of the hardy plants, cur
 
 [[Continue searching for the Relics of layer 4|Layer4 Relics]]
 [[Continue exploring the fourth layer|Layer4 Hub]]
+<</if>>
 
 
 :: Pick up the Sated Artist [layer4]
-<<CollectRelic $relic43>>
+<<CollectRelic $relic43>>\
+<<if !setup.passingTime()>>
 
 As the freezing winds rip through your protective gear, you lower your gaze to the small, sparse vegetation around you. Trudging through the bitter cold, you spot a peculiar set of tracks leading to one of the ice mounds. You decide to follow it.
 
@@ -1093,10 +1112,12 @@ Carefully stowing the Sated Artist into your pack, you step back into the brutal
 
 [[Continue searching for the Relics of layer 4|Layer4 Relics]]
 [[Continue exploring the fourth layer|Layer4 Hub]]
+<</if>>
 
 
 :: Pick up the Timekeeper's Keepsake [layer4]
-<<CollectRelic $relic44>>
+<<CollectRelic $relic44>>\
+<<if !setup.passingTime()>>
 
 Off to your left, you notice an anomaly in this frost-bitten world - a giant mechanical sundial, half-buried in the snow, its large gnomon casting a long shadow despite the gloom. Surrounding the sundial are numerous metallic objects, suspended in mid-air, coated in thick ice, as if time had stopped for them eons ago.
 
@@ -1110,28 +1131,34 @@ The cold suddenly seems to bite deeper, a reminder of the hostile environment yo
 
 [[Continue searching for the Relics of layer 4|Layer4 Relics]]
 [[Continue exploring the fourth layer|Layer4 Hub]]
+<</if>>
 
 
 :: Pick up the Creator's Bolt [layer4]
-<<CollectRelic $relic45>>
+<<CollectRelic $relic45>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic45.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 4|Layer4 Relics]]
 [[Continue exploring the fourth layer|Layer4 Hub]]
+<</if>>
 
 
 :: Pick up the Perpetual Repose [layer4]
-<<CollectRelic $relic46>>
+<<CollectRelic $relic46>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic46.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 4|Layer4 Relics]]
 [[Continue exploring the fourth layer|Layer4 Hub]]
+<</if>>
 
 
 :: Pick up the Toral Wave [layer4]
-<<CollectRelic $relic47>>
+<<CollectRelic $relic47>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic47.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -1139,15 +1166,18 @@ A source of electricity like this would be hard to use in combat, but perhaps if
 
 [[Continue searching for the Relics of layer 4|Layer4 Relics]]
 [[Continue exploring the fourth layer|Layer4 Hub]]
+<</if>>
 
 
 :: Pick up the Flamel's Folly [layer4]
-<<CollectRelic $relic48>>
+<<CollectRelic $relic48>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic48.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 4|Layer4 Relics]]
 [[Continue exploring the fourth layer|Layer4 Hub]]
+<</if>>
 
 
 :: Layer4 Travel Events [layer4 nobr]
@@ -1158,12 +1188,7 @@ You have successfully taken the $relic48.name Relic. Hopefully you can make good
 <<PassTime _triggers>>
 
 <<if _triggers.driftingSwallower()>>
-	<<if passage() == "Layer4 Ascend2">>
-		<br>During your long hike back up towards the third layer you hear a great hissing sound, as if a blimp were leaking its helium, fills your ears as a dark form descends on you from above. A monstrous beast floats above your head and unveils its tentacles in preparation of its attempt to shovel you into its enormous maw.<br><br>
-	<</if>>
-	<<if passage() == "Layer4 Exit2">>
-		<br>During your long trip down towards the fifth layer you hear a great hissing sound, as if a blimp were leaking its helium, fills your ears as a dark form descends on you from above. A monstrous beast floats above your head and unveils its tentacles in preparation of its attempt to shovel you into its enormous maw.<br><br>
-	<</if>>
+	<br>A great hissing sound, as if a blimp were leaking its helium, fills your ears as a dark form descends on you from above. A monstrous beast floats above your head and unveils its tentacles in preparation of its attempt to shovel you into its enormous maw.<br><br>
 
 	[[Deal with the Drifting Swallower|Layer4 Threat1][$returnPassage = passage()]]<br>
 <</if>>

--- a/src/layer4.twee
+++ b/src/layer4.twee
@@ -1419,8 +1419,6 @@ Threats:
 
 <<include 'CampCode'>>
 
-[[Return to exploring the layer without waiting|Layer4 Hub]]
-
 :: Layer4 Threat1 [layer4]
 <<set $timeL4T1 -= 7>>
 [img[setup.ImagePath+'Threats/driftingswallower.png']]

--- a/src/layer5.twee
+++ b/src/layer5.twee
@@ -1638,8 +1638,6 @@ Threats:
 
 <<include 'CampCode'>>
 
-[[Return to exploring the layer without waiting|Layer5 Hub]]
-
 :: Layer5 Borer Encounter [nobr]
 
 As you continue your journey through the fifth layer of the Abyss, the perpetual sandstorms whip around you, creating a cacophony of sound that threatens to drown out your thoughts. The swirling sands mix with the vivid hues of the flower petals, creating a kaleidoscope of colors that is both mesmerizing and disorienting. The heavy, fragrant scents of the dry, Miasma-fed flowers fill your nostrils, leaving you feeling simultaneously invigorated and overwhelmed.

--- a/src/layer5.twee
+++ b/src/layer5.twee
@@ -607,7 +607,8 @@ Having dealt with the booby trap, you are able to move forwards freely and obtai
 
 
 :: Pocket Hoard [layer5]
-<<CollectRelic $relic49>>
+<<CollectRelic $relic49>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic49.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -615,10 +616,12 @@ A trip to the One-sided Tunnel might be worthwhile now to empower your new Relic
 
 [[Continue searching for the Relics of layer 5|Layer5 Relics]]
 [[Continue exploring the fifth layer|Layer5 Hub]]
+<</if>>
 
 
 :: Sunbeam [layer5]
-<<CollectRelic $relic50>>
+<<CollectRelic $relic50>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic50.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -626,37 +629,45 @@ This Relic can only see its true potential unleashed in the hands of a skilled s
 
 [[Continue searching for the Relics of layer 5|Layer5 Relics]]
 [[Continue exploring the fifth layer|Layer5 Hub]]
+<</if>>
 
 
 :: Moonwatcher [layer5]
-<<CollectRelic $relic51>>
+<<CollectRelic $relic51>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic51.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 5|Layer5 Relics]]
 [[Continue exploring the fifth layer|Layer5 Hub]]
+<</if>>
 
 
 :: Siren's Call [layer5]
-<<CollectRelic $relic52>>
+<<CollectRelic $relic52>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic52.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 5|Layer5 Relics]]
 [[Continue exploring the fifth layer|Layer5 Hub]]
+<</if>>
 
 
 :: Zelus Band [layer5]
-<<CollectRelic $relic53>>
+<<CollectRelic $relic53>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic53.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 5|Layer5 Relics]]
 [[Continue exploring the fifth layer|Layer5 Hub]]
+<</if>>
 
 
 :: Everhevea [layer5]
-<<CollectRelic $relic54>>
+<<CollectRelic $relic54>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic54.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -664,40 +675,46 @@ The Everhevea can be used as 2 flasks for as long as you hold it, so at the very
 
 [[Continue searching for the Relics of layer 5|Layer5 Relics][$items[2].count+=2]]
 [[Continue exploring the fifth layer|Layer5 Hub][$items[2].count+=2]]
+<</if>>
 
 
 :: Reflex Emblem [layer5]
-<<CollectRelic $relic55>>
+<<CollectRelic $relic55>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic55.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 5|Layer5 Relics]]
 [[Continue exploring the fifth layer|Layer5 Hub]]
+<</if>>
 
 
 :: Twin Polaris [layer5]
-<<CollectRelic $relic56>>
+<<CollectRelic $relic56>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic56.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 5|Layer5 Relics]]
 [[Continue exploring the fifth layer|Layer5 Hub]]
+<</if>>
 
 
 :: Superpositional Skewer [layer5]
-<<CollectRelic $relic57>>
+<<CollectRelic $relic57>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic57.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 5|Layer5 Relics]]
 [[Continue exploring the fifth layer|Layer5 Hub]]
+<</if>>
 
 
 :: Empath Coil [layer5]
-<<nobr>>
+<<CollectRelic $relic58>>\
+<<if !setup.passingTime()>>\
 <<if !$slingshot>><<set $items[20].count -= 1>><</if>>
-<<CollectRelic $relic58>>
-<</nobr>>
 
 You have successfully taken the $relic58.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -705,24 +722,29 @@ This may be able to channel electricity, but without a source that ability is no
 
 [[Continue searching for the Relics of layer 5|Layer5 Relics]]
 [[Continue exploring the fifth layer|Layer5 Hub]]
+<</if>>
 
 
 :: Heavenly Merrymaker [layer5]
-<<CollectRelic $relic59>>
+<<CollectRelic $relic59>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic59.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 5|Layer5 Relics]]
 [[Continue exploring the fifth layer|Layer5 Hub]]
+<</if>>
 
 
 :: Vain Sculpt [layer5]
-<<CollectRelic $relic60>>
+<<CollectRelic $relic60>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic60.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 5|Layer5 Relics]]
 [[Continue exploring the fifth layer|Layer5 Hub]]
+<</if>>
 
 
 :: Take on Libido Reinforcement D [layer5]

--- a/src/layer5.twee
+++ b/src/layer5.twee
@@ -339,7 +339,7 @@ Already taken
 @@.unreachable;Located in a dark, sealed chamber with a light-activated lock. Requires a source of light.@@
 <<elseif _name === "Twin Polaris" && setup.carriedWeight + $hiredCompanions.length * 60 < 90>>
 @@.unreachable;Located in a sealed chamber locked by a pressure switch that must be held down with 90 kg of weight. The weight you and your companions can currently put on the switch is only <<print (setup.carriedWeight + $hiredCompanions.length * 60).toFixed(1)>> kg.@@
-<<elseif _name === "Empath Coil" && ($items[20].count < 1 || $items[13].count < 1) && $slingshot == 0>>
+<<elseif _name === "Empath Coil" && !$slingshot && (!setup.item('Pistol').count || setup.item('Pistol Bullets').count < 1)>>
 @@.unreachable;Located in a sealed chamber locked by a switch on the ceiling, far out of reach. Can be hit with a pistol, using 1 bullet.@@
 <<else>>
 <<print "[[Pick up the " + _name + "|Layer5 Booby][$temp = " + (_i + 1) + ", $booby = " + (_i % 3 + 1) + "]]">>
@@ -712,9 +712,9 @@ You have successfully taken the $relic57.name Relic. Hopefully you can make good
 
 
 :: Empath Coil [layer5]
+<<if !setup.passingTime() && !$slingshot>><<set setup.item('Pistol Bullets').count -= 1>><</if>>\
 <<CollectRelic $relic58>>\
-<<if !setup.passingTime()>>\
-<<if !$slingshot>><<set $items[20].count -= 1>><</if>>
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic58.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 

--- a/src/layer6.twee
+++ b/src/layer6.twee
@@ -306,7 +306,8 @@ You may pick up a copy of an old Relic for 20 dubloons and 2x its corruption cos
 
 
 :: Pick up the Ring of the Devourer [layer6]
-<<CollectRelic $relic61>>
+<<CollectRelic $relic61>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic61.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -314,37 +315,45 @@ Note: This Relic's functionality is not currently implemented.
 
 [[Continue searching for the Relics of layer 6|Layer6 Relics]]
 [[Continue exploring the sixth layer|Layer6 Hub]]
+<</if>>
 
 
 :: Pick up the Pulse Bloom [layer6]
-<<CollectRelic $relic62>>
+<<CollectRelic $relic62>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic62.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 6|Layer6 Relics]]
 [[Continue exploring the sixth layer|Layer6 Hub]]
+<</if>>
 
 
 :: Pick up the Out of Mind [layer6]
-<<CollectRelic $relic63>>
+<<CollectRelic $relic63>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic63.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 6|Layer6 Relics]]
 [[Continue exploring the sixth layer|Layer6 Hub]]
+<</if>>
 
 
 :: Pick up the Still Film [layer6]
-<<CollectRelic $relic64>>
+<<CollectRelic $relic64>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic64.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 6|Layer6 Relics]]
 [[Continue exploring the sixth layer|Layer6 Hub]]
+<</if>>
 
 
 :: Pick up the Forbidden Grimoire [layer6]
-<<CollectRelic $relic65>>
+<<CollectRelic $relic65>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic65.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -352,69 +361,84 @@ You can use this to improve the boons granted by your companions one time, choos
 
 [[Continue searching for the Relics of layer 6|Layer6 Relics]]
 [[Continue exploring the sixth layer|Layer6 Hub]]
+<</if>>
 
 
 :: Pick up the Luminous Phantasmagoria [layer6]
-<<CollectRelic $relic66>>
+<<CollectRelic $relic66>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic66.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 6|Layer6 Relics]]
 [[Continue exploring the sixth layer|Layer6 Hub]]
+<</if>>
 
 
 :: Pick up the Relativity Eye [layer6]
-<<CollectRelic $relic67>>
+<<CollectRelic $relic67>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic67.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 6|Layer6 Relics]]
 [[Continue exploring the sixth layer|Layer6 Hub]]
+<</if>>
 
 
 :: Pick up the Return to Sender [layer6]
-<<CollectRelic $relic68>>
+<<CollectRelic $relic68>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic68.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 6|Layer6 Relics]]
 [[Continue exploring the sixth layer|Layer6 Hub]]
+<</if>>
 
 
 :: Pick up the Yliaster Materia [layer6]
-<<CollectRelic $relic69>>
+<<CollectRelic $relic69>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic69.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 6|Layer6 Relics]]
 [[Continue exploring the sixth layer|Layer6 Hub]]
+<</if>>
 
 
 :: Pick up the Aeonglass [layer6]
-<<CollectRelic $relic70>>
+<<CollectRelic $relic70>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic70.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 6|Layer6 Relics]]
 [[Continue exploring the sixth layer|Layer6 Hub]]
+<</if>>
 
 
 :: Pick up the Apparatus Diaboli [layer6]
-<<CollectRelic $relic71>>
+<<CollectRelic $relic71>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic71.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 6|Layer6 Relics]]
 [[Continue exploring the sixth layer|Layer6 Hub]]
+<</if>>
 
 
 :: Pick up the Heavy is the Head [layer6]
-<<CollectRelic $relic72>>
+<<CollectRelic $relic72>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic72.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 6|Layer6 Relics]]
 [[Continue exploring the sixth layer|Layer6 Hub]]
+<</if>>
 
 
 :: Take on Submissiveness Rectification B [layer6]

--- a/src/layer6.twee
+++ b/src/layer6.twee
@@ -1084,8 +1084,6 @@ Threats:
 
 <<include 'CampCode'>>
 
-[[Return to exploring the layer without waiting|Layer6 Hub]]
-
 
 :: Layer6 Tentacle Encounter [layer6 nobr]
 

--- a/src/layer7.twee
+++ b/src/layer7.twee
@@ -1573,8 +1573,6 @@ You have worked $temp1 days and brought robots to artificial orgasm $temp2 times
 
 <<include 'CampCode'>>
 
-[[Return to exploring the layer without waiting|Layer7 Hub]]
-
 :: Layer7 Threat2 [layer7]
 <<nobr>>
 <<set $timeL7T2 -= 6>>

--- a/src/layer7.twee
+++ b/src/layer7.twee
@@ -341,9 +341,9 @@ You have successfully taken the $relic73.name Relic. Hopefully you can make good
 
 
 :: Pick up the Blind Divine [layer7]
+<<if !setup.passingTime() && !$slingshot>><<set setup.item('Pistol Bullets').count -= 4>><</if>>\
 <<CollectRelic $relic74>>\
-<<if !setup.passingTime()>>\
-<<if !$slingshot>><<set $items[20].count -= 4>><</if>>
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic74.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 

--- a/src/layer7.twee
+++ b/src/layer7.twee
@@ -1352,7 +1352,7 @@ You have no choice, you gain consciousness a few times to see yourself in a surg
 
 <<PassTime _triggers>>
 
-<<if _triggers.inDebt() && $easymode>>
+<<if _triggers.inDebt()>>
 	<br>[img[setup.ImagePath+'Threats/taxdrone.png']]<br><br>
 
 	<br>A quiet humming sound descends upon you as you see the Taxdrone floating towards you from over a nearby building. You reach into your pack to get your typical dubloon payment, but then you realize something is wrong, you can't find any dubloons! Perhaps you didn't keep track of them properly? But it's too late to get any now, the taxes are already due.<br><br>
@@ -1361,24 +1361,18 @@ You have no choice, you gain consciousness a few times to see yourself in a surg
 
 	Within a moment you are restrained by nets made of light and you feel a prick on your neck. You notice the drone has stabbed you with a syringe, but at this point it's too late to resist and your consciousness begins to fade, leaving you to succumb to your fate.<br><br>
 
-	As you awaken later that day you feel your entire body still aching. However, the Taxdrone is nowhere to be found and you feel like you escaped a terrible fate.<br><br>
+	<<if $easymode>>
+		As you awaken later that day you feel your entire body still aching. However, the Taxdrone is nowhere to be found and you feel like you escaped a terrible fate.<br><br>
 
-	<<link "Continue your journey" `passage()`>><</link>><br><br>
-	<<set $status.penalty += 2>>
-	<<set $status.duration += 1>>
-	<<set $dubloons = 3>>
-<<elseif _triggers.inDebt() && !$easymode>>
-	<br>[img[setup.ImagePath+'Threats/taxdrone.png']]<br><br>
+		<<link "Continue your journey" `passage()`>><</link>><br><br>
+		<<set $status.penalty += 2>>
+		<<set $status.duration += 1>>
+		<<set $dubloons = 3>>
+	<<else>>
+		You are now forced to become a permanent resident of Layer 7.<br><br>
 
-	<br>A quiet humming sound descends upon you as you see the Taxdrone floating towards you from over a nearby building. You reach into your pack to get your typical dubloon payment, but then you realize something is wrong, you can't find any dubloons! Perhaps you didn't keep track of them properly? But it's too late to get any now, the taxes are already due.<br><br>
-
-	The Taxdrone patiently requests that you submit your taxes as it displays a slot for you to deposit the dubloons into, but soon it realizes you will not be paying and the typically soft blue lights on the drone change to glaring red and an alarm sounds.<br><br>
-
-	Within a moment you are restrained by nets made of light and you feel a prick on your neck. You notice the drone has stabbed you with a syringe, but at this point it's too late to resist and your consciousness begins to fade, leaving you to succumb to your fate.<br><br>
-
-	You are now forced to become a permanent resident of Layer 7.<br><br>
-
-	[[Awaken to your new life|Layer7 Tax End]]<br><br>
+		[[Awaken to your new life|Layer7 Tax End]]<br><br>
+	<</if>>
 <<elseif _triggers.rehabilitated()>>
 	<br>A an enormous rumbling catches your attention as you walk through the seventh layer. A brief glance around reveals the source, an enormous, building-sized machine that is now rapidly approaching you. You consider running, but the Security Robot is moving at an incredible speed, leaving you no chance to get away. <br><br>
 

--- a/src/layer7.twee
+++ b/src/layer7.twee
@@ -330,19 +330,20 @@ If you're not dissuaded and choose to continue onward, it will take you 8 days t
 
 
 :: Pick up the Daedalus Mechanism [layer7]
-<<CollectRelic $relic73>>
+<<CollectRelic $relic73>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic73.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 7|Layer7 Relics]]
 [[Continue exploring the seventh layer|Layer7 Hub]]
+<</if>>
 
 
 :: Pick up the Blind Divine [layer7]
-<<nobr>>
+<<CollectRelic $relic74>>\
+<<if !setup.passingTime()>>\
 <<if !$slingshot>><<set $items[20].count -= 4>><</if>>
-<<CollectRelic $relic74>>
-<</nobr>>
 
 You have successfully taken the $relic74.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -350,10 +351,12 @@ This Relic grants you the ability to see in any dark place, removing the need fo
 
 [[Continue searching for the Relics of layer 7|Layer7 Relics]]
 [[Continue exploring the seventh layer|Layer7 Hub]]
+<</if>>
 
 
 :: Pick up the Lambent Specter [layer7]
-<<CollectRelic $relic75>>
+<<CollectRelic $relic75>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic75.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -361,46 +364,56 @@ This Relic grants you the power to create a golem, a steadfast and loyal compani
 
 [[Continue searching for the Relics of layer 7|Layer7 Relics]]
 [[Continue exploring the seventh layer|Layer7 Hub]]
+<</if>>
 
 
 :: Pick up the Phoenix Obol [layer7]
-<<CollectRelic $relic76>>
+<<CollectRelic $relic76>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic76.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 7|Layer7 Relics]]
 [[Continue exploring the seventh layer|Layer7 Hub]]
+<</if>>
 
 
 :: Pick up the Granted Granite [layer7]
-<<CollectRelic $relic77>>
+<<CollectRelic $relic77>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic77.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 7|Layer7 Relics]]
 [[Continue exploring the seventh layer|Layer7 Hub]]
+<</if>>
 
 
 :: Pick up the Joyous Sunder [layer7]
-<<CollectRelic $relic78>>
+<<CollectRelic $relic78>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic78.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 7|Layer7 Relics]]
 [[Continue exploring the seventh layer|Layer7 Hub]]
+<</if>>
 
 
 :: Pick up the Azure Aozora [layer7]
-<<CollectRelic $relic79>>
+<<CollectRelic $relic79>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic79.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 7|Layer7 Relics]]
 [[Continue exploring the seventh layer|Layer7 Hub]]
+<</if>>
 
 
 :: Pick up the Glare Vantage [layer7]
-<<CollectRelic $relic80>>
+<<CollectRelic $relic80>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic80.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -408,19 +421,23 @@ If you don't already have a source of light, the Glare Vantage will provide you 
 
 [[Continue searching for the Relics of layer 7|Layer7 Relics]]
 [[Continue exploring the seventh layer|Layer7 Hub]]
+<</if>>
 
 
 :: Pick up the Final Stage [layer7]
-<<CollectRelic $relic81>>
+<<CollectRelic $relic81>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic81.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 7|Layer7 Relics]]
 [[Continue exploring the seventh layer|Layer7 Hub]]
+<</if>>
 
 
 :: Pick up the Solace Lace [layer7]
-<<CollectRelic $relic82>>
+<<CollectRelic $relic82>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic82.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -428,24 +445,29 @@ This Relic provides you with comfort in the cold to reduce travel times by 2 day
 
 [[Continue searching for the Relics of layer 7|Layer7 Relics]]
 [[Continue exploring the seventh layer|Layer7 Hub]]
+<</if>>
 
 
 :: Pick up the Red Thread Flourish [layer7]
-<<CollectRelic $relic83>>
+<<CollectRelic $relic83>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic83.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 7|Layer7 Relics]]
 [[Continue exploring the seventh layer|Layer7 Hub]]
+<</if>>
 
 
 :: Pick up the Triage Rain [layer7]
-<<CollectRelic $relic84>>
+<<CollectRelic $relic84>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic84.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 7|Layer7 Relics]]
 [[Continue exploring the seventh layer|Layer7 Hub]]
+<</if>>
 
 
 :: Layer7Time

--- a/src/layer8.twee
+++ b/src/layer8.twee
@@ -2627,5 +2627,3 @@ You wait as your balloon rapidly ascends and you can watch the metallic building
 :: Layer8 Camp
 
 <<include 'CampCode'>>
-
-[[Return to exploring the layer without waiting|Layer8 Hub]]

--- a/src/layer8.twee
+++ b/src/layer8.twee
@@ -654,7 +654,7 @@ In this moment, you look forward, your mind already wrestling with the implicati
 How many eyes do you want to remove?
 
 <<radiobutton "$eyeRemove" 1 checked>> One 
-<<if ~$BionicEye>>
+<<if !$BionicEye>>
 	<<radiobutton "$eyeRemove" 2 >> Two
 <</if>>
 
@@ -819,7 +819,7 @@ Which limbs do you want to amputate?
 	<<radiobutton "$curse104.variation" 'LL' >> Both legs
 	<<radiobutton "$curse104.variation" 'ALL' >> An arm and both legs
 <</if>>\
-<<if ~$BionicArm>>\
+<<if !$BionicArm>>\
 	<<radiobutton "$curse104.variation" 'AA' >> Both arms
 	<<if !$playerCurses.some(e => e.name === "Seafolk")>>\
 		<<radiobutton "$curse104.variation" 'AAL' >> Both arms and a leg

--- a/src/layer8.twee
+++ b/src/layer8.twee
@@ -360,7 +360,7 @@ There is a very easily accessible source of water on this layer, the Lethe Taps,
 		<<radiobutton "$ammoStrat" 1 >> Use your ammo only when absolutely necessary <br>
 		<<radiobutton "$ammoStrat" 2 >> Use your ammo when tactically useful <br>
 		<<radiobutton "$ammoStrat" 4 >> Shoot at anything that moves <br>
-		<<if $slingshot && ~$hiredCompanions.some(e => e.name === "Cloud")>>
+		<<if $slingshot && !$hiredCompanions.some(e => e.name === "Cloud")>>
 			<<radiobutton "$ammoStrat" 4 >> Just use the modified Brave Vector as much as you can, so you can shoot without having to use any bullets  <br>
 		<<elseif $slingshot>>
 			<<radiobutton "$cloudStrat" 1>> Just use the modified Brave Vector as much as you can, while you ask Cloud to use the gun sparingly.  <br>

--- a/src/layer8.twee
+++ b/src/layer8.twee
@@ -398,7 +398,8 @@ You can consider your equipment, allies, and general health to take into account
 <</if>>
 
 :: Pick up the Voila Viola [layer8]
-<<CollectRelic $relic85>>
+<<CollectRelic $relic85>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic85.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -406,46 +407,56 @@ This may be useful against certain aquatic or aqueous enemies, if you can use it
 
 [[Continue searching for the Relics of layer 8|Layer8 Relics]]
 [[Continue exploring the eighth layer|Layer8 Hub]]
+<</if>>
 
 
 :: Pick up the Between Whispers [layer8]
-<<CollectRelic $relic86>>
+<<CollectRelic $relic86>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic86.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 8|Layer8 Relics]]
 [[Continue exploring the eighth layer|Layer8 Hub]]
+<</if>>
 
 
 :: Pick up the Absolute Oracle [layer8]
-<<CollectRelic $relic87>>
+<<CollectRelic $relic87>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic87.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 8|Layer8 Relics]]
 [[Continue exploring the eighth layer|Layer8 Hub]]
+<</if>>
 
 
 :: Pick up the Memory Reign [layer8]
-<<CollectRelic $relic88>>
+<<CollectRelic $relic88>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic88.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 8|Layer8 Relics]]
 [[Continue exploring the eighth layer|Layer8 Hub]]
+<</if>>
 
 
 :: Pick up the Drifting Aperture [layer8]
-<<CollectRelic $relic89>>
+<<CollectRelic $relic89>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic89.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 8|Layer8 Relics]]
 [[Continue exploring the eighth layer|Layer8 Hub]]
+<</if>>
 
 
 :: Pick up the Aegis Coffin [layer8]
-<<CollectRelic $relic90>>
+<<CollectRelic $relic90>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic90.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -453,19 +464,23 @@ By laying within this otherworldly Relic, you can undergo a miraculous transform
 
 [[Continue searching for the Relics of layer 8|Layer8 Relics]]
 [[Continue exploring the eighth layer|Layer8 Hub]]
+<</if>>
 
 
 :: Pick up the Gaia Theory [layer8]
-<<CollectRelic $relic91>>
+<<CollectRelic $relic91>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic91.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 8|Layer8 Relics]]
 [[Continue exploring the eighth layer|Layer8 Hub]]
+<</if>>
 
 
 :: Pick up the Glory's Grasp[layer8]
-<<CollectRelic $relic92>>
+<<CollectRelic $relic92>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic92.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -473,10 +488,12 @@ If your arm is lost, you can use this Relic to overcome the handicap and use thi
 
 [[Continue searching for the Relics of layer 8|Layer8 Relics]]
 [[Continue exploring the eighth layer|Layer8 Hub]]
+<</if>>
 
 
 :: Pick up the Pneuma Wisp [layer8]
-<<CollectRelic $relic93>>
+<<CollectRelic $relic93>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic93.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
@@ -484,33 +501,40 @@ This Relic should let you reach anything that requires scuba gear any allow you 
 
 [[Continue searching for the Relics of layer 8|Layer8 Relics]]
 [[Continue exploring the eighth layer|Layer8 Hub]]
+<</if>>
 
 
 :: Pick up the World's End Lock [layer8]
-<<CollectRelic $relic94>>
+<<CollectRelic $relic94>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic94.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 8|Layer8 Relics]]
 [[Continue exploring the eighth layer|Layer8 Hub]]
+<</if>>
 
 
 :: Pick up the Fray Goo [layer8]
-<<CollectRelic $relic95>>
+<<CollectRelic $relic95>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic95.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 8|Layer8 Relics]]
 [[Continue exploring the eighth layer|Layer8 Hub]]
+<</if>>
 
 
 :: Pick up the Null Void [layer8]
-<<CollectRelic $relic96>>
+<<CollectRelic $relic96>>\
+<<if !setup.passingTime()>>
 
 You have successfully taken the $relic96.name Relic. Hopefully you can make good use of it and make it worth that corruption cost.
 
 [[Continue searching for the Relics of layer 8|Layer8 Relics]]
 [[Continue exploring the eighth layer|Layer8 Hub]]
+<</if>>
 
 
 :: Layer8 Curses  [layer8 cards nobr]

--- a/src/layer9.twee
+++ b/src/layer9.twee
@@ -372,5 +372,3 @@ Threats:
 :: Layer9 Camp
 
 <<include 'CampCode'>>
-
-[[Return to exploring the layer without waiting|Layer9 Hub]]

--- a/src/relics.twee
+++ b/src/relics.twee
@@ -1650,7 +1650,7 @@ The one supernatural effect not cancelled is the unbreakability of Eternal Repos
         @@.unreachable;Found in a chest at the bottom of a very deep pool of...tentacle slime? Gross. You'll need diving gear to breathe long enough to reach it. Don't drink the tentacle slime, please.@@
     <<elseif _name === "Phoenix Obol" && !setup.havePotentialLightSource>>
         @@.unreachable;Located in a sealed, dark vault with a light-activated lock. Requires a source of light.@@
-    <<elseif _name === "Blind Divine" && $items[13].count == 0 && $items[20].count < 4 && $slingshot == 0>>
+    <<elseif _name === "Blind Divine" && !$slingshot && (!setup.item('Pistol').count || setup.item('Pistol Bullets').count < 4)>>
         @@.unreachable;Located in a vault sealed by 4 out-of-reach switches. Can be reached with bullets, expending 4 in the process. Even Cloud can't decrease this count; he can't make a bullet go in two directions at once.@@
     <<elseif _name === "Granted Granite" && setup.carriedWeight + $hiredCompanions.length * 60 < 200>>
         @@.unreachable;Located in a vault sealed by a pressure switch that requires 200 kg to remain pressed. The weight you and your companions can currently put on the switch is only <<print (setup.carriedWeight + $hiredCompanions.length * 60).toFixed(1)>> kg.@@

--- a/src/widgets.twee
+++ b/src/widgets.twee
@@ -3014,13 +3014,19 @@
 
 :: Collect Relic widget [widget nobr]
 <<widget "CollectRelic">>
-<<capture _relic>>
+<<capture _relic _travelTime>>
 	<<set _relic = _args[0]>>
-	<<set $ownedRelics.push(_relic)>>
-	<<AdjustedTravelTime "$tempTime" _relic.time false `-$SibylBuff`>><<PassTime $tempTime>>
-	<<set $corruption -= Math.max(_relic.corr - $corRed + ($currentLayer != 6 ? 5 * Math.trunc($hexflame / 10) : 0), 0)>>
-	<<if _relic.pic>>
-		[img[setup.ImagePath + _relic.pic]]<br>
+	<<if !setup.passingTime()>>
+		<<AdjustedTravelTime "_travelTime" _relic.time false `-$SibylBuff`>>
+		<<set setup.startPassingTime(_travelTime)>>
+	<</if>>
+	<<include `"Layer" + $currentLayer + " Travel Events"`>>
+	<<if !setup.passingTime()>>
+		<<set $ownedRelics.push(_relic)>>
+		<<set $corruption -= Math.max(_relic.corr - $corRed + ($currentLayer != 6 ? 5 * Math.trunc($hexflame / 10) : 0), 0)>>
+		<<if _relic.pic>>
+			[img[setup.ImagePath + _relic.pic]]<br>
+		<</if>>
 	<</if>>
 <</capture>>
 <</widget>>

--- a/src/widgets.twee
+++ b/src/widgets.twee
@@ -132,7 +132,7 @@
 		<</if>>
 		<<set _due = $due>>
 
-		<<if  ($time - $app.pregnantT> 270 & $time - $app.pregnantT<=$due) || ($time - $menCycleT < -30 && $menCycleFlag == true)>>
+		<<if  ($time - $app.pregnantT> 270 && $time - $app.pregnantT<=$due) || ($time - $menCycleT < -30 && $menCycleFlag == true)>>
 			<<set _handle.lactation += 2>>
 		<</if>>
 
@@ -150,13 +150,13 @@
 		<</if>>
 	<</if>>
 	<<if _handle.pregnantT != 9999>>
-		<<if $time - _handle.pregnantT>= 90 & $time - _tempPreg<=130 >>
+		<<if $time - _handle.pregnantT>= 90 && $time - _tempPreg<=130 >>
 			<<set _handle.breastsCor += 0.5>>
-		<<elseif $time - _handle.pregnantT> 130 & $time - _tempPreg<=180 >>
+		<<elseif $time - _handle.pregnantT> 130 && $time - _tempPreg<=180 >>
 			<<set _handle.breastsCor += 1>>
-		<<elseif $time - _handle.pregnantT> 180 & $time - _tempPreg<=240>>
+		<<elseif $time - _handle.pregnantT> 180 && $time - _tempPreg<=240>>
 			<<set _handle.breastsCor += 1.5>>
-		<<elseif $time - _handle.pregnantT> 240 & $time - _tempPreg<=_due>>
+		<<elseif $time - _handle.pregnantT> 240 && $time - _tempPreg<=_due>>
 			<<set _handle.lactation += 1>> 
 			<<set _handle.breastsCor += 1>>
 		<</if>>
@@ -623,7 +623,7 @@
 		<<print "<<set _handle  = $companion"+ _tempName +" >>">>
 	<</if>>
 
-	<<if $time - _tempPreg>= 90 & $time - _tempPreg<=_due >>
+	<<if $time - _tempPreg>= 90 && $time - _tempPreg<=_due >>
 		<<set _handle.gender += 1>>
 	<</if>>
 	<<include "BreastCorrected">>
@@ -780,9 +780,9 @@
 	<</for>>
 	
 	<<if _i==$hiredCompanions.length>>
-		<<if $time-$menCycleT<16 & $time-$menCycleT>=13>>
+		<<if $time-$menCycleT<16 && $time-$menCycleT>=13>>
 			<<set $app.libido += 1>>
-		<<elseif $time-$menCycleT<25 & $time-$menCycleT>=20>>
+		<<elseif $time-$menCycleT<25 && $time-$menCycleT>=20>>
 			<<set $app.libido -= 1>>
 		<</if>>
 
@@ -1350,21 +1350,21 @@
 			<<set _handle.HandicapThreat -=2>>
 		<</if>>
 
-		<<if $time - $app.pregnantT< 45 & $time - $app.pregnantT>= 35>>
+		<<if $time - $app.pregnantT< 45 && $time - $app.pregnantT>= 35>>
 			<<set _handle.HandicapMovement -=2>>
-		<<elseif $time - $app.pregnantT< 90 & $time - $app.pregnantT>= 45>>
+		<<elseif $time - $app.pregnantT< 90 && $time - $app.pregnantT>= 45>>
 			<<set _handle.HandicapThreat -=2>>
 			<<set _handle.HandicapMovement -=4>>
 			<<set _handle.HandicapCarry -=3>>
-		<<elseif $time - $app.pregnantT< 180 & $time - $app.pregnantT>= 120>>
+		<<elseif $time - $app.pregnantT< 180 && $time - $app.pregnantT>= 120>>
 			<<set _handle.HandicapThreat -=1>>
 			<<set _handle.HandicapMovement -=2>>
 			<<set _handle.HandicapCarry -=2>>
-		<<elseif $time - $app.pregnantT< 240 & $time - $app.pregnantT>=180>>
+		<<elseif $time - $app.pregnantT< 240 && $time - $app.pregnantT>=180>>
 			<<set _handle.HandicapThreat -=2>>
 			<<set _handle.HandicapMovement -=3>>
 			<<set _handle.HandicapCarry -=3>>
-		<<elseif $time - $app.pregnantT< $due & $time - $app.pregnantT>=240>>
+		<<elseif $time - $app.pregnantT< $due && $time - $app.pregnantT>=240>>
 			<<set _handle.HandicapThreat -=4>>
 			<<set _handle.HandicapMovement -=5>>
 			<<set _handle.HandicapCarry -=5>>
@@ -2134,9 +2134,9 @@
 			<<set $menstruating = true>>
 		<</if>>
 		<<set $pregChance = 0>>
-	<<elseif $menFirstCycle == false & $time-$menCycleT>28 >>
+	<<elseif $menFirstCycle == false && $time-$menCycleT>28 >>
 		@@.alert1; You expected your cycle to have started by now, but it hasn't. Still, there's no need to worry – periods can be late, right?<br><br>
-	<<elseif $time-$menCycleT<5 & $time-$menCycleT>0 & $menstruating == true>>
+	<<elseif $time-$menCycleT<5 && $time-$menCycleT>0 && $menstruating == true>>
 		<<if !settings.MenCycleToggleFilter>>
 			<<if $menFirstCycle == true>>
 				<<if $EventHorizonWear== false>>
@@ -2158,16 +2158,16 @@
 			<</if>>
 		<</if>>
 		<<set $pregChance = 0>>
-	<<elseif $time-$menCycleT<9 & $time-$menCycleT>=5>>
+	<<elseif $time-$menCycleT<9 && $time-$menCycleT>=5>>
 		<<set $menstruating == false>>
 		<<set $pregChance = 0>>
-	<<elseif $time-$menCycleT<13 & $time-$menCycleT>=9>>
+	<<elseif $time-$menCycleT<13 && $time-$menCycleT>=9>>
 		<<set $menstruating == false>>
 		<<set $pregChance = ($time-$menCycleT-8)*0.06>>
-	<<elseif $time-$menCycleT<16 & $time-$menCycleT>=13>>
+	<<elseif $time-$menCycleT<16 && $time-$menCycleT>=13>>
 		<<set $menstruating == false>>
 		<<set $pregChance = 0.3>>
-	<<elseif $time-$menCycleT<18 & $time-$menCycleT>=16>>
+	<<elseif $time-$menCycleT<18 && $time-$menCycleT>=16>>
 		<<set $menstruating == false>>
 		<<set $pregChance = 0.3-($time-$menCycleT-15)*0.1>>
 	<<else>>	
@@ -2183,11 +2183,11 @@
 <</if>>
 
 <<if $app.pregnantT <= $time - 14>>
-	<<if $time - $app.pregnantT < 35 & $time - $app.pregnantT >= 28 & $menFirstCycle == false>>
+	<<if $time - $app.pregnantT < 35 && $time - $app.pregnantT >= 28 && $menFirstCycle == false>>
 		@@.alert1; Your heart races as you realize your cycle should have started by now. Perhaps it's simply late, no need to panic just yet, right? The uncertainty lingers.<br><br>
-	<<elseif $time - $app.pregnantT < 45 & $time - $app.pregnantT >= 35 & $menFirstCycle == false>>
+	<<elseif $time - $app.pregnantT < 45 && $time - $app.pregnantT >= 35 && $menFirstCycle == false>>
 		@@.alert1; Anxiety creeps in as your period remains conspicuously absent. This lateness is unusual for you, and the thought of pregnancy begins to haunt your mind.<br><br>
-	<<elseif $time - $app.pregnantT < 90 & $time - $app.pregnantT >= 45 && $random == 0>>
+	<<elseif $time - $app.pregnantT < 90 && $time - $app.pregnantT >= 45 && $random == 0>>
 		@@.alert1; You find yourself overwhelmed by exhaustion, and bouts of nausea threaten to topple you. This isn't ideal for your travels or facing any threats.
 		<<if $menFirstCycle == false>>
 			@@.alert1; The truth is undeniable – you're pregnant. Now, you must decide what to do next.
@@ -2195,17 +2195,17 @@
 			@@.alert1; The miasma could be causing some sort of illness. Maybe it will pass, or perhaps you need medical attention.
 		<</if>>
 		<br><br>
-	<<elseif $time - $app.pregnantT < 120 & $time - $app.pregnantT >= 90 & $menFirstCycle == false && $random == 0>>
+	<<elseif $time - $app.pregnantT < 120 && $time - $app.pregnantT >= 90 && $menFirstCycle == false && $random == 0>>
 		@@.alert1; Your pregnancy occupies your thoughts, but aside from that, you feel relatively fine. You notice your breasts and butt have grown a little, and a hint of fatigue lingers, but there's nothing too concerning.<br><br>
-	<<elseif $time - $app.pregnantT < 180 & $time - $app.pregnantT >= 120 & $menFirstCycle == false && $random == 0>>
+	<<elseif $time - $app.pregnantT < 180 && $time - $app.pregnantT >= 120 && $menFirstCycle == false && $random == 0>>
 		@@.alert1; Your pregnancy belly is now round and prominent. You occasionally feel a gentle kick from within, but your growing belly begins to hinder your travels more and more.<br><br>
-	<<elseif $time - $app.pregnantT < 180 & $time - $app.pregnantT >= 120 & $menFirstCycle == true && $random == 0>>
-		@@.alert1; You've gained considerable weight, especially around your belly, which sometimes experiences a peculiar tickling sensation. Your butt, thighs, and <<if $app.breastsCor<3 & $app.sex=="male">>pecs<<else>>breasts<</if>> have also accumulated some fat. This extra weight will slow you down during your travels.<br><br>
-	<<elseif $time - $app.pregnantT < 240 & $time - $app.pregnantT >=180 & $menFirstCycle == false && $random == 0>>
+	<<elseif $time - $app.pregnantT < 180 && $time - $app.pregnantT >= 120 && $menFirstCycle == true && $random == 0>>
+		@@.alert1; You've gained considerable weight, especially around your belly, which sometimes experiences a peculiar tickling sensation. Your butt, thighs, and <<if $app.breastsCor<3 && $app.sex=="male">>pecs<<else>>breasts<</if>> have also accumulated some fat. This extra weight will slow you down during your travels.<br><br>
+	<<elseif $time - $app.pregnantT < 240 && $time - $app.pregnantT >=180 && $menFirstCycle == false && $random == 0>>
 		@@.alert1; It's impossible to deny your pregnancy now. Your child's movements inside your swollen belly have become more frequent. But the added weight and energy-draining nature of pregnancy make navigating the Abyss increasingly difficult.<br><br>
-	<<elseif $time - $app.pregnantT < 240 & $time - $app.pregnantT >=180 & $menFirstCycle == true && $random == 0>>
+	<<elseif $time - $app.pregnantT < 240 && $time - $app.pregnantT >=180 && $menFirstCycle == true && $random == 0>>
 		@@.alert1; You can no longer ignore the truth – you're pregnant and have been for some time. Your child's movements within your belly are unmistakable. Your energy is drained more quickly than usual, whether from the added weight or the pregnancy itself. With a large, round belly and about half your normal energy, navigating the Abyss has become significantly more challenging.<br><br>
-	<<elseif $time - $app.pregnantT < $due & $time - $app.pregnantT >=240 && $random == 0>>
+	<<elseif $time - $app.pregnantT < $due && $time - $app.pregnantT >=240 && $random == 0>>
 		@@.alert2; Your advanced pregnancy has made even simple tasks feel like monumental challenges. Standing, sitting, bending, and sleeping require great effort. Walking is limited to short distances, while running and fighting are out of the question. Milk stains from your breasts mar your clothes, reminding you of your impending labor. Your ability to traverse the Abyss is severely limited. Ensure you have enough supplies for the days you'll be immobilized after giving birth!<br><br>
 	<</if>>
 <</if>>
@@ -2302,7 +2302,7 @@
 <<widget "PregCheck">>
 <<set _temp = random(0,100)>>
 
-<<if _temp <= $pregChance*100 & $app.pregnantT==9999 & $menCycleFlag == true >>
+<<if _temp <= $pregChance*100 && $app.pregnantT==9999 && $menCycleFlag == true >>
 	<<if  $playerCurses.some(e => e.name === "Eggxellent")>>
 		<<set $EggsFertilized = true>>
 	<<else>>


### PR DESCRIPTION
This makes it possible for timed events to trigger during a relic hunt (before picking up the relic) and while camping (before returning to the hub)!

Also 2 minor changes:
* Deduplicated the shared parts of the layer 7 taxdrone event.
* Changed the text for the layer 4 threat to the hub trigger text (which doesn't reference ascent or descent), to avoid the branching logic and show it from relic and camp events too. Not a big loss, I think.

To make the relics work, I basically had to wrap them in a big `<<if>>`, to avoid the relic acquisition text showing if an event happened. Slightly annoying but a purely mechanical change. I left the indentation alone.

The camp code passage now includes the "return to hub" option and if you choose to camp, it loops around on itself instead of going back to the hub (to let time finish passing).

Since each hub still has logic for showing events, the change to the camp logic doesn't really do much (other than accurately showing the day when the event happens). But I'm hoping to remove that hub logic soon since it shouldn't be necessary once events are handled like this.