### PR TITLE
Clean up appearance widgets and add helpers for pregnancy

### DIFF
--- a/src/companionConversations.twee
+++ b/src/companionConversations.twee
@@ -2891,7 +2891,7 @@ Saeko meticulously guides you through a comprehensive timetable, detailing every
 <<if $app.libido > 3>>
 [[Propose some adult activities to your Twin|Twin Sex Inquiry]]<br>
 <</if>>
-<<if $TwinConvoPreg==false && $time - $companionTwin.pregnantT >= 120>>
+<<if !$TwinConvoPreg && setup.daysConsideredPregnant($companionTwin) >= 120>>
 [[Talk about the reduced fitness of your Twin| Twin Pregnant]]<br>
 <</if>>
 
@@ -3038,7 +3038,7 @@ $companionTwin.name casts a smoldering glance your way as <<if $companionTwin.se
 	<br><br>
 	<<elseif $app.penisCor < 2>>
 	<<if ($playerCurses.some(e => e.name === "Absolute Pregnancy") && $companionTwin.womb > 0) || (_temp < 20 && ($companionTwin.womb1=="throat" || $companionTwin.womb2=="throat")) >>
-	<<set $companionTwin.pregnantT = $time-14>><<set $pregTwinMC = true>>
+	<<set setup.setConsideredPregnant($companionTwin)>><<set $pregTwinMC = true>>
 	<</if>>
 	<<say $companionTwin>> Hmm, it's a bit small, isn't it?<</say>><br>
 	<<say $mc>>Yeah, well, stuff happened, okay?<</say>><br>
@@ -3052,7 +3052,7 @@ $companionTwin.name casts a smoldering glance your way as <<if $companionTwin.se
 	<br><br>
 	<<elseif $app.penisCor > 6>>
 	<<if ($playerCurses.some(e => e.name === "Absolute Pregnancy") && $companionTwin.womb > 0) || (_temp < 20 && ($companionTwin.womb1=="throat" || $companionTwin.womb2=="throat")) >>
-	<<set $companionTwin.pregnantT = $time-14>><<set $pregTwinMC = true>>
+	<<set setup.setConsideredPregnant($companionTwin)>><<set $pregTwinMC = true>>
 	<</if>>
 	<<say $companionTwin>> You're quite the big boy, aren't you?<</say>><br>
 	<<say $mc>>Haha, what can I say? Stuff happened.<</say>><br>
@@ -3073,7 +3073,7 @@ $companionTwin.name casts a smoldering glance your way as <<if $companionTwin.se
 	<<say $companionTwin>> Okay...<</say>>
 	<<else>>
 	<<if ($playerCurses.some(e => e.name === "Absolute Pregnancy") && $companionTwin.womb > 0) || (_temp < 20 && ($companionTwin.womb1=="throat" || $companionTwin.womb2=="throat")) >>
-	<<set $companionTwin.pregnantT = $time-14>><<set $pregTwinMC = true>>
+	<<set setup.setConsideredPregnant($companionTwin)>><<set $pregTwinMC = true>>
 	<</if>>
 	<<say $companionTwin>> Hello there.<</say>><br>
 	$companionTwin.name sensuously licks your shaft up and down before taking it into <<if $companionTwin.sex=='male'>>his <<else>>her <</if>>mouth. You close your eyes, surrendering to the sensations that envelop your body. Suddenly, $companionTwin.name begins sucking your cock with enthusiasm, surprising you.
@@ -3144,7 +3144,7 @@ As you both eagerly undress, you turn $companionTwin.name around and position yo
 <br><br>
 <<if $app.penisCor<= 4>>
 	<<if ($playerCurses.some(e => e.name === "Absolute Pregnancy") && $companionTwin.womb > 0) || (_temp<20 && ($companionTwin.womb1=="anus" || $companionTwin.womb2=="anus"))>>
-		<<set $companionTwin.pregnantT = $time-14>><<set $pregTwinMC = true>>
+		<<set setup.setConsideredPregnant($companionTwin)>><<set $pregTwinMC = true>>
 	<</if>>
 	<<say $companionTwin>> You don't have to be so gentle. Just push it all the way in.<</say>><br>
 	<<say $mc>>Uh... It is all the way in.<</say>><br>
@@ -3156,7 +3156,7 @@ As you both eagerly undress, you turn $companionTwin.name around and position yo
 	<br><br>
 <<elseif $app.penisCor> 6 >>
 	<<if ($playerCurses.some(e => e.name === "Absolute Pregnancy") && $companionTwin.womb > 0) || (_temp<20 && ($companionTwin.womb1=="anus" || $companionTwin.womb2=="anus"))>>
-		<<set $companionTwin.pregnantT = $time-14>><<set $pregTwinMC = true>>
+		<<set setup.setConsideredPregnant($companionTwin)>><<set $pregTwinMC = true>>
 	<</if>>
 	<<say $companionTwin>> Ow, ow, slow down. How much more is there?<</say>><br>
 	<<say $mc>>Uh... It's almost all the way in.<</say>><br>
@@ -3166,7 +3166,7 @@ As you both eagerly undress, you turn $companionTwin.name around and position yo
 	<br><br>
 <<elseif $app.penisCor> 9 >>
 	<<if ($playerCurses.some(e => e.name === "Absolute Pregnancy") && $companionTwin.womb > 0) || (_temp<2 && ($companionTwin.womb1=="anus" || $companionTwin.womb2=="anus"))>>
-		<<set $companionTwin.pregnantT = $time-14>><<set $pregTwinMC = true>>
+		<<set setup.setConsideredPregnant($companionTwin)>><<set $pregTwinMC = true>>
 	<</if>>
 	<<say $companionTwin>> Ow, ow, slow down. How much more is there?<</say>><br>
 	<<say $mc>>Uh... quite a lot, to be honest.<</say>><br>
@@ -3176,7 +3176,7 @@ As you both eagerly undress, you turn $companionTwin.name around and position yo
 	<br><br>
 <<else>>
 	<<if ($playerCurses.some(e => e.name === "Absolute Pregnancy") && $companionTwin.womb > 0) || (_temp<20 && ($companionTwin.womb1=="anus" || $companionTwin.womb2=="anus"))>>
-		<<set $companionTwin.pregnantT = $time-14>><<set $pregTwinMC = true>>
+		<<set setup.setConsideredPregnant($companionTwin)>><<set $pregTwinMC = true>>
 	<</if>>
 	<<say $companionTwin>> Oh, that's perfect. Just push it all the way in.<</say>><br>
 	<<say $mc>>As you wish!<</say>><br>
@@ -3209,7 +3209,7 @@ Both of you shed your garments with fervor, your desire for one another palpable
 <br><br>
 <<if $app.penisCor<= 4>>
 	<<if (_temp < 20 || $playerCurses.some(e => e.name === "Absolute Pregnancy")) && !$playerCurses.some(e => e.name === "Absolute Birth Control")>>
-		<<set $companionTwin.pregnantT = $time-14>><<set $pregTwinMC = true>>
+		<<set setup.setConsideredPregnant($companionTwin)>><<set $pregTwinMC = true>>
 	<</if>>
 	<<say $companionTwin>> Just push it all the way in. You don't need to be so gentle.<</say>><br>
 	<<say $mc>>Uh... It is all the way in.<</say>><br>
@@ -3221,7 +3221,7 @@ Both of you shed your garments with fervor, your desire for one another palpable
 	<br><br>
 <<elseif $app.penisCor> 6 >>
 	<<if (_temp < 20 || $playerCurses.some(e => e.name === "Absolute Pregnancy")) && !$playerCurses.some(e => e.name === "Absolute Birth Control")>>
-		<<set $companionTwin.pregnantT = $time-14>><<set $pregTwinMC = true>>
+		<<set setup.setConsideredPregnant($companionTwin)>><<set $pregTwinMC = true>>
 	<</if>>
 	<<say $companionTwin>> Ow, ow, slow down. How much more is there?<</say>><br>
 	<<say $mc>>Uh... It's almost all the way in.<</say>><br>
@@ -3238,7 +3238,7 @@ Both of you shed your garments with fervor, your desire for one another palpable
 	<br><br>
 <<else>>
 	<<if (_temp < 20 || $playerCurses.some(e => e.name === "Absolute Pregnancy")) && !$playerCurses.some(e => e.name === "Absolute Birth Control")>>
-		<<set $companionTwin.pregnantT = $time-14>><<set $pregTwinMC = true>>
+		<<set setup.setConsideredPregnant($companionTwin)>><<set $pregTwinMC = true>>
 	<</if>>
 	<<say $companionTwin>> Ow, that's right, just push it all the way in.<</say>><br>
 	<<say $mc>>As you wish!<</say>><br>
@@ -3305,7 +3305,7 @@ As the last of your clothes fall to the floor, you can't help but admire the ero
 [[End your 'conversation'|Party overview]]
 
 <<if _temp < 2 || $playerCurses.some(e => e.name === "Absolute Pregnancy") || $companionTwin.curses.some(e => e.name === "Absolute Pregnancy")>>
-	<<set $companionTwin.pregnantT = $time-14>><<set $pregTwinMC = true>>\
+	<<set setup.setConsideredPregnant($companionTwin)>><<set $pregTwinMC = true>>\
 <</if>>
 
 :: Twin Sex Boobjob Receive[nobr]
@@ -3324,7 +3324,7 @@ $companionTwin.name gazes at you with lust-filled eyes as <<if $companionTwin.se
 	[[End your 'conversation'|Party overview]]
 <<elseif $app.penisCor > 6>>
 	<<if ($companionTwin.curses.some(e => e.name === "Absolute Pregnancy") || $playerCurses.some(e => e.name === "Absolute Pregnancy")) && $companionTwin.womb > 0>>
-		<<set $companionTwin.pregnantT = $time-14>><<set $pregTwinMC = true>>
+		<<set setup.setConsideredPregnant($companionTwin)>><<set $pregTwinMC = true>>
 	<</if>>
 	<<say $companionTwin>> You're quite the big boy, aren't you?<</say>><br>
 	<<say $mc>>Haha, what can I say? Stuff happened.<</say>><br>
@@ -3336,7 +3336,7 @@ $companionTwin.name gazes at you with lust-filled eyes as <<if $companionTwin.se
 	[[End your 'conversation'|Party overview]]
 <<elseif $app.penisCor > 9>>
 	<<if ($companionTwin.curses.some(e => e.name === "Absolute Pregnancy") || $playerCurses.some(e => e.name === "Absolute Pregnancy")) && $companionTwin.womb > 0>>
-		<<set $companionTwin.pregnantT = $time-14>><<set $pregTwinMC = true>>
+		<<set setup.setConsideredPregnant($companionTwin)>><<set $pregTwinMC = true>>
 	<</if>>
 	<<say $companionTwin>> Oh, wow. I'm glad that's going between my breasts and not somewhere else. What a monster...<</say>><br>
 	<<say $mc>>Well, what can I say? Stuff happened.<</say>><br>
@@ -3348,7 +3348,7 @@ $companionTwin.name gazes at you with lust-filled eyes as <<if $companionTwin.se
 	[[End your 'conversation'|Party overview]]
 <<else>>
 	<<if ($companionTwin.curses.some(e => e.name === "Absolute Pregnancy") || $playerCurses.some(e => e.name=== "Absolute Pregnancy")) && $companionTwin.womb > 0>>
-		<<set $companionTwin.pregnantT = $time-14>><<set $pregTwinMC = true>>
+		<<set setup.setConsideredPregnant($companionTwin)>><<set $pregTwinMC = true>>
 	<</if>>
 	<<say $companionTwin>> Hello there.<</say>><br>
 	$companionTwin.name sensually licks your throbbing member, <<if $companionTwin.sex=="male">>his<<else>>her<</if>> tongue dancing teasingly along its length before <<if $companionTwin.sex=="male">>he<<else>>she<</if>> wraps it in <<if $companionTwin.sex=="male">>his<<else>>her<</if>> soft, ample cleavage. <<if $companionTwin.sex=="male">>He<<else>>She<</if>> begins to expertly move <<if $companionTwin.sex=="male">>his<<else>>her<</if>> voluptuous breasts up and down your eager shaft.
@@ -3454,7 +3454,7 @@ You shudder as an explosive orgasm rolls through you, and as if triggered by you
 	<<if $companionTwin.sex=="male">>He<<else>>She<</if>> plants a soft, lingering kiss on your lips as she stands up and begins to clean <<if $companionTwin.sex=="male">>him<<else>>her<</if>>self.
 	<br><br>
 	<<if (_temp < 2 || $playerCurses.some(e => e.name === "Absolute Pregnancy") || $companionTwin.some(e => e.name === "Absolute Pregnancy")) && !$playerCurses.some(e => e.name === "Absolute Birth Control")>>\
-		<<set $companionTwin.pregnantT = $time-14>><<set $pregTwinMC = true>>\
+		<<set setup.setConsideredPregnant($companionTwin)>><<set $pregTwinMC = true>>\
 	<</if>>\
 <<elseif $companionTwin.penisCor > 0 && $app.vagina > 0 && $app.penisCor == 0>>
 	<br>
@@ -3486,7 +3486,7 @@ You shudder as an explosive orgasm rolls through you, and as if triggered by you
 	You both stand up and start cleaning yourselves.
 	<br><br>
 	<<if $companionTwin.womb > 0 && ((_temp < 2 || $playerCurses.some(e => e.name === "Absolute Pregnancy")) && !$playerCurses.some(e => e.name === "Absolute Birth Control"))>>\
-		<<set $companionTwin.pregnantT = $time-14>><<set $pregTwinMC = true>>\
+		<<set setup.setConsideredPregnant($companionTwin)>><<set $pregTwinMC = true>>\
 	<</if>>
 	<<if !$companionTwin.curses.some(e => e.name === "Absolute Birth Control")>>\
 		<<if $companionTwin.curses.some(e => e.name === "Absolute Pregnancy") && $app.womb> 0>>

--- a/src/companionSetup.twee
+++ b/src/companionSetup.twee
@@ -57,16 +57,14 @@ hair: "light blue",
 penis: 4,
 penisCor: 4,
 doublePenis: false,
-modpenis: 0,
 vagina: 0,
 gender: 3,
-modgender:0,
 switch: false,
 breasts: 0,
-modbreasts: 0,
 breastsCor: 0,
 lactation: 0,
-pregnantT: 9999,
+pregnantT: setup.never,
+due: setup.never,
 ears: "normal human",
 height: 144,
 modheight: 0,
@@ -121,16 +119,14 @@ hair: "light purple",
 penis: 0,
 penisCor: 0,
 doublePenis: false,
-modpenis: 0,
 vagina: 1,
 gender: 6,
-modgender:0,
 switch: false,
 breasts: 3,
-modbreasts: 0,
 breastsCor: 3,
 lactation: 0,
-pregnantT: 9999,
+pregnantT: setup.never,
+due: setup.never,
 ears: "normal human",
 height: 168,
 modheight: 0,
@@ -185,16 +181,14 @@ hair: "dark blue",
 penis: 8,
 penisCor: 8,
 doublePenis: false,
-modpenis: 0,
 vagina: 0,
 gender: 1,
-modgender:0,
 switch: false,
 breasts: 0,
-modbreasts: 0,
 breastsCor: 0,
 lactation: 0,
-pregnantT: 9999,
+pregnantT: setup.never,
+due: setup.never,
 ears: "normal human",
 height: 185,
 modheight: 0,
@@ -249,16 +243,14 @@ hair: "red",
 penis: 0,
 penisCor: 0,
 doublePenis: false,
-modpenis: 0,
 vagina: 1,
 gender: 6,
-modgender:0,
 switch: false,
 breasts: 4,
-modbreasts: 0,
 breastsCor: 4,
 lactation: 0,
-pregnantT: 9999,
+pregnantT: setup.never,
+due: setup.never,
 ears: "normal human",
 height: 165,
 modheight: 0,
@@ -313,16 +305,14 @@ hair: "brown",
 penis: 6,
 penisCor: 6,
 doublePenis: false,
-modpenis: 0,
 vagina: 0,
 gender: 1,
-modgender:0,
 switch: false,
 breasts: 0,
-modbreasts: 0,
 breastsCor: 0,
 lactation: 0,
-pregnantT: 9999,
+pregnantT: setup.never,
+due: setup.never,
 ears: "normal human",
 height: 175,
 modheight: 0,
@@ -377,16 +367,14 @@ hair: "black",
 penis: 0,
 penisCor: 0,
 doublePenis: false,
-modpenis: 0,
 vagina: 1,
 gender: 6,
-modgender:0,
 switch: false,
 breasts: 2,
-modbreasts: 0,
 breastsCor: 2,
 lactation: 0,
-pregnantT: 9999,
+pregnantT: setup.never,
+due: setup.never,
 ears: "normal human",
 height: 160,
 modheight: 0,
@@ -451,9 +439,9 @@ type: ""
 <<set $MaruConvo0 = false>>
 <<set $MaruConvo1 = false>>
 <<set $MaruConvo2 = false>>
-<<set $Maru_LastT = 9999>>
+<<set $Maru_LastT = setup.never>>
 <<set $MaruConvoPreg = false>>
-<<set $lastBirthMaru = 9999>>
+<<set $lastBirthMaru = setup.never>>
 
 <<set $AgeLogMaru = []>>
 <<set $GenderLogMaru = []>>
@@ -466,9 +454,9 @@ type: ""
 <<set $LilyConvo2 = false>>
 <<set $LilyPromise = false>>
 <<set $LilyConvoLac = false>>
-<<set $Lily_LastT = 9999>>
+<<set $Lily_LastT = setup.never>>
 <<set $LilyConvoPreg = false>>
-<<set $lastBirthLily = 9999>>
+<<set $lastBirthLily = setup.never>>
 
 <<set $AgeLogLily = []>>
 <<set $GenderLogLily = []>>
@@ -484,9 +472,9 @@ type: ""
 <<set $KhemiaConvoMoreMasc = false>>
 <<set $KhemiaConvoMostMasc = false>>
 <<set $khmeiaWettingFlag = false>>
-<<set $Khemia_LastT = 9999>>
+<<set $Khemia_LastT = setup.never>>
 <<set $KhemiaConvoPreg = false>>
-<<set $lastBirthKhemia = 9999>>
+<<set $lastBirthKhemia = setup.never>>
 
 <<set $AgeLogKhemia = []>>
 <<set $GenderLogKhemia = []>>
@@ -499,9 +487,9 @@ type: ""
 <<set $CherryConvo2 = false>>
 <<set $CherryConvoLac = false>>
 <<set $CherryFluffy = false>>
-<<set $Cherry_LastT = 9999>>
+<<set $Cherry_LastT = setup.never>>
 <<set $CherryConvoPreg = false>>
-<<set $lastBirthCherry = 9999>>
+<<set $lastBirthCherry = setup.never>>
 
 <<set $AgeLogCherry = []>>
 <<set $GenderLogCherry = []>>
@@ -513,9 +501,9 @@ type: ""
 <<set $CloudConvo1 = false>>
 <<set $CloudConvo2 = false>>
 <<set $CloudConvoLac = false>>
-<<set $Cloud_LastT = 9999>>
+<<set $Cloud_LastT = setup.never>>
 <<set $CloudConvoPreg = false>>
-<<set $lastBirthCloud = 9999>>
+<<set $lastBirthCloud = setup.never>>
 <<set $altCloud	   = true>>
 
 <<set $AgeLogCloud = []>>
@@ -528,9 +516,9 @@ type: ""
 <<set $SaekoConvo1 = false>>
 <<set $SaekoConvo2 = false>>
 <<set $SaekoConvoPlant = false>>
-<<set $Saeko_LastT = 9999>>
+<<set $Saeko_LastT = setup.never>>
 <<set $SaekoConvoPreg = false>>
-<<set $lastBirthSaeko = 9999>>
+<<set $lastBirthSaeko = setup.never>>
 
 <<set $AgeLogSaeko = []>>
 <<set $GenderLogSaeko = []>>
@@ -540,11 +528,11 @@ type: ""
 
 <<set $TwinConvo1 = false>>
 <<set $TwinConvo2 = false>>
-<<set $Twin_LastT = 9999>>
+<<set $Twin_LastT = setup.never>>
 <<set $TwinFly = false>>
 <<set $TwinConvoPreg = false>>
 <<set $pregTwinMC = false>>
-<<set $lastBirthTwin = 9999>>
+<<set $lastBirthTwin = setup.never>>
 <<set $TwinVar1 = 0>>
 
 <<set $AgeLogTwin = []>>
@@ -826,16 +814,16 @@ Overall the world would probably see <<if _companion.sex=="male">>him<<else>>her
 :: Maru Overview [noreturn]
 [img[setup.ImagePath+$companionMaru.image]]
 <<include "Maru Introduction">>
-<<if $time - $companionMaru.pregnantT > 0 >>\
-	<<if $time - $companionMaru.pregnantT< 60 && $time - $companionMaru.pregnantT>= 30 >>\
-	Maru has seemed a little sick recently. Nothing too serious, but it's not like when you first came down here.
-	<<elseif $time - $companionMaru.pregnantT< 180 && $time - $companionMaru.pregnantT>= 120 && $MaruConvoPreg==false >>\
+<<if setup.daysConsideredPregnant($companionMaru) > 0>>\
+	<<if 30 <= setup.daysConsideredPregnant($companionMaru) && setup.daysConsideredPregnant($companionMaru) < 60>>\
+		Maru has seemed a little sick recently. Nothing too serious, but it's not like when you first came down here.
+	<<elseif 120 <= setup.daysConsideredPregnant($companionMaru) && setup.daysConsideredPregnant($companionMaru) < 180 && !$MaruConvoPreg>>\
 		Maru was never that fit, but he has been falling behind a lot recently. He also seems to have put on some weight. Perhaps you should discuss his eating habits with him?
-	<<elseif $time - $companionMaru.pregnantT< 180 && $time - $companionMaru.pregnantT>= 120 && $MaruConvoPreg==true>>\
+	<<elseif 120 <= setup.daysConsideredPregnant($companionMaru) && setup.daysConsideredPregnant($companionMaru) < 180 && $MaruConvoPreg>>\
 		Maru has a small, but obvious bulge for his pregnant belly.
-	<<elseif $time - $companionMaru.pregnantT< 240 && $time - $companionMaru.pregnantT>=180 >>\
+	<<elseif 180 <= setup.daysConsideredPregnant($companionMaru) && setup.daysConsideredPregnant($companionMaru) < 240>>\
 		Maru's belly is huge and bulging forward in a way that obviously identifies him as pregnant. 
-	<<elseif $time - $companionMaru.pregnantT>=240>>\
+	<<elseif setup.daysConsideredPregnant($companionMaru) >= 240>>\
 		Maru has a very large and very obvious pregnant belly. He's probably due soon, though it's hard to know exactly when.
 	<</if>>
 <</if>>
@@ -846,16 +834,16 @@ Overall the world would probably see <<if _companion.sex=="male">>him<<else>>her
 :: Lily Overview [noreturn]
 [img[setup.ImagePath+$companionLily.image]]
 <<include "Lily Introduction">>
-<<if $time - $companionLily.pregnantT > 0 >>\
-	<<if $time - $companionLily.pregnantT< 60 && $time - $companionLily.pregnantT>= 30 >>\
-	Lily hasn't been as much of her energetic self lately, she looks rather tired a lot of the time.
-	<<elseif $time - $companionLily.pregnantT< 180 && $time - $companionLily.pregnantT>= 120 && $LilyConvoPreg==false >>\
+<<if setup.daysConsideredPregnant($companionLily) > 0>>\
+	<<if 30 <= setup.daysConsideredPregnant($companionLily) && setup.daysConsideredPregnant($companionLily) < 60>>\
+		Lily hasn't been as much of her energetic self lately, she looks rather tired a lot of the time.
+	<<elseif 120 <= setup.daysConsideredPregnant($companionLily) && setup.daysConsideredPregnant($companionLily) < 180 && !$LilyConvoPreg>>\
 		Lily has been having some kind of mood swings, going back and forth between very energetic to completely exhausted. She even seems to have put on some weight, has she stopped exercising as much as she used to? Maybe you should have a talk with her about it.
-	<<elseif $time - $companionLily.pregnantT< 180 && $time - $companionLily.pregnantT>= 120 && $LilyConvoPreg==true>>\
+	<<elseif 120 <= setup.daysConsideredPregnant($companionLily) && setup.daysConsideredPregnant($companionLily) < 180 && $LilyConvoPreg>>\
 		Lily has a small, but obvious bulge for her pregnant belly.
-	<<elseif $time - $companionLily.pregnantT< 240 && $time - $companionLily.pregnantT>=180 >>\
+	<<elseif 180 <= setup.daysConsideredPregnant($companionLily) && setup.daysConsideredPregnant($companionLily) < 240>>\
 		Lily's belly is huge and bulging forward in a way that obviously identifies her as pregnant. 
-	<<elseif $time - $companionLily.pregnantT>=240>>\
+	<<elseif setup.daysConsideredPregnant($companionLily) >= 240>>\
 		Lily has a very large and very obvious pregnant belly. She's probably due soon, though it's hard to know exactly when.
 	<</if>>
 <</if>>
@@ -866,16 +854,16 @@ Overall the world would probably see <<if _companion.sex=="male">>him<<else>>her
 :: Khemia Overview [noreturn]
 [img[setup.ImagePath+$companionKhemia.image]]
 <<include "Khemia Introduction">>
-<<if $time - $companionKhemia.pregnantT > 0 >>\
-	<<if $time - $companionKhemia.pregnantT< 60 && $time - $companionKhemia.pregnantT>= 30 >>\
-	Khemia seems to have contracted some stomach illness, as he is frequently vomiting in the morning after you wake up. Hopefully he's able to recover soon.
-	<<elseif $time - $companionKhemia.pregnantT< 180 && $time - $companionKhemia.pregnantT>= 120 >>\
+<<if setup.daysConsideredPregnant($companionKhemia) > 0>>\
+	<<if 30 <= setup.daysConsideredPregnant($companionKhemia) && setup.daysConsideredPregnant($companionKhemia) < 60>>\
+		Khemia seems to have contracted some stomach illness, as he is frequently vomiting in the morning after you wake up. Hopefully he's able to recover soon.
+	<<elseif 120 <= setup.daysConsideredPregnant($companionKhemia) && setup.daysConsideredPregnant($companionKhemia) < 180>>\
 		Khemia has developed somewhat of pot belly. It's not too much of a problem, as he was always a quite a bit more fit than everyone else, but it seems uncharacteristic of him to secretly snack so much. 
-	<<elseif $time - $companionKhemia.pregnantT< 240 && $time - $companionKhemia.pregnantT>= 180 && $KhemiaConvoPreg==false>>\
+	<<elseif 180 <= setup.daysConsideredPregnant($companionKhemia) && setup.daysConsideredPregnant($companionKhemia) < 240 && !$KhemiaConvoPreg>>\
 		This is getting ridiculous, Khemia's belly has become quite large. His chest, his ass everything seems to collect fat, but it's nothing compared to his belly. This is no longer normal and honestly worrysome, maybe you should have a talk to see what's going on with him.
-	<<elseif $time - $companionKhemia.pregnantT< 240 && $time - $companionKhemia.pregnantT>=180 && $KhemiaConvoPreg==true>>\
+	<<elseif 180 <= setup.daysConsideredPregnant($companionKhemia) && setup.daysConsideredPregnant($companionKhemia) < 240 && $KhemiaConvoPreg>>\
 		Khemia belly is huge and bulging forward in a way that obviously identifies him as pregnant. 
-	<<elseif $time - $companionKhemia.pregnantT>=240>>\
+	<<elseif setup.daysConsideredPregnant($companionKhemia) >= 240>>\
 		Khemia has a very large and very obvious pregnant belly. He's probably due soon, though it's hard to know exactly when.
 	<</if>>
 <</if>>
@@ -886,16 +874,16 @@ Overall the world would probably see <<if _companion.sex=="male">>him<<else>>her
 :: Cherry Overview [noreturn]
 [img[setup.ImagePath+$companionCherry.image]]
 <<include "Cherry Introduction">>
-<<if $time - $companionCherry.pregnantT > 0 >>\
-	<<if $time - $companionCherry.pregnantT< 60 && $time - $companionCherry.pregnantT>= 30 >>\
-	Cherry seems to have contracted some stomach illness, as she is frequently vomiting in the morning after you wake up. Hopefully she's able to recover soon.
-	<<elseif $time - $companionCherry.pregnantT< 180 && $time - $companionCherry.pregnantT>= 120 && $CherryConvoPreg==false >>\
+<<if setup.daysConsideredPregnant($companionCherry) > 0>>\
+	<<if 30 <= setup.daysConsideredPregnant($companionCherry) && setup.daysConsideredPregnant($companionCherry) < 60>>\
+		Cherry seems to have contracted some stomach illness, as she is frequently vomiting in the morning after you wake up. Hopefully she's able to recover soon.
+	<<elseif 120 <= setup.daysConsideredPregnant($companionCherry) && setup.daysConsideredPregnant($companionCherry) < 180 && !$CherryConvoPreg>>\
 		Cherry has been distancing herself from social contact even more than usual. She seems to avoid everyone and trails the group by a significant amount. Perhaps you should have a talk with her to see what's going on.
-	<<elseif $time - $companionCherry.pregnantT< 180 && $time - $companionCherry.pregnantT>= 120 && $CherryConvoPreg==true>>\
+	<<elseif 120 <= setup.daysConsideredPregnant($companionCherry) && setup.daysConsideredPregnant($companionCherry) < 180 && $CherryConvoPreg>>\
 		Cherry has a small, but obvious bulge for her pregnant belly.
-	<<elseif $time - $companionCherry.pregnantT< 240 && $time - $companionCherry.pregnantT>=180 >>\
+	<<elseif 180 <= setup.daysConsideredPregnant($companionCherry) && setup.daysConsideredPregnant($companionCherry) < 240>>\
 		Cherry's belly is huge and bulging forward in a way that obviously identifies her as pregnant. 
-	<<elseif $time - $companionCherry.pregnantT>=240>>\
+	<<elseif setup.daysConsideredPregnant($companionCherry) >= 240>>\
 		Cherry has a very large and very obvious pregnant belly. She's probably due soon, though it's hard to know exactly when.
 	<</if>>
 <</if>>
@@ -906,16 +894,16 @@ Overall the world would probably see <<if _companion.sex=="male">>him<<else>>her
 :: Cloud Overview [noreturn]
 [img[setup.ImagePath+$companionCloud.image]]
 <<include "Cloud Introduction">>
-<<if $time - $companionCloud.pregnantT > 0 >>\
-	<<if $time - $companionCloud.pregnantT< 60 && $time - $companionCloud.pregnantT>= 30 >>\
-	Cloud hasn't been pulling his weight as much he should recently. He pitches his own tent, then immediately goes to sleep most nights. It's strange he isn't helping as much as he used to.
-	<<elseif $time - $companionCloud.pregnantT< 180 && $time - $companionCloud.pregnantT>= 120 && $CloudConvoPreg==false >>\
+<<if setup.daysConsideredPregnant($companionCloud) > 0>>\
+	<<if 30 <= setup.daysConsideredPregnant($companionCloud) && setup.daysConsideredPregnant($companionCloud) < 60>>\
+		Cloud hasn't been pulling his weight as much he should recently. He pitches his own tent, then immediately goes to sleep most nights. It's strange he isn't helping as much as he used to.
+	<<elseif 120 <= setup.daysConsideredPregnant($companionCloud) && setup.daysConsideredPregnant($companionCloud) < 180 && !$CloudConvoPreg>>\
 		Cloud seems to be avoiding chores and lounges around quite a bit more than usual. He's even become a little pudgy recently and put on some fat on his belly. Perhaps you should have a talk with him to see what's going on.
-	<<elseif $time - $companionCloud.pregnantT< 180 && $time - $companionCloud.pregnantT>= 120 && $CloudConvoPreg==true>>\
+	<<elseif 120 <= setup.daysConsideredPregnant($companionCloud) && setup.daysConsideredPregnant($companionCloud) < 180 && $CloudConvoPreg>>\
 		Cloud hhas a small, but obvious bulge for his pregnant belly.
-	<<elseif $time - $companionCloud.pregnantT< 240 && $time - $companionCloud.pregnantT>=180 >>\
+	<<elseif 180 <= setup.daysConsideredPregnant($companionCloud) && setup.daysConsideredPregnant($companionCloud) < 240>>\
 		Cloud's belly is huge and bulging forward in a way that obviously identifies him as pregnant. 
-	<<elseif $time - $companionCloud.pregnantT>=240>>\
+	<<elseif setup.daysConsideredPregnant($companionCloud) >= 240>>\
 		Cloud has a very large and very obvious pregnant belly. He's probably due soon, though it's hard to know exactly when.
 	<</if>>
 <</if>>
@@ -926,16 +914,16 @@ Overall the world would probably see <<if _companion.sex=="male">>him<<else>>her
 :: Saeko Overview [noreturn]
 [img[setup.ImagePath+$companionSaeko.image]]
 <<include "Saeko Introduction">>
-<<if $time - $companionSaeko.pregnantT > 0 >>\
-	<<if $time - $companionSaeko.pregnantT< 60 && $time - $companionSaeko.pregnantT>= 30 >>\
-	Saeko has been sneaking off and seems sick, has she been testing something on herself?
-	<<elseif $time - $companionSaeko.pregnantT< 180 && $time - $companionSaeko.pregnantT>= 120 && $SaekoConvoPreg==false >>\
+<<if setup.daysConsideredPregnant($companionSaeko) > 0>>\
+	<<if 30 <= setup.daysConsideredPregnant($companionSaeko) && setup.daysConsideredPregnant($companionSaeko) < 60>>\
+		Saeko has been sneaking off and seems sick, has she been testing something on herself?
+	<<elseif 120 <= setup.daysConsideredPregnant($companionSaeko) && setup.daysConsideredPregnant($companionSaeko) < 180 && !$SaekoConvoPreg>>\
 		Saeko is being evasive about something. And whatever it is, it doesn't seem to be good for her health, as she is frequently tired and seems bloated. Perhaps you should have a talk with her to see what's going on.
-	<<elseif $time - $companionSaeko.pregnantT< 180 && $time - $companionSaeko.pregnantT>= 120 && $SaekoConvoPreg==true>>\
+	<<elseif 120 <= setup.daysConsideredPregnant($companionSaeko) && setup.daysConsideredPregnant($companionSaeko) < 180 && $SaekoConvoPreg>>\
 		Saeko has a small, but obvious bulge for her pregnant belly.
-	<<elseif $time - $companionSaeko.pregnantT< 240 && $time - $companionSaeko.pregnantT>=180 >>\
+	<<elseif 180 <= setup.daysConsideredPregnant($companionSaeko) && setup.daysConsideredPregnant($companionSaeko) < 240>>\
 		Saeko's belly is huge and bulging forward in a way that obviously identifies her as pregnant. 
-	<<elseif $time - $companionSaeko.pregnantT>=240>>\
+	<<elseif setup.daysConsideredPregnant($companionSaeko) >= 240>>\
 		Saeko has a very large and very obvious pregnant belly. She's probably due soon, though it's hard to know exactly when.
 	<</if>>
 <</if>>
@@ -946,16 +934,16 @@ Overall the world would probably see <<if _companion.sex=="male">>him<<else>>her
 :: Twin Overview [noreturn]
 [img[setup.ImagePath+$companionTwin.image]]
 <<include "Twin Introduction">>
-<<if $time - $companionTwin.pregnantT > 0 >>\
-	<<if $time - $companionTwin.pregnantT< 60 && $time - $companionTwin.pregnantT>= 30 >>\
-	Lately your twin has been sick quite frequently. Is this a side effect of being conjured by a Curse?
-	<<elseif $time - $companionTwin.pregnantT< 180 && $time - $companionTwin.pregnantT>= 120 && $TwinConvoPreg==false >>\
+<<if setup.daysConsideredPregnant($companionTwin) > 0>>\
+	<<if 30 <= setup.daysConsideredPregnant($companionTwin) && setup.daysConsideredPregnant($companionTwin) < 60>>\
+		Lately your twin has been sick quite frequently. Is this a side effect of being conjured by a Curse?
+	<<elseif 120 <= setup.daysConsideredPregnant($companionTwin) && setup.daysConsideredPregnant($companionTwin) < 180 && !$TwinConvoPreg>>\
 		Your twin has really gotten out of shape recently. She's been lagging behind the group more and more frequently with her breaks. She also seems to have put on some weight. Perhaps you should have a talk with her to see what's going on.
-	<<elseif $time - $companionTwin.pregnantT< 180 && $time - $companionTwin.pregnantT>= 120 && $TwinConvoPreg==true>>\
+	<<elseif 120 <= setup.daysConsideredPregnant($companionTwin) && setup.daysConsideredPregnant($companionTwin) < 180 && $TwinConvoPreg>>\
 		Your twin has a small, but obvious bulge for her pregnant belly.
-	<<elseif $time - $companionTwin.pregnantT< 240 && $time - $companionTwin.pregnantT>=180 >>\
+	<<elseif 180 <= setup.daysConsideredPregnant($companionTwin) && setup.daysConsideredPregnant($companionTwin) < 240>>\
 		Your twin's belly is huge and bulging forward in a way that obviously identifies her as pregnant. 
-	<<elseif $time - $companionTwin.pregnantT>=240>>\
+	<<elseif setup.daysConsideredPregnant($companionTwin) >= 240>>\
 		Your twin has a very large and very obvious pregnant belly. She's probably due soon, though it's hard to know exactly when.
 	<</if>>
 <</if>>

--- a/src/curses.twee
+++ b/src/curses.twee
@@ -1115,6 +1115,14 @@ type: ""
     9: ["Libido Reinforcement G", "Gender Reversal G", "Asset Robustness G", "Literalization", "Consent Dissent", "The Maxim", "Adverse Possession", "Erased", "Tickly Tentacles", "Eye-scream", "A Mouthful", "Below the Veil"],
 }>>
 
+<<set setup.cursesNegatedByNull = [
+    "Double Pepperoni",
+    "Softie",
+    "Hard Mode",
+    "Lactation Rejuvenation A",
+    "Lactation Rejuvenation B",
+]>>
+
 :: Libido Reinforcement A Description
 
 Gives one level of the Libido Reinforcement Curse, which boosts your sex drive according to how many Libido Reinforcement effects you've taken. See the above table for details.

--- a/src/global.twee
+++ b/src/global.twee
@@ -546,13 +546,13 @@ Your body appears rather out of shape, and you could certainly benefit from some
 <</if>>
 <<if $AegisWear>>Although imperceptible to an outside observer, your natural skeleton has been seamlessly replaced with a lightweight and resilient orichalcum framework.<br><br><</if>>
 
-<<if $time - $app.pregnantT < 180 && $time - $app.pregnantT >= 120 && $menFirstCycle == false>>
+<<if 120 <= setup.daysConsideredPregnant($app) && setup.daysConsideredPregnant($app) < 180 && !$menFirstCycle>>
 	Your pregnancy is now visibly noticeable, with your belly round and growing. You occasionally feel a gentle flutter within, a reminder of the life blossoming inside you.<br><br>
-<<elseif $time - $app.pregnantT < 180 && $time - $app.pregnantT >= 120 && $menFirstCycle == true>>
+<<elseif 120 <= setup.daysConsideredPregnant($app) && setup.daysConsideredPregnant($app) < 180 && $menFirstCycle>>
 	You've gained some weight, and your belly has become rounder. Every so often, you experience ticklish spasms from within, possibly a sign of your baby's movements.<br><br>
-<<elseif $time - $app.pregnantT < 240 && $time - $app.pregnantT >= 180 && $menFirstCycle == false>>
+<<elseif 180 <= setup.daysConsideredPregnant($app) && setup.daysConsideredPregnant($app) < 240>>
 	Your belly is now large and unmistakably that of a pregnant person. Your child's movements within your womb are frequent, and at times, the intensity of the sensations surprises you.<br><br>
-<<elseif $time - $app.pregnantT < $due && $time - $app.pregnantT >= 240>>
+<<elseif setup.daysConsideredPregnant($app) >= 240 && setup.daysUntilDue($app) > 0>>
 	Your belly is sizable and clearly pregnant. Your child often tries to move and kick within your womb, but space is becoming limited. The sensations can be quite intense, but you sense that your pregnancy is nearing its end.<br><br>
 <</if>>
 
@@ -874,8 +874,7 @@ Helpful people on the surface managed to find your items safely, retrieving all 
 
 :: Labor Scene
 <<set _string = "Layer" + $currentLayer + " Hub">>\
-<<set $due = 9999>>\
-<<set $app.pregnantT = 9999>>\
+<<set setup.setNotPregnant($app)>>\
 <<set $menCycleFlag = true>>\
 <<set $menCycleT = $time+63>>\
 <<set $BabysBirthed += 1>>\
@@ -997,7 +996,7 @@ It emits of a brigth flash of light that forces you to close your eyes, and you 
 <<set _temp1 = _i>>
 <</if>>
 <</for>>
-<<set $hiredCompanions[_temp1].pregnantT =9999>>
+<<set setup.setNotPregnant($hiredCompanions[_temp1])>>
 <</nobr>>
 As you walk together, $companionLabor begins to lag slightly behind. Suddenly, you hear a soft moan. Turning around, you find $companionLabor hunched over, her face twisted in pain.
 
@@ -1523,8 +1522,8 @@ If you are over 18, please go back and enter an age above 18 to continue.
 					<<elseif _curse.name == "Dizzying Heights" && !$HeightIncrease>>
 						As you look into the marbles you see your own reflection in the marble, as well as the miasma of the Curse swirling within.<br>
 						You see your own reflection alternating between growing and shrinking. After a while you see the Curse has settle on a height...<br>
-						<<radiobutton "$HeightIncrease " -1 checked>> Decrease<br>
-						<<radiobutton "$HeightIncrease " 1 >> Increase<br>
+						<<radiobutton "$HeightIncrease" -1 checked>> Decrease<br>
+						<<radiobutton "$HeightIncrease" 1 >> Increase<br>
 					<<elseif _curse.name == "Hemospectrum" && !$curse70.variation>>
 						What would you like your new blood (or maybe hemolymph, depending on how human you still are) color to be?<br>
 						<<radiobutton "$curse70.variation" "blue" checked>> Blue<br>
@@ -2005,11 +2004,11 @@ How many dubloons would you like to pay back?
 	<<if $WettingSolution == 0>>
 		<<if $playerCurses.some(e => e.name === "Urine Reamplification A") || $playerCurses.some(e => e.name === "Urine Reamplification B")>>
 			<<if $playerCurses.some(e => e.name === "Urine Reamplification A") && $playerCurses.some(e => e.name === "Urine Reamplification B")>>
-				<<set _random = random(1, Math.pow(3, _state.weightedDayIndex))>>
-				<<set _threshold = Math.pow(3, _state.weightedDayIndex) - Math.pow(2, _state.weightedDayIndex)>>
+				<<set _random = random(1, 3**_state.weightedDayIndex)>>
+				<<set _threshold = 3**_state.weightedDayIndex - 2**_state.weightedDayIndex>>
 			<<else>>
-				<<set _random = random(1, Math.pow(15, _state.weightedDayIndex))>>
-				<<set _threshold = Math.pow(15, _state.weightedDayIndex) - Math.pow(14, _state.weightedDayIndex)>>
+				<<set _random = random(1, 15**_state.weightedDayIndex)>>
+				<<set _threshold = 15**_state.weightedDayIndex - 14**_state.weightedDayIndex>>
 			<</if>>
 			<<if _random <= _threshold>>
 				<<include "Wetting Events">>
@@ -2861,8 +2860,8 @@ $flaskMatrixLabel[$flaskPref] ($flaskMatrix[$flaskPref] remaining)
 	<br><br>
 	<<if _selection == "Oral Dom">>
 	<<include "Hijinks Oral Dom">>
-	<<if _handle.pregnantT == 9999 && $app.penisCor >0 && (_handle.womb1 == "throat" || _handle.womb2 == "throat") && (_temp < 20 || _handle.curses.some(e => e.name === "Absolute Pregnancy")) && !_handle.curses.some(e => e.name === "Absolute Birth Control") && !$app.curses.some(e => e.name === "Absolute Birth Control")>>
-		<<set _handle.pregnantT = $time-14>>
+	<<if !setup.isPregnant(_handle) && $app.penisCor >0 && (_handle.womb1 == "throat" || _handle.womb2 == "throat") && (_temp < 20 || _handle.curses.some(e => e.name === "Absolute Pregnancy")) && !_handle.curses.some(e => e.name === "Absolute Birth Control") && !$app.curses.some(e => e.name === "Absolute Birth Control")>>
+		<<set setup.setConsideredPregnant(_handle)>>
 	<</if>>
 	<<elseif _selection == "Oral Sub">>
 	<<include "Hijinks Oral Sub">>
@@ -2879,11 +2878,11 @@ $flaskMatrixLabel[$flaskPref] ($flaskMatrix[$flaskPref] remaining)
 	<</if>>
 	<<elseif _selection == "DP Dom">>
 
-	<<if _handle.pregnantT == 9999 && _handle.womb > 0 && (_temp < 20 || _handle.curses.some(e => e.name === "Absolute Pregnancy")) && !_handle.curses.some(e => e.name === "Absolute Birth Control") && !$app.curses.some(e => e.name === "Absolute Birth Control")>>
-		<<set _handle.pregnantT = $time-14>>
+	<<if !setup.isPregnant(_handle) && _handle.womb > 0 && (_temp < 20 || _handle.curses.some(e => e.name === "Absolute Pregnancy")) && !_handle.curses.some(e => e.name === "Absolute Birth Control") && !$app.curses.some(e => e.name === "Absolute Birth Control")>>
+		<<set setup.setConsideredPregnant(_handle)>>
 	<</if>>
 	<<if (_handle.womb1 == "anus" || _handle.womb2 == "anus") && (_temp < 20 || _handle.curses.some(e => e.name === "Absolute Pregnancy")) && !_handle.curses.some(e => e.name === "Absolute Birth Control") && !$app.curses.some(e => e.name === "Absolute Birth Control")>>
-		<<set _handle.pregnantT = $time-14>>
+		<<set setup.setConsideredPregnant(_handle)>>
 	<</if>>
 	<<elseif _selection == "Anal Sub">>
 
@@ -2892,8 +2891,8 @@ $flaskMatrixLabel[$flaskPref] ($flaskMatrix[$flaskPref] remaining)
 	<</if>>
 	<<elseif _selection == "Anal Dom">>
 
-	<<if _handle.pregnantT == 9999 && (_handle.womb1 == "anus" || _handle.womb2 == "anus") && (_temp < 20 || _handle.curses.some(e => e.name === "Absolute Pregnancy")) && !_handle.curses.some(e => e.name === "Absolute Birth Control") && !$app.curses.some(e => e.name === "Absolute Birth Control")>>
-		<<set _handle.pregnantT = $time-14>>
+	<<if !setup.isPregnant(_handle) && (_handle.womb1 == "anus" || _handle.womb2 == "anus") && (_temp < 20 || _handle.curses.some(e => e.name === "Absolute Pregnancy")) && !_handle.curses.some(e => e.name === "Absolute Birth Control") && !$app.curses.some(e => e.name === "Absolute Birth Control")>>
+		<<set setup.setConsideredPregnant(_handle)>>
 	<</if>>
 	<<elseif _selection == "Regular Sub">>
 
@@ -2902,13 +2901,13 @@ $flaskMatrixLabel[$flaskPref] ($flaskMatrix[$flaskPref] remaining)
 	<</if>>
 	<<elseif _selection == "Regular Dom">>
 
-	<<if _handle.pregnantT == 9999 && _handle.womb > 0 && (_temp < 20 || _handle.curses.some(e => e.name === "Absolute Pregnancy")) && !_handle.curses.some(e => e.name === "Absolute Birth Control") && !$app.curses.some(e => e.name === "Absolute Birth Control")>>
-		<<set _handle.pregnantT = $time-14>>
+	<<if !setup.isPregnant(_handle) && _handle.womb > 0 && (_temp < 20 || _handle.curses.some(e => e.name === "Absolute Pregnancy")) && !_handle.curses.some(e => e.name === "Absolute Birth Control") && !$app.curses.some(e => e.name === "Absolute Birth Control")>>
+		<<set setup.setConsideredPregnant(_handle)>>
 	<</if>>
 	<<elseif _selection == "Regular Alt Sub">>
 
-	<<if _handle.pregnantT == 9999 && _handle.womb > 0 && (_temp < 20 || _handle.curses.some(e => e.name === "Absolute Pregnancy")) && !_handle.curses.some(e => e.name === "Absolute Birth Control") && !$app.curses.some(e => e.name === "Absolute Birth Control")>>
-		<<set _handle.pregnantT = $time-14>>
+	<<if !setup.isPregnant(_handle) && _handle.womb > 0 && (_temp < 20 || _handle.curses.some(e => e.name === "Absolute Pregnancy")) && !_handle.curses.some(e => e.name === "Absolute Birth Control") && !$app.curses.some(e => e.name === "Absolute Birth Control")>>
+		<<set setup.setConsideredPregnant(_handle)>>
 	<</if>>	
 	<<elseif _selection == "Regular Alt Dom">>
 
@@ -2917,8 +2916,8 @@ $flaskMatrixLabel[$flaskPref] ($flaskMatrix[$flaskPref] remaining)
 	<</if>>
 	<<elseif _selection == "Boobjob Dom">>
 
-	<<if _handle.pregnantT == 9999 && _handle.womb > 0 && _handle.curses.some(e => e.name === "Absolute Pregnancy")>>
-		<<set _handle.pregnantT = $time-14>>
+	<<if !setup.isPregnant(_handle) && _handle.womb > 0 && _handle.curses.some(e => e.name === "Absolute Pregnancy")>>
+		<<set setup.setConsideredPregnant(_handle)>>
 	<</if>>
 	<<elseif _selection == "Boobjob Sub">>
 
@@ -2931,8 +2930,8 @@ $flaskMatrixLabel[$flaskPref] ($flaskMatrix[$flaskPref] remaining)
 		<<set $pregChance /= 10>>
 		<<PregCheck>>
 	<</if>>
-	<<if _handle.pregnantT == 9999 && _handle.womb > 0 && (_temp < 2 || _handle.curses.some(e => e.name === "Absolute Pregnancy")) && !_handle.curses.some(e => e.name === "Absolute Birth Control") && !$app.curses.some(e => e.name === "Absolute Birth Control")>>
-		<<set _handle.pregnantT = $time-14>>
+	<<if !setup.isPregnant(_handle) && _handle.womb > 0 && (_temp < 2 || _handle.curses.some(e => e.name === "Absolute Pregnancy")) && !_handle.curses.some(e => e.name === "Absolute Birth Control") && !$app.curses.some(e => e.name === "Absolute Birth Control")>>
+		<<set setup.setConsideredPregnant(_handle)>>
 	<</if>>*/
 	<</if>>
 <</if>>

--- a/src/init.twee
+++ b/src/init.twee
@@ -177,14 +177,13 @@ document.documentElement.setAttribute("lang", "en");
 <<set $heatCycleT_flag = false>>
 <<set $menFirstCycle = true>>
 <<set $EggsFertilized = false>>
-<<set $due = 9999>>
 <<set $BabysBirthed = 0>>
 
 <<set $escBalDepl = 0>>
 <<set $convoStart = 1>>
 <<set $endloop = false>>
 <<set $LastEx =0>>
-<<set $SizeHandicap=0>>
+<<set $SizeHandicap = 0>>
 <<set $SibylBuff = 0 >>
 <<set $slingshot = 0>>
 <<set $joyousSword = 0>>
@@ -253,20 +252,18 @@ hair: "black",
 penis: 6,
 openis: 6,
 doublePenis: false,
-modpenis: 0,
 penisCor: 6,
 vagina: 0,
 gender: 1,
 ogender: 1,
-modgender:0,
 switch: false,
 breasts: 0,
 obreasts: 0,
-modbreasts: 0,
 breastsCor: 0,
 breastsLabel: "flat",
 lactation: 0,
-pregnantT: 9999,
+pregnantT: setup.never,
+due: setup.never,
 ears: "normal human",
 height: 170,
 oheight: 170,
@@ -545,16 +542,14 @@ pic: "Wonders/puritytree.png"
 		penis: $app.openis,
 		penisCor: $app.openis,
 		doublePenis: false,
-		modpenis: 0,
 		vagina: 0,
 		gender: $app.ogender,
-		modgender:0,
 		switch: false,
 		breasts: $app.obreast,
-		modbreasts: 0,
 		breastsCor: $app.obreast,
 		lactation: 0,
-		pregnantT: 9999,
+		pregnantT: setup.never,
+		due: setup.never,
 		ears: "normal human",
 		height: $app.oheight,
 		modheight: 0,

--- a/src/layer1.twee
+++ b/src/layer1.twee
@@ -422,10 +422,10 @@ The Curses you have obtained with Cherry's Chaotic Luck are $curses[_temp1].name
 <</if>>
 <<if _temp1==9 || _temp2==9>>
 	<<set $dizzyCount +=1>>
-	<<if $HeightIncrease == 0>>
-		<br>Would you like to increase or descrease your height?<br>
-		<<radiobutton "$HeightIncrease " -1 checked>> Decrease<br>
-		<<radiobutton "$HeightIncrease " 1 >> Increase<br>
+	<<if !$HeightIncrease>>
+		<br>Would you like to increase or decrease your height?<br>
+		<<radiobutton "$HeightIncrease" -1 checked>> Decrease<br>
+		<<radiobutton "$HeightIncrease" 1 >> Increase<br>
 	<<elseif $HeightIncrease == 1>>
 		You feel yourself growing even more.<br>
 	<<else>>
@@ -466,10 +466,10 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 	<<set $GenderLog.push($curse5)>>[[Continue on to the rest of the layer|Layer1 Hub]]
 <<elseif $temp2==9>>
 	<<set $dizzyCount +=1>>
-	<<if $HeightIncrease == 0>>
-		Would you like to increase or descrease your height?<br>
-		<<radiobutton "$HeightIncrease " -1 checked>> Decrease<br>
-		<<radiobutton "$HeightIncrease " 1 >> Increase<br>
+	<<if !$HeightIncrease>>
+		Would you like to increase or decrease your height?<br>
+		<<radiobutton "$HeightIncrease" -1 checked>> Decrease<br>
+		<<radiobutton "$HeightIncrease" 1 >> Increase<br>
 	<<elseif $HeightIncrease == 1>>
 		You feel yourself growing even more.<br>
 	<<else>>
@@ -906,10 +906,10 @@ It seems that you now look like either an elf out of a storybook or someone who 
 [img[setup.ImagePath + $curse10.pic]]
 
 <<nobr>>
-<<if $HeightIncrease == 0>>
-	Would you like to increase or descrease your height?<br>
-	<<radiobutton "$HeightIncrease " -1 checked>> Decrease<br>
-	<<radiobutton "$HeightIncrease " 1 >> Increase<br>
+<<if !$HeightIncrease>>
+	Would you like to increase or decrease your height?<br>
+	<<radiobutton "$HeightIncrease" -1 checked>> Decrease<br>
+	<<radiobutton "$HeightIncrease" 1 >> Increase<br>
 <<elseif $HeightIncrease == 1>>
 	In the first moments after the Curse sets in, you hardly notice anything amiss. However, a growing discomfort seizes your body, leaving you feeling sore and aching. You sit down, trying to alleviate the pain as dizziness overwhelms you. The sensation feels familiar, reminiscent of something from long ago... growing pains.<br><br>
 

--- a/src/layer1.twee
+++ b/src/layer1.twee
@@ -409,9 +409,6 @@ The Curses you have obtained with Cherry's Chaotic Luck are $curses[_temp1].name
 <</if>>
 <<if _temp1==2 || _temp2==2>>
 	<<set $GenderLog.push($curse3)>>
-	<<if $app.sex=="male" && $app.breastsCor>0 >>
-		<<set $GenderLog.push("Interact A")>>
-	<</if>>
 <</if>>
 <<if _temp1==4 || _temp2==4>>
 	<<set $GenderLog.push($curse5)>>
@@ -461,7 +458,7 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 <<elseif $temp2==1>>
 	<<set $GenderLog.push($curse2)>>[[Continue on to the rest of the layer|Layer1 Hub]]
 <<elseif $temp2==2>>
-	<<set $GenderLog.push($curse3)>><<if $app.sex=="male" && $app.breastsCor>0 >><<set $GenderLog.push("Interact A")>><</if>>[[Continue on to the rest of the layer|Layer1 Hub]]
+	<<set $GenderLog.push($curse3)>>[[Continue on to the rest of the layer|Layer1 Hub]]
 <<elseif $temp2==4>>
 	<<set $GenderLog.push($curse5)>>[[Continue on to the rest of the layer|Layer1 Hub]]
 <<elseif $temp2==9>>
@@ -765,7 +762,7 @@ You realize the fabric is in fact some kind of long glove. You stick your hand i
 
 
 :: Take on Asset Robustness A [layer1]
-<<set $playerCurses.push($curse3)>><<set $corruption += $curse3.corr>><<set $GenderLog.push($curse3)>><<if $app.sex=="male" && $app.breastsCor>0 >><<set $GenderLog.push("Interact A")>><</if>>\
+<<set $playerCurses.push($curse3)>><<set $corruption += $curse3.corr>><<set $GenderLog.push($curse3)>>\
 [img[setup.ImagePath + $curse3.pic]]
 <<GenderCorrected>>\
 <<if $app.penisCor>0 && $app.breastsCor==0 >>

--- a/src/layer2.twee
+++ b/src/layer2.twee
@@ -433,7 +433,7 @@ The Curses you have obtained with Cherry's Chaotic Luck are $curses[$temp1].name
 	<<set $GenderLog.push($curse14)>>
 <</if>>
 <<if $curses[$temp1].name == "Asset Robustness B" || $curses[$temp2].name == "Asset Robustness B">>
-	<<set $GenderLog.push($curse15)>><<if $app.sex=="male" && $app.breastsCor>0 >><<set $GenderLog.push("Interact B")>><</if>>
+	<<set $GenderLog.push($curse15)>>
 <</if>>
 <<if $curses[$temp1].name ==  "Sex Switcheroo" || $curses[$temp2].name ==  "Sex Switcheroo">>
 	<<set $GenderLog.push($curse22)>>
@@ -516,7 +516,7 @@ What type of fur would you like to gain?
 	<<set $GenderLog.push($curse14)>>
 <</if>>
 <<if $curses[$temp2].name ==  "Asset Robustness B">>
-	<<set $GenderLog.push($curse15)>><<if $app.sex=="male" && $app.breastsCor>0 >><<set $GenderLog.push("Interact B")>><</if>>
+	<<set $GenderLog.push($curse15)>>
 <</if>>
 <<if $curses[$temp2].name ==  "Sex Switcheroo">>
 	<<set $GenderLog.push($curse22)>>
@@ -828,7 +828,7 @@ How do you feel? Did you ask your companion before the switch? Be prepared for y
 
 
 :: Take on Asset Robustness B [layer2]
-<<set $playerCurses.push($curse15)>><<set $corruption += $curse15.corr>><<set $GenderLog.push($curse15)>><<if $app.sex=="male" && $app.breastsCor>0 >><<set $GenderLog.push("Interact B")>><</if>>\
+<<set $playerCurses.push($curse15)>><<set $corruption += $curse15.corr>><<set $GenderLog.push($curse15)>>\
 [img[setup.ImagePath + $curse15.pic]]
 <<GenderCorrected>>
 <<if $app.penisCor>0 && $app.breastsCor==0 >>

--- a/src/layer3.twee
+++ b/src/layer3.twee
@@ -459,7 +459,7 @@ This may impact how your sexual encounters and conversations with your companion
 
 
 :: Take on Asset Robustness C [layer3]
-<<set $playerCurses.push($curse27)>><<set $corruption += $curse27.corr>><<set $GenderLog.push($curse27)>><<if $app.sex=="male" && $app.breastsCor>0 >><<set $GenderLog.push("Interact C")>><</if>>\
+<<set $playerCurses.push($curse27)>><<set $corruption += $curse27.corr>><<set $GenderLog.push($curse27)>>\
 <<GenderCorrected>>\
 [img[setup.ImagePath + $curse27.pic]]
 
@@ -994,7 +994,7 @@ Please enter your new skin/eye color:
 	<<set $GenderLog.push($curse26)>>
 <</if>>
 <<if $curses[_temp1].name ==  "Asset Robustness C" || $curses[_temp2].name ==  "Asset Robustness C">>
-	<<set $GenderLog.push($curse27)>><<if $app.sex=="male" && $app.breastsCor>0 >><<set $GenderLog.push("Interact C")>><</if>>
+	<<set $GenderLog.push($curse27)>>
 <</if>>
 <<if $curses[_temp1].name == "Power Dom" || $curses[_temp2].name ==  "Power Dom">>
 	<<set $LibidoLog.push($curse29)>>
@@ -1058,7 +1058,7 @@ Please enter your new skin/eye color:
 	<<set $GenderLog.push($curse26)>>
 <</if>>
 <<if $curses[_temp2].name == "Asset Robustness C">>
-	<<set $GenderLog.push($curse27)>><<if $app.sex=="male" && $app.breastsCor>0 >><<set $GenderLog.push("Interact C")>><</if>>
+	<<set $GenderLog.push($curse27)>>
 <</if>>
 <<if $curses[_temp2].name == "Power Dom">>
 	<<set $LibidoLog.push($curse29)>>

--- a/src/layer4.twee
+++ b/src/layer4.twee
@@ -162,8 +162,8 @@ How would you like to use Cherry's chaotic luck ability?
 [img[setup.ImagePath+'Clipped-Fin/Abyss Diver Page 5-foraging.png']]
 
 If you decide to start foraging for food or water, it means that you will not consume your stored food rations or water supply while consuming time on tasks in this layer, but you will not obtain more supplies by starting to forage here.
-<<if $HeightIncrease == "0" && $forageFood == 1>>
-Would you like to increase or descrease your height due to eating flairabou meat?
+<<if !$HeightIncrease && $forageFood == 1>>
+Would you like to increase or decrease your height due to eating flairabou meat?
 
 <<radiobutton "$HeightIncrease" -1 checked>> Decrease
 <<radiobutton "$HeightIncrease" 1 >> Increase

--- a/src/layer4.twee
+++ b/src/layer4.twee
@@ -338,7 +338,7 @@ As you continue your descent into the frost-bitten depths, you ponder your situa
 
 
 :: Take on Asset Robustness D [layer4]
-<<set $playerCurses.push($curse43)>><<set $corruption += $curse43.corr>><<set $GenderLog.push($curse43)>><<if $app.sex=="male" && $app.breastsCor>0 >><<set $GenderLog.push("Interact D")>><</if>>\
+<<set $playerCurses.push($curse43)>><<set $corruption += $curse43.corr>><<set $GenderLog.push($curse43)>>\
 <<GenderCorrected>>\
 [img[setup.ImagePath + $curse4.pic]]
 
@@ -1334,7 +1334,7 @@ Please enter your new scale color:
 <</if>>
 <<nobr>>
 <<if $curses[$temp1].name ==  "Asset Robustness D" || $curses[$temp2].name ==  "Asset Robustness D">>
-	<<set $GenderLog.push($curse43)>><<if $app.sex=="male" && $app.breastsCor>0 >><<set $GenderLog.push("Interact D")>><</if>>
+	<<set $GenderLog.push($curse43)>>
 <</if>>
 
 <<if $curses[$temp1].name ==  "Libido Reinforcement C" || $curses[$temp2].name ==  "Asset Robustness D">>
@@ -1375,7 +1375,7 @@ Please enter your new scale color:
 
 <</if>>
 <<nobr>><<if $playerCurses.some(e => e.name === "Asset Robustness D")>>
-	<<set $GenderLog.push($curse43)>><<if $app.sex=="male" && $app.breastsCor>0 >><<set $GenderLog.push("Interact D")>><</if>>
+	<<set $GenderLog.push($curse43)>>
 <</if>>
 
 <<if $playerCurses.some(e => e.name === "Libido Reinforcement C")>>

--- a/src/layer5.twee
+++ b/src/layer5.twee
@@ -1276,21 +1276,9 @@ Please enter your new exoskeleton color:
 
 	<<link "Reroll with Devil's Own" "Layer5 Cherry Curse">>
 		<<set $corruption -= $playerCurses[$playerCurses.length - 1].corr>>
-		<<if $curses[$temp1].type == "Gender" >>
-			<<set _temp = $GenderLog.length>>
-			<<if $GenderLog[_temp-1] == "Interact A" || $GenderLog[_temp-1] == "Interact B" || $GenderLog[_temp-1] == "Interact C" || $GenderLog[_temp-1] == "Interact D" || $GenderLog[_temp-1] == "Interact E" || $GenderLog[_temp-1] == "Interact F" || $GenderLog[_temp-1] == "Interact G">>
-				<<set $GenderLog.deleteAt(_temp-1)>>
-			<</if>>
-		<</if>>
 		<<RemoveCurse $curses[$temp1]>>
 		
 		<<set $corruption -= $playerCurses[$playerCurses.length - 1].corr>>
-		<<if $curses[$temp2].type == "Gender" >>
-			<<set _temp = $GenderLog.length>>
-			<<if $GenderLog[_temp-1] == "Interact A" || $GenderLog[_temp-1] == "Interact B" || $GenderLog[_temp-1] == "Interact C" || $GenderLog[_temp-1] == "Interact D" || $GenderLog[_temp-1] == "Interact E" || $GenderLog[_temp-1] == "Interact F" || $GenderLog[_temp-1] == "Interact G">>
-				<<set $GenderLog.deleteAt(_temp-1)>>
-			<</if>>
-		<</if>>
 		<<RemoveCurse $curses[$temp2]>>
 
 		<<set setup.loseRelic("Devil's Own")>>
@@ -1367,12 +1355,6 @@ Please enter your new exoskeleton color:
 		<<set $corruption += Math.floor(Math.max(($relics[$temp1].corr / 2) - $corRed, 0))>>
 		
 		<<set $corruption -= $playerCurses[$playerCurses.length - 1].corr>>
-		<<if $curses[$temp2].type == "Gender" >>
-			<<set _temp = $GenderLog.length>>
-			<<if $GenderLog[_temp-1] == "Interact A" || $GenderLog[_temp-1] == "Interact B" || $GenderLog[_temp-1] == "Interact C" || $GenderLog[_temp-1] == "Interact D" || $GenderLog[_temp-1] == "Interact E" || $GenderLog[_temp-1] == "Interact F" || $GenderLog[_temp-1] == "Interact G">>
-				<<set $GenderLog.deleteAt(_temp-1)>>
-			<</if>>
-		<</if>>
 		<<RemoveCurse $curses[$temp2]>>
 		<<set setup.loseRelic("Devil's Own")>>
 	<</link>>

--- a/src/layer5.twee
+++ b/src/layer5.twee
@@ -134,8 +134,8 @@ How would you like to use Cherry's chaotic luck ability?
 	As the aphrodisiacs permeate the air, a primal urge seizes you, igniting an intense heat deep within. Overwhelmed by a desire more powerful than anything you've ever experienced, your senses are heightened and your body craves satisfaction. Intoxicated by this tidal wave of passion, your thoughts blur, and your memories of the day meld together into a tapestry of sensual encounters.<br><br>
 	<<if _selection == "Oral Dom">>
 	At one point, you recall _handle.name's <<if _handle.sex=="male">>his<<else>>her<</if>> lips <<if $app.penisCor > 2 && $app.vagina == 0>>encircling your throbbing cock, the moist warmth enveloping you entirely. It wasn't long before you released your pent-up desires, filling _handle.name's throat with your essence.<<elseif $app.penisCor <= 2 && $app.vagina > 0>>pressed firmly against your quivering pussy, their tongue working relentlessly, driving you to an earth-shattering climax that left you weak in the knees.<<else>>wrapped tightly around your cock, then shifting lower to lavish attention on your pulsating pussy. You lost count of your orgasms, but one particularly intense wave left _handle.name eagerly swallowing your release.<</if>>
-	<<if _handle.pregnantT == 9999 && $app.penisCor >0 && (_handle.womb1 == "throat" || _handle.womb2 == "throat") && (_temp < 20 || _handle.curses.some(e => e.name === "Absolute Pregnancy")) && !_handle.curses.some(e => e.name === "Absolute Birth Control") && !$app.curses.some(e => e.name === "Absolute Birth Control")>>
-		<<set _handle.pregnantT = $time-14>>
+	<<if !setup.isPregnant(_handle) && $app.penisCor >0 && (_handle.womb1 == "throat" || _handle.womb2 == "throat") && (_temp < 20 || _handle.curses.some(e => e.name === "Absolute Pregnancy")) && !_handle.curses.some(e => e.name === "Absolute Birth Control") && !$app.curses.some(e => e.name === "Absolute Birth Control")>>
+		<<set setup.setConsideredPregnant(_handle)>>
 	<</if>>
 	<<elseif _selection == "Oral Sub">>
 	At one point, you remember your lips <<if _handle.penisCor > 2 && _handle.vagina == 0>>wrapped around _handle.name's throbbing cock, taking it deep into your throat as the salty tip occasionally rewarded your efforts with a burst of flavor.<<elseif _handle.penisCor <= 2 && _handle.vagina > 0>>pressed against _handle.name's slick pussy, your tongue exploring <<if _handle.sex=="male">>his<<else>>her<</if>> warm folds with fervor.<<else>>wrapped around _handle.name's cock, swallowing it to the hilt before switching to lavish attention on <<if _handle.sex=="male">>his<<else>>her<</if>> dripping pussy.<</if>>
@@ -152,11 +152,11 @@ How would you like to use Cherry's chaotic luck ability?
 	<</if>>
 	<<elseif _selection == "DP Dom">>
 	Some memories flicker more clearly than others, but you're certain that at one point both your penises were simultaneously filling _handle.name's eager holes. The unique sensation of two cocks being stimulated at the same time was exhilarating, and the shared orgasm that followed was a transcendent experience unlike any other.
-	<<if _handle.pregnantT == 9999 && _handle.womb > 0 && (_temp < 20 || _handle.curses.some(e => e.name === "Absolute Pregnancy")) && !_handle.curses.some(e => e.name === "Absolute Birth Control") && !$app.curses.some(e => e.name === "Absolute Birth Control")>>
-		<<set _handle.pregnantT = $time-14>>
+	<<if !setup.isPregnant(_handle) && _handle.womb > 0 && (_temp < 20 || _handle.curses.some(e => e.name === "Absolute Pregnancy")) && !_handle.curses.some(e => e.name === "Absolute Birth Control") && !$app.curses.some(e => e.name === "Absolute Birth Control")>>
+		<<set setup.setConsideredPregnant(_handle)>>
 	<</if>>
 	<<if (_handle.womb1 == "anus" || _handle.womb2 == "anus") && (_temp < 20 || _handle.curses.some(e => e.name === "Absolute Pregnancy")) && !_handle.curses.some(e => e.name === "Absolute Birth Control") && !$app.curses.some(e => e.name === "Absolute Birth Control")>>
-		<<set _handle.pregnantT = $time-14>>
+		<<set setup.setConsideredPregnant(_handle)>>
 	<</if>>
 	<<elseif _selection == "Anal Sub">>
 	Your memory is filled with the sultry sound of your own moans, as _handle.name's throbbing penis penetrated your tight, quivering ass. You can't quite remember the exact duration of the relentless pounding, but the aftermath left you breathless and drooling, utterly sated.
@@ -165,8 +165,8 @@ How would you like to use Cherry's chaotic luck ability?
 	<</if>>
 	<<elseif _selection == "Anal Dom">>
 	The vivid recollection of _handle.name's desperate moans rings in your ears, as your rock-hard dick relentlessly pounded <<if _handle.sex=="male">>his<<else>>her<</if>> inviting ass. The memory of how long you dominated _handle.name's behind is hazy, but one thing is clear: <<if _handle.sex=="male">>he<<else>>she<</if>> was left a panting, drooling mess in the aftermath.
-	<<if _handle.pregnantT == 9999 && (_handle.womb1 == "anus" || _handle.womb2 == "anus") && (_temp < 20 || _handle.curses.some(e => e.name === "Absolute Pregnancy")) && !_handle.curses.some(e => e.name === "Absolute Birth Control") && !$app.curses.some(e => e.name === "Absolute Birth Control")>>
-		<<set _handle.pregnantT = $time-14>>
+	<<if !setup.isPregnant(_handle) && (_handle.womb1 == "anus" || _handle.womb2 == "anus") && (_temp < 20 || _handle.curses.some(e => e.name === "Absolute Pregnancy")) && !_handle.curses.some(e => e.name === "Absolute Birth Control") && !$app.curses.some(e => e.name === "Absolute Birth Control")>>
+		<<set setup.setConsideredPregnant(_handle)>>
 	<</if>>
 	<<elseif _selection == "Regular Sub">>
 	Your memories are filled with the warmth and comfort of being embraced by _handle.name. The tender cuddling gradually evolved into passionate kisses and caresses until <<if _handle.sex=="male">>he<<else>>she<</if>> was lying naked on top of you. Your ecstatic screams filled the air as <<if _handle.sex=="male">>he<<else>>she<</if>> filled you with their essence, your legs locked around their waist, trapping them in your loving embrace.
@@ -175,13 +175,13 @@ How would you like to use Cherry's chaotic luck ability?
 	<</if>>
 	<<elseif _selection == "Regular Dom">>
 	The memory of gently cuddling _handle.name soon turned into a passionate session of intimate hugs and feverish kisses. Before long, <<if _handle.sex=="male">>he<<else>>she<</if>> was naked beneath you, trembling with anticipation. As you penetrated <<if _handle.sex=="male">>him<<else>>her<</if>>, _handle.name's cries of ecstasy filled the room, their legs locked around your waist, while you released your passion deep inside of <<if _handle.sex=="male">>him<<else>>her<</if>>.
-	<<if _handle.pregnantT == 9999 && _handle.womb > 0 && (_temp < 20 || _handle.curses.some(e => e.name === "Absolute Pregnancy")) && !_handle.curses.some(e => e.name === "Absolute Birth Control") && !$app.curses.some(e => e.name === "Absolute Birth Control")>>
-		<<set _handle.pregnantT = $time-14>>
+	<<if !setup.isPregnant(_handle) && _handle.womb > 0 && (_temp < 20 || _handle.curses.some(e => e.name === "Absolute Pregnancy")) && !_handle.curses.some(e => e.name === "Absolute Birth Control") && !$app.curses.some(e => e.name === "Absolute Birth Control")>>
+		<<set setup.setConsideredPregnant(_handle)>>
 	<</if>>
 	<<elseif _selection == "Regular Alt Sub">>
 	You recall the moment when _handle.name tenderly took your hand and guided you down to lie beside <<if _handle.sex=="male">>him<<else>>her<</if>>. As your lips met in a passionate embrace, <<if _handle.sex=="male">>he<<else>>she<</if>> eagerly undressed you. Your arousal was evident as both of you became naked, and _handle.name couldn't help but notice. <<if _handle.sex=="male">>He<<else>>She<</if>> climbed on top of you, sensually riding you until you both reached shuddering, toe-curling climaxes.
-	<<if _handle.pregnantT == 9999 && _handle.womb > 0 && (_temp < 20 || _handle.curses.some(e => e.name === "Absolute Pregnancy")) && !_handle.curses.some(e => e.name === "Absolute Birth Control") && !$app.curses.some(e => e.name === "Absolute Birth Control")>>
-		<<set _handle.pregnantT = $time-14>>
+	<<if !setup.isPregnant(_handle) && _handle.womb > 0 && (_temp < 20 || _handle.curses.some(e => e.name === "Absolute Pregnancy")) && !_handle.curses.some(e => e.name === "Absolute Birth Control") && !$app.curses.some(e => e.name === "Absolute Birth Control")>>
+		<<set setup.setConsideredPregnant(_handle)>>
 	<</if>>	
 	<<elseif _selection == "Regular Alt Dom">>
 	You remember taking _handle.name's hand and drawing <<if _handle.sex=="male">>him<<else>>her<</if>> close to lie beside you. As your lips collided in fervent kisses, you eagerly undressed <<if _handle.sex=="male">>him<<else>>her<</if>>. _handle.name was visibly aroused by the time you were both naked, a fact you delighted in. You straddled _handle.name and rode <<if _handle.sex=="male">>him<<else>>her<</if>> passionately, the intensity building until you both succumbed to electrifying, toe-curling orgasms.
@@ -190,8 +190,8 @@ How would you like to use Cherry's chaotic luck ability?
 	<</if>>
 	<<elseif _selection == "Boobjob Dom">>
 	You remember accidentally brushing against _handle.name's breast, which surprisingly elicited a flirtatious giggle. Within moments, <<if _handle.sex=="male">>his<<else>>her<</if>> breasts were exposed and you were caressing them with fervor. Unable to control yourself any longer, you pushed <<if _handle.sex=="male">>him<<else>>her<</if>> down and unveiled your throbbing arousal. Then, you reveled in the sensation of _handle.name enveloping your shaft with <<if _handle.sex=="male">>his<<else>>her<</if>> ample cleavage, working it expertly until you reached a climactic release, showering <<if _handle.sex=="male">>him<<else>>her<</if>> with your essence.
-	<<if _handle.pregnantT == 9999 && _handle.womb > 0 && _handle.curses.some(e => e.name === "Absolute Pregnancy")>>
-		<<set _handle.pregnantT = $time-14>>
+	<<if !setup.isPregnant(_handle) && _handle.womb > 0 && _handle.curses.some(e => e.name === "Absolute Pregnancy")>>
+		<<set setup.setConsideredPregnant(_handle)>>
 	<</if>>
 	<<elseif _selection == "Boobjob Sub">>
 	You remember _handle.name accidentally brushing against your breast, evoking a wicked giggle that you couldn't suppress. Soon, your breasts were bared, and <<if _handle.sex=="male">>he<<else>>she<</if>> was eagerly fondling them. Unable to contain <<if _handle.sex=="male">>himself<<else>>herself<</if>> any longer, _handle.name pushed you down and revealed <<if _handle.sex=="male">>his<<else>>her<</if>> throbbing arousal. Then, you felt _handle.name nestle <<if _handle.sex=="male">>his<<else>>her<</if>> shaft between your enticing cleavage, and you eagerly worked it with equal enthusiasm. The pleasure built until <<if _handle.sex=="male">>he<<else>>she<</if>> reached a powerful climax, drenching you in <<if _handle.sex=="male">>his<<else>>her<</if>> hot, sticky release.
@@ -204,8 +204,8 @@ How would you like to use Cherry's chaotic luck ability?
 		<<set $pregChance /= 10>>
 		<<PregCheck>>
 	<</if>>
-	<<if _handle.pregnantT == 9999 && _handle.womb > 0 && (_temp < 2 || _handle.curses.some(e => e.name === "Absolute Pregnancy")) && !_handle.curses.some(e => e.name === "Absolute Birth Control") && !$app.curses.some(e => e.name === "Absolute Birth Control")>>
-		<<set _handle.pregnantT = $time-14>>
+	<<if !setup.isPregnant(_handle) && _handle.womb > 0 && (_temp < 2 || _handle.curses.some(e => e.name === "Absolute Pregnancy")) && !_handle.curses.some(e => e.name === "Absolute Birth Control") && !$app.curses.some(e => e.name === "Absolute Birth Control")>>
+		<<set setup.setConsideredPregnant(_handle)>>
 	<</if>>
 	<<elseif _selection == "Self">>
 	<<if $app.sex=="doll-like">>

--- a/src/layer6.twee
+++ b/src/layer6.twee
@@ -879,21 +879,9 @@ The Curses you have obtained with Cherry's Chaotic Luck are $curses[$temp1].name
 
 	<<link "Reroll with Devil's Own" "Layer6 Cherry Curse">>
 		<<set $corruption -= $playerCurses[$playerCurses.length - 1].corr>>
-		<<if $curses[$temp1].type == "Gender" >>
-			<<set _temp = $GenderLog.length>>
-			<<if $GenderLog[_temp-1] == "Interact A" || $GenderLog[_temp-1] == "Interact B" || $GenderLog[_temp-1] == "Interact C" || $GenderLog[_temp-1] == "Interact D" || $GenderLog[_temp-1] == "Interact E" || $GenderLog[_temp-1] == "Interact F" || $GenderLog[_temp-1] == "Interact G">>
-				<<set $GenderLog.deleteAt(_temp-1)>>
-			<</if>>
-		<</if>>
 		<<RemoveCurse $curses[$temp1]>>
 		
 		<<set $corruption -= $playerCurses[$playerCurses.length - 1].corr>>
-		<<if $curses[$temp2].type == "Gender" >>
-			<<set _temp = $GenderLog.length>>
-			<<if $GenderLog[_temp-1] == "Interact A" || $GenderLog[_temp-1] == "Interact B" || $GenderLog[_temp-1] == "Interact C" || $GenderLog[_temp-1] == "Interact D" || $GenderLog[_temp-1] == "Interact E" || $GenderLog[_temp-1] == "Interact F" || $GenderLog[_temp-1] == "Interact G">>
-				<<set $GenderLog.deleteAt(_temp-1)>>
-			<</if>>
-		<</if>>
 		<<RemoveCurse $curses[$temp2]>>
 		<<set setup.loseRelic("Devil's Own")>>
 	<</link>>
@@ -940,12 +928,6 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 		<<set $corruption += Math.floor(Math.max(($relics[$temp1].corr / 2) - $corRed, 0))>>
 		
 		<<set $corruption -= $playerCurses[$playerCurses.length - 1].corr>>
-		<<if $curses[$temp2].type == "Gender" >>
-			<<set _temp = $GenderLog.length>>
-			<<if $GenderLog[_temp-1] == "Interact A" || $GenderLog[_temp-1] == "Interact B" || $GenderLog[_temp-1] == "Interact C" || $GenderLog[_temp-1] == "Interact D" || $GenderLog[_temp-1] == "Interact E" || $GenderLog[_temp-1] == "Interact F" || $GenderLog[_temp-1] == "Interact G">>
-				<<set $GenderLog.deleteAt(_temp-1)>>
-			<</if>>
-		<</if>>
 		<<RemoveCurse $curses[$temp2]>>
 		<<set setup.loseRelic("Devil's Own")>>
 	<</link>>

--- a/src/layer7.twee
+++ b/src/layer7.twee
@@ -470,46 +470,6 @@ You have successfully taken the $relic84.name Relic. Hopefully you can make good
 <</if>>
 
 
-:: Layer7Time
-<<nobr>>
-<<set $tempTime = (Math.max((1+$SizeHandicap)*($tempTime - $timeRed + $status.penalty + (Math.trunc($hexflame / 10))), 0))>>
-<<if $status.duration > 0>>
-	<<set $status.duration -= 1>>
-	<<else>>
-	<<set $status.penalty = 0>>
-<</if>>
-<<set $timeL7 += $tempTime>>
-<<if $dubloons < 500>>
-	<<set $timeL7T2 += $tempTime>>
-<</if>>
-<<set $time += $tempTime>>
-<<if $dubloons >= 300>>
-	<<set $dubloons -= 1>>
-	<<elseif $dubloons >= 100>>
-	<<set $dubloons -= 2>>
-	<<else>>
-	<<set $dubloons -= 3>>
-<</if>>
-<<if $forageFood == 1>>
-	<<else>>
-	<<set $items[1].count -= $tempTime>>
-<</if>>
-<<for $i = 0; $i < $tempTime; $i++>>
-	<<if $forageWater == 0>>
-		<<if $items[3].count > 0>>
-			<<set $items[3].count -= 1, 0>>
-			<<set $items[2].count += 1, 0>>
-		<<else>>
-			<<set $items[0].count -= 1>>
-		<</if>>
-	<</if>>
-	<<if $hexflame > 9>>
-		<<set $hexflame -= 1>>
-	<</if>>
-<</for>>
-<</nobr>>
-
-
 :: Layer7 Forge1 [layer7]
 <<nobr>>
 <<set $temp1 = -1>>

--- a/src/layer7.twee
+++ b/src/layer7.twee
@@ -839,7 +839,7 @@ Dubloons:
 
 
 :: Take on Asset Robustness E [layer7]
-<<set $playerCurses.push($curse87)>><<set $corruption += $curse87.corr>><<set $GenderLog.push($curse87)>><<if $app.sex=="male" && $app.breastsCor>0 >><<set $GenderLog.push("Interact E")>><</if>>\
+<<set $playerCurses.push($curse87)>><<set $corruption += $curse87.corr>><<set $GenderLog.push($curse87)>>\
 [img[setup.ImagePath + $curse87.pic]]
 
 <<GenderCorrected>><<if $app.penisCor>0 && $app.breastsCor==0 >>
@@ -1178,7 +1178,7 @@ The Curses you have obtained with Cherry's Chaotic Luck are $curses[$temp1].name
 	<<set $GenderLog.push($curse86)>>
 <</if>>
 <<if $curses[$temp1].name == "Asset Robustness E" || $curses[$temp2].name == "Asset Robustness E" >>
-	<<set $GenderLog.push($curse87)>><<if $app.sex=="male" && $app.breastsCor>0 >><<set $GenderLog.push("Interact E")>><</if>>
+	<<set $GenderLog.push($curse87)>>
 <</if>>
 <<if $curses[$temp1].name == "Weakling" || $curses[$temp2].name == "Weakling">>
 	<<set $playerCurses.push($curse91)>>
@@ -1197,21 +1197,9 @@ The Curses you have obtained with Cherry's Chaotic Luck are $curses[$temp1].name
 
 	<<link "Reroll with Devil's Own" "Layer7 Cherry Curse">>
 		<<set $corruption -= $playerCurses[$playerCurses.length - 1].corr>>
-		<<if $curses[$temp1].type == "Gender" >>
-			<<set _temp = $GenderLog.length>>
-			<<if $GenderLog[_temp-1] == "Interact A" || $GenderLog[_temp-1] == "Interact B" || $GenderLog[_temp-1] == "Interact C" || $GenderLog[_temp-1] == "Interact D" || $GenderLog[_temp-1] == "Interact E" || $GenderLog[_temp-1] == "Interact F" || $GenderLog[_temp-1] == "Interact G">>
-				<<set $GenderLog.deleteAt(_temp-1)>>
-			<</if>>
-		<</if>>
 		<<RemoveCurse $curses[$temp1]>>
 		
 		<<set $corruption -= $playerCurses[$playerCurses.length - 1].corr>>
-		<<if $curses[$temp2].type == "Gender" >>
-			<<set _temp = $GenderLog.length>>
-			<<if $GenderLog[_temp-1] == "Interact A" || $GenderLog[_temp-1] == "Interact B" || $GenderLog[_temp-1] == "Interact C" || $GenderLog[_temp-1] == "Interact D" || $GenderLog[_temp-1] == "Interact E" || $GenderLog[_temp-1] == "Interact F" || $GenderLog[_temp-1] == "Interact G">>
-				<<set $GenderLog.deleteAt(_temp-1)>>
-			<</if>>
-		<</if>>
 		<<RemoveCurse $curses[$temp2]>>
 
 		<<set setup.loseRelic("Devil's Own")>>
@@ -1249,7 +1237,7 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 	<<set $GenderLog.push($curse86)>>
 <</if>>
 <<if $curses[$temp2].name == "Asset Robustness E">>
-	<<set $GenderLog.push($curse87)>><<if $app.sex=="male" && $app.breastsCor>0 >><<set $GenderLog.push("Interact E")>><</if>>
+	<<set $GenderLog.push($curse87)>>
 <</if>>
 <<if $curses[$temp2].name == "Weakling">>
 	<<set $playerCurses.push($curse91)>>
@@ -1271,12 +1259,6 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 		<<set $corruption += Math.floor(Math.max(($relics[$temp1].corr / 2) - $corRed, 0))>>
 		
 		<<set $corruption -= $playerCurses[$playerCurses.length - 1].corr>>
-		<<if $curses[$temp2].type == "Gender" >>
-			<<set _temp = $GenderLog.length>>
-			<<if $GenderLog[_temp-1] == "Interact A" || $GenderLog[_temp-1] == "Interact B" || $GenderLog[_temp-1] == "Interact C" || $GenderLog[_temp-1] == "Interact D" || $GenderLog[_temp-1] == "Interact E" || $GenderLog[_temp-1] == "Interact F" || $GenderLog[_temp-1] == "Interact G">>
-				<<set $GenderLog.deleteAt(_temp-1)>>
-			<</if>>
-		<</if>>
 		<<RemoveCurse $curses[$temp2]>>
 		<<set setup.loseRelic("Devil's Own")>>
 	<</link>>

--- a/src/layer8.twee
+++ b/src/layer8.twee
@@ -596,7 +596,7 @@ You have successfully taken the $relic96.name Relic. Hopefully you can make good
 
 
 :: Take on Asset Robustness F [layer8]
-<<set $playerCurses.push($curse99)>><<set $corruption += $curse99.corr>><<set $GenderLog.push($curse99)>><<if $app.sex=="male" && $app.breastsCor>0 >><<set $GenderLog.push("Interact F")>><</if>>\
+<<set $playerCurses.push($curse99)>><<set $corruption += $curse99.corr>><<set $GenderLog.push($curse99)>>\
 [img[setup.ImagePath + $curse99.pic]]
 
 You have successfully taken on the $curse99.name Curse. Hopefully you are okay with accepting the permanent consequences.
@@ -1154,7 +1154,7 @@ The Curses you have obtained with Cherry's Chaotic Luck are $curses[$temp1].name
 	<<set $GenderLog.push($curse98)>>
 <</if>>
 <<if $curses[$temp1].name == "Asset Robustness F" || $curses[$temp2].name == "Asset Robustness F" >>
-	<<set $GenderLog.push($curse99)>><<if $app.sex=="male" && $app.breastsCor>0 >><<set $GenderLog.push("Interact F")>><</if>>
+	<<set $GenderLog.push($curse99)>>
 <</if>>
 <<if $curses[$temp1].name == "Eye on the Prize" || $curses[$temp2].name == "Eye on the Prize" >>
 	<<set $HandicapLog.push($curse101)>>
@@ -1193,21 +1193,9 @@ The Curses you have obtained with Cherry's Chaotic Luck are $curses[$temp1].name
 
 	<<link "Reroll with Devil's Own" "Layer8 Cherry Curse">>
 		<<set $corruption -= $playerCurses[$playerCurses.length - 1].corr>>
-		<<if $curses[$temp1].type == "Gender" >>
-			<<set _temp = $GenderLog.length>>
-			<<if $GenderLog[_temp-1] == "Interact A" || $GenderLog[_temp-1] == "Interact B" || $GenderLog[_temp-1] == "Interact C" || $GenderLog[_temp-1] == "Interact D" || $GenderLog[_temp-1] == "Interact E" || $GenderLog[_temp-1] == "Interact F" || $GenderLog[_temp-1] == "Interact G">>
-				<<set $GenderLog.deleteAt(_temp-1)>>
-			<</if>>
-		<</if>>
 		<<RemoveCurse $curses[$temp1]>>
 		
 		<<set $corruption -= $playerCurses[$playerCurses.length - 1].corr>>
-		<<if $curses[$temp2].type == "Gender" >>
-			<<set _temp = $GenderLog.length>>
-			<<if $GenderLog[_temp-1] == "Interact A" || $GenderLog[_temp-1] == "Interact B" || $GenderLog[_temp-1] == "Interact C" || $GenderLog[_temp-1] == "Interact D" || $GenderLog[_temp-1] == "Interact E" || $GenderLog[_temp-1] == "Interact F" || $GenderLog[_temp-1] == "Interact G">>
-				<<set $GenderLog.deleteAt(_temp-1)>>
-			<</if>>
-		<</if>>
 		<<RemoveCurse $curses[$temp2]>>
 
 		<<set setup.loseRelic("Devil's Own")>>
@@ -1245,7 +1233,7 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 	<<set $GenderLog.push($curse98)>>
 <</if>>
 <<if $curses[$temp2].name == "Asset Robustness F" >>
-	<<set $GenderLog.push($curse99)>><<if $app.sex=="male" && $app.breastsCor>0 >><<set $GenderLog.push("Interact F")>><</if>>
+	<<set $GenderLog.push($curse99)>>
 <</if>>
 <<if  $curses[$temp2].name == "Eye on the Prize" >>
 	<<set $HandicapLog.push($curse101)>>
@@ -1287,12 +1275,6 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 		<<set $corruption += Math.floor(Math.max(($relics[$temp1].corr / 2) - $corRed, 0))>>
 		
 		<<set $corruption -= $playerCurses[$playerCurses.length - 1].corr>>
-		<<if $curses[$temp2].type == "Gender" >>
-			<<set _temp = $GenderLog.length>>
-			<<if $GenderLog[_temp-1] == "Interact A" || $GenderLog[_temp-1] == "Interact B" || $GenderLog[_temp-1] == "Interact C" || $GenderLog[_temp-1] == "Interact D" || $GenderLog[_temp-1] == "Interact E" || $GenderLog[_temp-1] == "Interact F" || $GenderLog[_temp-1] == "Interact G">>
-				<<set $GenderLog.deleteAt(_temp-1)>>
-			<</if>>
-		<</if>>
 		<<RemoveCurse $curses[$temp2]>>
 		<<set setup.loseRelic("Devil's Own")>>
 	<</link>>

--- a/src/layer8.twee
+++ b/src/layer8.twee
@@ -919,21 +919,14 @@ You give a wry smile, looking down at your new arms. There's a certain allure to
 [img[setup.ImagePath + $curse108.pic]]
 <<nobr>>
 	<<set $playerCurses.push($curse108)>><<set $corruption += $curse108.corr>><<set $GenderLog.push($curse108)>>
-	<<if $playerCurses.some(e => e.name === "Double Pepperoni")>>
-		<<RemoveCurse $curse39.name>>
-		<<set $corruption -= $curse39.corr>>
-		<br>You feel the Double Pepperoni Curse leaving your body.<br>
-	<</if>>
-	<<if $playerCurses.some(e => e.name === "Softie")>>
-		<<RemoveCurse $curse51.name>>
-		<<set $corruption -= $curse51.corr>>
-		<br>You feel the Softie Curse leaving your body.<br>
-	<</if>>
-	<<if $playerCurses.some(e => e.name === "Hard Mode")>>
-		<<RemoveCurse $curse52.name>>
-		<<set $corruption -= $curse52.corr>>
-		<br>You feel the Hard Mode Curse leaving your body.<br>
-	<</if>>
+	<<for _curseName range setup.cursesNegatedByNull>>
+		<<set _curse = setup.curse(_curseName)>>
+		<<if $playerCurses.some(e => e.name == _curseName)>>
+			<<RemoveCurse _curseName>>
+			<<set $corruption -= _curse.corr>>
+			<br>You feel the _curseName Curse leaving your body.<br>
+		<</if>>
+	<</for>>
 <</nobr>>\
 
 A soft hum resonates in your ear, growing louder and more persistent. You can't discern its source, but it wraps itself around your senses, penetrating deep within you, leaving you with an uneasy anticipation. Your heart pounds in sync with this uncanny rhythm, and you realize - it's the pulsating heartbeat of the Abyss.
@@ -1019,7 +1012,7 @@ What biological sex do you want your twin to be?
 <<radiobutton "$curse111.variation2"  "same" >> Give me a perfectly identical twin!
 
 :: Take on Double Trouble 2 [;ayer 8]
-<<set $playerCurses.push($curse111)>><<set $corruption += $curse111.corr>><<set $TwinVar1=random(0,1)>><<set $Twin_LastT=$time>>\
+<<set $playerCurses.push($curse111)>><<set $corruption += $curse111.corr>><<set $TwinVar1=random(0,1)>><<set $Twin_LastT = $time>>\
 [img[setup.ImagePath + $curse111.pic]]
 <<CloneSelf>><<CarryAdjust>>
 You feel dizzy and tumble forward. You manage to catch yourself before you hit the ground, but your backpack and all your equipment falls on the ground. As the dizzyness increases, the world goes black. 

--- a/src/script.js
+++ b/src/script.js
@@ -15,56 +15,56 @@ Config.navigation.override = function (destPassage) {
 	if (StoryVar.starving >= 6 || StoryVar.dehydrated >= 3 || StoryVar.gameOver) {
 		return "GameOver";
 	}
-	if (StoryVar.time >= StoryVar.due) {
+	if (setup.daysUntilDue(StoryVar.app) == 0) {
 		return "Labor Scene";
 	}
-	if (StoryVar.time - StoryVar.companionMaru.pregnantT >= 280) {
-		StoryVar.companionLabor = StoryVar.companionMaru.name
-		StoryVar.MaruConvoPreg = false
-		StoryVar.companionMaru.pregnantT = 9999
-		StoryVar.lastBirthMaru = StoryVar.time
+	if (setup.daysUntilDue('Maru') == 0) {
+		StoryVar.companionLabor = StoryVar.companionMaru.name;
+		StoryVar.MaruConvoPreg = false;
+		setup.setNotPregnant('Maru');
+		StoryVar.lastBirthMaru = StoryVar.time;
 		return "Labor Scene Companion";
 	}
-	if (StoryVar.time - StoryVar.companionLily.pregnantT >= 280) {
-		StoryVar.companionLabor = StoryVar.companionLily.name
-		StoryVar.LilyConvoPreg = false
-		StoryVar.companionLily.pregnantT = 9999
-		StoryVar.lastBirthLily = StoryVar.time
+	if (setup.daysUntilDue('Lily') == 0) {
+		StoryVar.companionLabor = StoryVar.companionLily.name;
+		StoryVar.LilyConvoPreg = false;
+		setup.setNotPregnant('Lily');
+		StoryVar.lastBirthLily = StoryVar.time;
 		return "Labor Scene Companion";
 	}
-	if (StoryVar.time - StoryVar.companionKhemia.pregnantT >= 280) {
-		StoryVar.companionLabor = StoryVar.companionKhemia.name
-		StoryVar.KhemiaConvoPreg = false
-		StoryVar.companionKhemia.pregnantT = 9999
-		StoryVar.lastBirthKhemia = StoryVar.time
+	if (setup.daysUntilDue('Khemia') == 0) {
+		StoryVar.companionLabor = StoryVar.companionKhemia.name;
+		StoryVar.KhemiaConvoPreg = false;
+		setup.setNotPregnant('Khemia');
+		StoryVar.lastBirthKhemia = StoryVar.time;
 		return "Labor Scene Companion";
 	}
-	if (StoryVar.time - StoryVar.companionCherry.pregnantT >= 280) {
-		StoryVar.companionLabor = StoryVar.companionCherry.name
-		StoryVar.CherryConvoPreg = false
-		StoryVar.companionCherry.pregnantT = 9999
-		StoryVar.lastBirthCherry = StoryVar.time
+	if (setup.daysUntilDue('Cherry') == 0) {
+		StoryVar.companionLabor = StoryVar.companionCherry.name;
+		StoryVar.CherryConvoPreg = false;
+		setup.setNotPregnant('Cherry');
+		StoryVar.lastBirthCherry = StoryVar.time;
 		return "Labor Scene Companion";
 	}
-	if (StoryVar.time - StoryVar.companionCloud.pregnantT >= 280) {
-		StoryVar.companionLabor = StoryVar.companionCloud.name
-		StoryVar.CloudConvoPreg = false
-		StoryVar.companionCloud.pregnantT = 9999
-		StoryVar.lastBirthCloud = StoryVar.time
+	if (setup.daysUntilDue('Cloud') == 0) {
+		StoryVar.companionLabor = StoryVar.companionCloud.name;
+		StoryVar.CloudConvoPreg = false;
+		setup.setNotPregnant('Cloud');
+		StoryVar.lastBirthCloud = StoryVar.time;
 		return "Labor Scene Companion";
 	}
-	if (StoryVar.time - StoryVar.companionSaeko.pregnantT >= 280) {
-		StoryVar.companionLabor = StoryVar.companionSaeko.name
-		StoryVar.SaekoConvoPreg = false
-		StoryVar.companionSaeko.pregnantT = 9999
-		StoryVar.lastBirthSaeko = StoryVar.time
+	if (setup.daysUntilDue('Saeko') == 0) {
+		StoryVar.companionLabor = StoryVar.companionSaeko.name;
+		StoryVar.SaekoConvoPreg = false;
+		setup.setNotPregnant('Saeko');
+		StoryVar.lastBirthSaeko = StoryVar.time;
 		return "Labor Scene Companion";
 	}
-	if (StoryVar.time - StoryVar.companionTwin.pregnantT >= 280) {
-		StoryVar.companionLabor = StoryVar.companionTwin.name
-		StoryVar.TwinConvoPreg = false
-		StoryVar.companionTwin.pregnantT = 9999
-		StoryVar.lastBirthTwin = StoryVar.time
+	if (setup.daysUntilDue('Twin') == 0) {
+		StoryVar.companionLabor = StoryVar.companionTwin.name;
+		StoryVar.TwinConvoPreg = false;
+		setup.setNotPregnant('Twin');
+		StoryVar.lastBirthTwin = StoryVar.time;
 		return "Labor Scene Companion";
 	}
 	if (isFinite(StoryVar.app.appAge) && StoryVar.app.appAge < 3 && StoryVar.app.age > 17) {
@@ -150,14 +150,23 @@ $(document).on(':passagestart', () => {
 		}
 	}
 
+	// Restore object identity between curses in curse logs and $curseN variables.
+	const logNameSuffixes = ['', ...vars.companions.map(companion => companion.name)];
+	for (const type of ['Height', 'Gender', 'Age', 'Libido', 'Handicap']) {
+		for (const suffix of logNameSuffixes) {
+			const events = vars[`${type}Log${suffix}`];
+			for (const [i, event] of events.entries()) {
+				const curseVar = curseVars.find(curseVar => event.name == curseVar.name);
+				if (curseVar) events[i] = curseVar;
+			}
+		}
+		// Restore object identity between twin curse logs and mc curse logs.
+		vars[`${type}LogTwin`] = vars[`${type}Log`];
+	}
+
 	// Restore object identity between $app.curses, $companionTwin.curses and $playerCurses.
 	for (const target of ['app', 'companionTwin']) {
 		vars[target].curses = vars.playerCurses;
-	}
-
-	// Restore object identity between twin curse logs and mc curse logs.
-	for (const type of ['Height', 'Gender', 'Age', 'Libido', 'Handicap']) {
-		vars[`${type}LogTwin`] = vars[`${type}Log`];
 	}
 
 	/* ---- Relic object identity ---- */
@@ -243,22 +252,22 @@ Setting.addHeader("Content Settings");
 
 Setting.addToggle("MaleSceneToggleFilter", {
 	label : "Enable random sex scences involving male characters",
-	default  : 1,
+	default  : true,
 });
 
 Setting.addToggle("FemaleSceneToggleFilter", {
 	label : "Enable random sex scences involving female characters",
-	default  : 1,
+	default  : true,
 });
 
 Setting.addToggle("OtherSceneToggleFilter", {
 	label : "Enable random sex scences involving futa characters or characters without genitals",
-	default  : 1,
+	default  : true,
 });
 
 Setting.addToggle("MenCycleToggleFilter", {
 	label : "Hide messages containing information about your menstrual cycle ",
-	default  : 1,
+	default  : true,
 });
 
 Setting.addRange("appAgeControl", {
@@ -488,5 +497,58 @@ Object.defineProperties(setup, {
 	// Stops passing time for the active passage (called by <<PassTime>>).
 	stopPassingTime: {
 		value: () => variables().passTimeState?.delete(passage()),
+	},
+	never: {
+		value: 999999999, // Just needs to be an unreasonably large number so that $time can never exceed it.
+	},
+	// Checks whether the given character is pregnant.
+	isPregnant: {
+		value(character) {
+			const characterVar = typeof character != 'string' ? character : setup.companion(character);
+			return characterVar.pregnantT <= variables().time;
+		}
+	},
+	// Sets the given character as pregnant (fertilized) from two weeks ago.
+	setConsideredPregnant: {
+		value(character) {
+			const characterVar = typeof character != 'string' ? character : setup.companion(character);
+			characterVar.pregnantT = variables().time - 14;
+			characterVar.due = characterVar.pregnantT + 280 + random(-7, 7);
+		},
+	},
+	// Sets the given character as not pregnant.
+	setNotPregnant: {
+		value(character) {
+			const characterVar = typeof character != 'string' ? character : setup.companion(character);
+			characterVar.pregnantT = setup.never;
+			characterVar.due = setup.never;
+		},
+	},
+	// Gets (or sets) the due date for the given character if they're pregnant (max value otherwise).
+	dueDate: {
+		value(character) {
+			const characterVar = typeof character != 'string' ? character : setup.companion(character);
+			if (!setup.isPregnant(characterVar)) {
+				characterVar.due = setup.never;
+			} else if (typeof characterVar.due == 'undefined') {
+				characterVar.due = characterVar.pregnantT + 280 + random(-7, 7);
+			}
+			return characterVar.due;
+		},
+	},
+	// Gets the number of days that the given character has been pregnant.
+	daysConsideredPregnant: {
+		value(character) {
+			const characterVar = typeof character != 'string' ? character : setup.companion(character);
+			return Math.max(variables().time - characterVar.pregnantT, 0);
+		},
+	},
+	// Gets the number of days until the given character is due to give birth.
+	daysUntilDue: {
+		value(character) {
+			const characterVar = typeof character != 'string' ? character : setup.companion(character);
+			if (!setup.isPregnant(characterVar)) return setup.never;
+			return Math.max(setup.dueDate(characterVar) - variables().time, 0);
+		},
 	},
 });

--- a/src/start.twee
+++ b/src/start.twee
@@ -117,7 +117,6 @@ Before proceeding, please estimate your carrying capacity (in kg) if you were in
 	<<set $app.ogender = 1>>
 	<<set $app.vagina = 0>>
 	<<set $app.osex = "male">>
-	<<set settings.MenCycleToggleFilter = 0>>
 <<else>>
 	<<set $app.penis = 0>>
 	<<set $app.openis = 0>>
@@ -133,7 +132,6 @@ Before proceeding, please estimate your carrying capacity (in kg) if you were in
 	<<set $menFirstCycle = false>>
 	<<set $menCycleT_flag = true>>
 	<<set $heatCycleT_flag = true>>
-	<<set settings.MenCycleToggleFilter = 1>>
 <</if>>
 <<set $app.obreasts = $app.breasts>>
 <<set $app.breastsCor = parseInt($app.breasts)>>

--- a/src/surface.twee
+++ b/src/surface.twee
@@ -275,8 +275,8 @@ It won't take too long to make your way down to the Abyss proper &mdash; there's
 <</nobr>>
 You have successfully hired Maru. Hopefully he brings you a lot of joy and helps you along in your journey.
 
-[[Hire more companions|Surface Companions][$Maru_LastT=$time]]
-[[Return to Outset Town|Surface Hub][$Maru_LastT=$time]]
+[[Hire more companions|Surface Companions][$Maru_LastT = $time]]
+[[Return to Outset Town|Surface Hub][$Maru_LastT = $time]]
 
 
 :: Hire Lily [surface]
@@ -290,8 +290,8 @@ You have successfully hired Maru. Hopefully he brings you a lot of joy and helps
 <</nobr>>
 You have successfully hired Lily. Hopefully her electric personality and excellent haggling serve you well in your journey.
 
-[[Hire more companions|Surface Companions][$Lily_LastT=$time]]
-[[Return to Outset Town|Surface Hub][$Lily_LastT=$time]]
+[[Hire more companions|Surface Companions][$Lily_LastT = $time]]
+[[Return to Outset Town|Surface Hub][$Lily_LastT = $time]]
 
 
 :: Hire Khemia [surface]
@@ -304,8 +304,8 @@ You have successfully hired Lily. Hopefully her electric personality and excelle
 <</nobr>>
 You have successfully hired Khemia. Hopefully his fighting expertise and experience in traversing the abyss help you along your journey.
 
-[[Hire more companions|Surface Companions][$Khemia_LastT=$time]]
-[[Return to Outset Town|Surface Hub][$Khemia_LastT=$time]]
+[[Hire more companions|Surface Companions][$Khemia_LastT = $time]]
+[[Return to Outset Town|Surface Hub][$Khemia_LastT = $time]]
 
 
 :: Hire Cherry [surface]
@@ -319,8 +319,8 @@ You have successfully hired Khemia. Hopefully his fighting expertise and experie
 <</nobr>>
 You have successfully hired Cherry. Hopefully her chaotic luck and medical knowledge serve you well in your journey.
 
-[[Hire more companions|Surface Companions][$Cherry_LastT=$time]]
-[[Return to Outset Town|Surface Hub][$Cherry_LastT=$time]]
+[[Hire more companions|Surface Companions][$Cherry_LastT = $time]]
+[[Return to Outset Town|Surface Hub][$Cherry_LastT = $time]]
 
 
 :: Hire Cloud [surface]
@@ -335,8 +335,8 @@ You have successfully hired Cherry. Hopefully her chaotic luck and medical knowl
 You have successfully hired Cloud! Hopefully he brings you a lot of joy and helps you along in your journey.
 
 <<include "Cloud Ability">>
-[[Hire more companions|Surface Companions][$Cloud_LastT=$time]]
-[[Return to Outset Town|Surface Hub][$Cloud_LastT=$time]]
+[[Hire more companions|Surface Companions][$Cloud_LastT = $time]]
+[[Return to Outset Town|Surface Hub][$Cloud_LastT = $time]]
 
 
 :: Hire Saeko [surface]
@@ -350,8 +350,8 @@ You have successfully hired Cloud! Hopefully he brings you a lot of joy and help
 <</nobr>>
 You have successfully hired Saeko. Hopefully her extensive knowledge of abyssal theory and corruption serve you well in your journey.
 
-[[Hire more companions|Surface Companions][$Saeko_LastT=$time]]
-[[Return to Outset Town|Surface Hub][$Saeko_LastT=$time]]
+[[Hire more companions|Surface Companions][$Saeko_LastT = $time]]
+[[Return to Outset Town|Surface Hub][$Saeko_LastT = $time]]
 
 
 :: Buy Water [item]

--- a/src/widgets.twee
+++ b/src/widgets.twee
@@ -303,15 +303,23 @@
 					/* Curse may be taken multiple times, so check the index to get the right variation. */
 					<<set _eventVariation = _event[`variation${_wombEvents.indexOf(_event) + 1}`]>>
 					<<if !_handle.womb1>>
-						<<if _eventVariation != 'vagina' || _handle.vagina > 0>>
+						<<if _handle.sex == 'doll-like'>>
+							<<set _handle.womb1 = ['vagina', 'urethra'].includes(_eventVariation) ? 'anus' : _eventVariation>>
+						<<elseif _handle.vagina < 1>>
+							<<set _handle.womb1 = _eventVariation == 'vagina' ? 'anus' : _eventVariation>>
+						<<else>>
 							<<set _handle.womb1 = _eventVariation>>
-							<<set _handle.womb += 1>>
 						<</if>>
+						<<set _handle.womb += 1>>
 					<<elseif !_handle.womb2>>
-						<<if _eventVariation != 'vagina' || _handle.vagina > 0>>
+						<<if _handle.sex == 'doll-like'>>
+							<<set _handle.womb2 = ['vagina', 'urethra'].includes(_eventVariation) ? 'anus' : _eventVariation>>
+						<<elseif _handle.vagina < 1>>
+							<<set _handle.womb2 = _eventVariation == 'vagina' ? 'anus' : _eventVariation>>
+						<<else>>
 							<<set _handle.womb2 = _eventVariation>>
-							<<set _handle.womb += 1>>
 						<</if>>
+						<<set _handle.womb += 1>>
 					<</if>>
 				<<case '1 Day Water Forage Major Impact'>>
 					<<if _handle.penis > 0>><<set _handle.penis += 1>><</if>>
@@ -323,25 +331,23 @@
 					<<elseif _handle.penis > 0>>
 						<<set _handle.penis -= 1>>
 						<<if _handle.penis < 1>>
-							<<set _handle.sex = _handle.vagina > 0 ? 'female' : 'doll-like'>>
+							<<if _handle.vagina < 1>>
+								<<if _handle.womb1 == 'urethra'>><<set _handle.womb1 = 'anus'>><</if>>
+								<<if _handle.womb2 == 'urethra'>><<set _handle.womb2 = 'anus'>><</if>>
+								<<set _handle.sex = 'doll-like'>>
+							<<else>>
+								<<set _handle.sex = 'female'>>
+							<</if>>
 						<</if>>
 					<<elseif _handle.vagina > 0>>
 						<<if _handle.appAge < 10>>
 							<<set _handle.vagina -= 1>>
 							<<set _handle.womb -= 1>>
 							<<if _handle.vagina < 1>>
-								<<if _handle.womb2 == 'vagina'>>
-									<<set _handle.womb2 = ''>>
-									<<set _handle.womb -= 1>>
-								<</if>>
-								<<if _handle.womb1 == 'vagina'>>
-									<<set _handle.womb1 = _handle.womb2>>
-									<<set _handle.womb2 = ''>>
-									<<set _handle.womb -= 1>>
-								<</if>>
+								<<if ['vagina', 'urethra'].includes(_handle.womb1)>><<set _handle.womb1 = 'anus'>><</if>>
+								<<if ['vagina', 'urethra'].includes(_handle.womb2)>><<set _handle.womb2 = 'anus'>><</if>>
 								<<set _handle.sex = 'doll-like'>>
 							<</if>>
-							<<set _handle.sex = _handle.vagina > 0 ? 'female' : 'doll-like'>>
 						<</if>>
 					<</if>>
 			<</switch>>

--- a/src/widgets.twee
+++ b/src/widgets.twee
@@ -1,637 +1,506 @@
-:: Change Height [widget nobr]
+:: HeightCorrected [widget nobr]
 <<widget "HeightCorrected">>
-/*declare variables as follows when calling widget
-1) $app.heigth
-2) $app.oheight
-3) $app.gender
-4) $app.osex (= "female")
-5) $app.appAge
-*/
 
 <<GenderCorrected>>
-<<for _i=0; _i<=$hiredCompanions.length; _i++>>
-	<<if _i==$hiredCompanions.length>>
-		<<set _handle = $app>>
-		<<set _HeightLog = $HeightLog>>
-	<<else>>
-		<<if $hiredCompanions[_i].name == $companionTwin.name >>
-			<<set _tempName = "Twin">>
-		<<else>>
-			<<set _tempName = $hiredCompanions[_i].name>>
+
+<<capture _handle _log _genderlvl _height_adult _height_change _x _x_rel>>
+	<<for _handle range $hiredCompanions.concat($app)>>
+		<<set _name = _handle != $companionTwin ? _handle.name : 'Twin'>>
+		<<set _logName = _handle === $app ? 'Log' : `Log${_name}`>>
+		<<print `<<set _log = $Height${_logName}>>`>>
+
+		<<set _genderlvl = _handle.gender - 1>>
+
+		<<set _height_change = $HeightIncrease * (
+			5.0 * _log.filter(e => e.name === "Dizzying Heights").length +
+			3.0 * _log.filter(e => e.name === "1 Day Food Forage Major Impact").length +
+			0.5 * _log.filter(e => e.name === "1 Day Food Forage Minor Impact").length
+		)>>
+
+		<<if _log.some(e => e.name === "Colossal-able")>>
+			<<set _height_change = _handle.height * 70 - _handle.height>>
+			<<set $SizeHandicap = 1>>
+		<<elseif _log.some(e => e.name === "Minish-ish")>>
+			<<set _height_change = _handle.height / 10 - _handle.height>>
+			<<set $SizeHandicap = $hiredCompanions.length < 1 ? 1 : 0>>
 		<</if>>
-		<<print "<<set _handle  = $companion"+ _tempName +" >>">>
-		<<print "<<set _HeightLog  = $HeightLog"+ _tempName +" >>">>
-	<</if>>
 
-	<<set $genderlvl = _handle.gender-1>>
+		/* Change in height with genderlevel changes and height increases/decreases; it is modeled such that */
+		/* 5 cm is always 5 cm with respect to your starting height and irrespective of starting gender.     */
+		<<set _height_adult = 
+			_handle.oheight * (1 - 0.01525 * (_genderlvl - (_handle.osex == "female" ? 5 : 0))) +
+			_height_change  * (1 - 0.01525 * (_handle.osex == "female" ? 5 : 0))
+		>>
 
-	<<if $genderlvl< 0 >>
-		<<set $genderlvl = 0>>
-	<<elseif $genderlvl> 5>>
-		<<set $genderlvl = 5>>
-	<</if>>
+		<<set _x = 18 - _handle.appAge>>
 
-	<<if _handle.osex=="female">>
-		<<set $female_start=1>>
-	<<else>>
-		<<set $female_start=0>>
-	<</if>>
-
-	<<if $HeightIncrease==1>>
-		<<set _temp1 =_HeightLog.filter(e => e.name === "Dizzying Heights").length>>
-		<<set _temp2 =_HeightLog.filter(e => e.name === "1 Day Food Forage Major Impact").length>>
-		<<set _temp3 =_HeightLog.filter(e => e.name === "1 Day Food Forage Minor Impact").length>>
-		<<set $height_change=5*_temp1+3*_temp2+0.5*_temp3>>
-	<<else>>
-		<<set _temp1 =_HeightLog.filter(e => e.name === "Dizzying Heights").length>>
-		<<set _temp2 =_HeightLog.filter(e => e.name === "1 Day Food Forage Major Impact").length>>
-		<<set _temp3 =_HeightLog.filter(e => e.name === "1 Day Food Forage Minor Impact").length>>
-		<<set $height_change=-5*_temp1-3*_temp2-0.5*_temp3>>	
-	<</if>>
-
-	<<if _HeightLog.some(e=> e.name === "Colossal-able")>>
-		<<set $height_change=_handle.height*70-_handle.height>>
-		<<set $SizeHandicap=1>>
-	<</if>>
-
-	<<if _HeightLog.some(e=> e.name === "Minish-ish")>>
-		<<set $height_change=_handle.height/10-_handle.height>>
-		<<if $hiredCompanions.length < 1>>
-			<<set $SizeHandicap=1>>
+		<<if _x <= 0.2 * _genderlvl>>
+			<<set _handle.heightCor = _height_adult>>
+		<<elseif 0.2 * _genderlvl < _x && _x <= 6>>
+			/* Puberty phase: It shifts for females as theirs ends earlier; for simplicity */
+			/* I assumed the start is the same regardless although this is not entirely    */
+			/* correct. I used a polynomial here to simulate the 'reverse growth spurt'.   */
+			<<set _x_rel = _x - 0.2 * _genderlvl>>
+			<<set _handle.heightCor = _height_adult * (1 -
+				( 4.70611e-3 - 8.1433e-4 * _genderlvl) * _x_rel -
+				( 1.1049e-4  - 1.140e-5  * _genderlvl) * _x_rel**2 -
+				( 1.6698e-3  - 1.3722e-4 * _genderlvl) * _x_rel**3 -
+				(-1.7701e-4  + 2.114e-5  * _genderlvl) * _x_rel**4
+			)>>
+		<<elseif 6 < _x && _x <= 15>>
+			/* The second phase of linear growth or decline, it's a decent approximation without making things too     */
+			/* complicated. It ends at age 3 (originally 4, but changed it to not break the rest of the code). The     */
+			/* calculation for the puberty growth spurt is in here to provide a starting point for the linear decline. */
+			<<set _x_rel = 6 - 0.2 * _genderlvl>>
+			<<set _handle.heightCor = _height_adult * (1 -
+				( 4.70611e-3 - 8.1433e-4 * _genderlvl) * _x_rel -
+				( 1.1049e-4  - 1.140e-5  * _genderlvl) * _x_rel**2 -
+				( 1.6698e-3  - 1.3722e-4 * _genderlvl) * _x_rel**3 -
+				(-1.7701e-4  + 2.114e-5  * _genderlvl) * _x_rel**4 -
+				(0.033 + 0.0009 * _genderlvl) * (_x - 6)
+			)>>
 		<</if>>
-	<</if>>
-
-	<<set $x =18 - _handle.appAge>>
-/* change in height with genderlevel changes and height increases/decreases it is modeled such that 5 cm is always 5 cm with respect to your starting height and irrespective of starting gender
-*/
-
-	<<set $height_adult = _handle.oheight +$height_change -$height_change*(1-0.92375)*$female_start -0.01525*_handle.oheight*$genderlvl +0.01525*_handle.oheight*5*$female_start>>
-
-	<<if $x<=0 +1/5 *$genderlvl>>
-		<<set _handle.heightCor = $height_adult>>
-
-/* The puberty phase: it shifts for females as their ends earlier, for simplicity I assumed the start is the same regardless although this is not entirely correct. I ussed a polynomial here to simulate the 'reverse growth spurt'
-*/
-
-	<<elseif $x > 0+1/5*$genderlvl && $x<=6>>
-		<<set $C1=-4.70611e-3 +8.1433e-4  *$genderlvl>>
-    	<<set $C2=-1.1049e-4  +1.140e-5   *$genderlvl>>
-    	<<set $C3=-1.6698e-3  +1.3722e-4  *$genderlvl>>
-    	<<set $C4= 1.7701e-4  -2.114e-5   *$genderlvl>>
-    	<<set $x_rel = $x-1/5*$genderlvl>>
-    	<<set _handle.heightCor = $height_adult *(1 +$C1*$x_rel +$C2*Math.pow($x_rel,2) +$C3*Math.pow($x_rel,3) +$C4*Math.pow($x_rel,4) )>>
-
-/* the second phase of linear growth or decline, its a decent approximation without making things to complicated. It ends at age 3 (originally 4, but changed it to not break the rest of the code) the calculation for the puberty growth spurt is in here to provide a starting point for the linear decline
-*/
-	<<elseif $x>6 && $x<=15>>
-		<<set $C1=-4.70611e-3 +8.1433e-4  *$genderlvl>>
-    	<<set $C2=-1.1049e-4  +1.140e-5   *$genderlvl>>
-    	<<set $C3=-1.6698e-3  +1.3722e-4  *$genderlvl>>
-    	<<set $C4= 1.7701e-4  -2.114e-5   *$genderlvl>>
-    	<<set $x_rel = 6-1/5*$genderlvl>>
-    	<<set $height_pub = $height_adult*(1 +$C1*$x_rel +$C2*Math.pow($x_rel,2) +$C3*Math.pow($x_rel,3) +$C4*Math.pow($x_rel,4) )>>
-
-    	<<set _handle.heightCor = $height_pub -$height_adult*(0.033 +0.0009*$genderlvl) *( $x-6 )>>
-	<</if>>
-<</for>>
-
+	<</for>>
+<</capture>>
 <</widget>>
 
-:: BreastCorrected [nobr]
-	<<set $x = 18 -_handle.appAge>>
-	<<set _handle.breastsCor =_handle.breasts>>
-	<<set _handle.lactation = 0>>
-	<<set $genderlvl = _handle.gender-1>>
-
-	<<if $genderlvl< 0 >>
-		<<set $genderlvl = 0>>
-	<<elseif $genderlvl> 5>>
-		<<set $genderlvl = 5>>
-	<</if>>
-
-	<<if $x>0 +1/5 *$genderlvl>>
-		<<set _handle.breastsCor = _handle.breasts - 0.1*$x*_handle.breasts>>
-		<<if  _handle.breastsCor<0>>
-			<<set _handle.breastsCor =0>>
-		<</if>>
-	<</if>>
- 	<<if _handle.curses.some(e => e.name === "Lactation Rejuvenation A")>>
-		<<set _handle.lactation += 1>>
-	<</if>>
-	<<if _handle.curses.some(e => e.name === "Lactation Rejuvenation B")>>
-		<<set _handle.lactation += 1>>
-	<</if>>
-
-	<<if _handle.curses.some(e => e.name === "Double Pepperoni") && _handle.breastsCor == 0>>
-			<<set _handle.breastsCor +=1>>
-	<</if>>
-
-	<<if _i == $hiredCompanions.length>>
-		<<if $time-$menCycleT-$menCycleVar>20 && $menCycleFlag == true>>
-			<<set _handle.breastsCor += 1>> 
-		<</if>>
-		<<set _due = $due>>
-
-		<<if  ($time - $app.pregnantT> 270 && $time - $app.pregnantT<=$due) || ($time - $menCycleT < -30 && $menCycleFlag == true)>>
-			<<set _handle.lactation += 2>>
-		<</if>>
-
-	<<else>>
-		<<print "<<set _tempBirth = $lastBirth" + _tempName + ">>">>
-		<<set _due = 280 + _handle.pregnantT>>
-		<<if _tempName=="Lily" && $LilyConvoLac=="true">>
-			<<set _flag=true>>
-		<<else>>
-			<<set _flag=false>>
-		<</if>>
-
-		<<if ($time - _tempBirth < 30 && _tempBirth!=9999)|| _flag>>
-			<<set _handle.lactation += 2>>
-		<</if>>
-	<</if>>
-	<<if _handle.pregnantT != 9999>>
-		<<if $time - _handle.pregnantT>= 90 && $time - _tempPreg<=130 >>
-			<<set _handle.breastsCor += 0.5>>
-		<<elseif $time - _handle.pregnantT> 130 && $time - _tempPreg<=180 >>
-			<<set _handle.breastsCor += 1>>
-		<<elseif $time - _handle.pregnantT> 180 && $time - _tempPreg<=240>>
-			<<set _handle.breastsCor += 1.5>>
-		<<elseif $time - _handle.pregnantT> 240 && $time - _tempPreg<=_due>>
-			<<set _handle.lactation += 1>> 
-			<<set _handle.breastsCor += 1>>
-		<</if>>
-	<</if>>
-
-	<<if _handle.sex == "doll-like">>
-		<<set _handle.lactation = 0>>
-	<<elseif _handle.lactation > 2>>
-		<<set _handle.lactation = 2>>
-	<</if>>
-
-
-	<<set _handle.breastsCor += _handle.lactation>>	
-
-	<<if $app.breastsCor < 1>>
-		<<set _handle.breastsLabel = "flat">>
-	<<elseif $app.breastsCor < 2>>
-		<<set _handle.breastsLabel = "AA">>
-	<<elseif $app.breastsCor < 3>>
-		<<set _handle.breastsLabel = "A">>
-	<<elseif $app.breastsCor < 4>>
-		<<set _handle.breastsLabel = "B">>
-	<<elseif $app.breastsCor < 5>>
-		<<set _handle.breastsLabel = "C">>
-	<<elseif $app.breastsCor < 6>>
-		<<set _handle.breastsLabel = "D">>
-	<<elseif $app.breastsCor < 7>>
-		<<set _handle.breastsLabel = "E">>
-	<<elseif $app.breastsCor < 8>>
-		<<set _handle.breastsLabel = "F">>
-	<<elseif $app.breastsCor < 9>>
-		<<set _handle.breastsLabel = "G">>
-	<<elseif $app.breastsCor < 10>>
-		<<set _handle.breastsLabel = "H">>
-	<<elseif $app.breastsCor < 11>>
-		<<set _handle.breastsLabel = "I">>
-	<<elseif $app.breastsCor < 12>>
-		<<set _handle.breastsLabel = "J">>
-	<<elseif $app.breastsCor < 13>>
-		<<set _handle.breastsLabel = "K">>
-	<<elseif $app.breastsCor < 14>>
-		<<set _handle.breastsLabel = "L">>
-	<<elseif $app.breastsCor < 15>>
-		<<set _handle.breastsLabel = "M">>
-	<<elseif $app.breastsCor < 16>>
-		<<set _handle.breastsLabel = "N">>
-	<<elseif $app.breastsCor < 17>>
-		<<set _handle.breastsLabel = "O">>
-	<<elseif $app.breastsCor < 18>>
-		<<set _handle.breastsLabel = "P">>
-	<<elseif $app.breastsCor < 19>>
-		<<set _handle.breastsLabel = "Q">>
-	<<elseif $app.breastsCor < 20>>
-		<<set _handle.breastsLabel = "R">>
-	<<elseif $app.breastsCor >= 20>>
-		<<set _handle.breastsLabel = "S">>
-	<</if>>
-
-:: PenisCorrected [nobr]
-<<if _handle.sex != "female" && _handle.sex != "doll-like" >>
-	<<set $x = 16 -_handle.appAge>>
-	<<set _handle.penisCor =_handle.penis>>
-	<<set $genderlvl = _handle.gender-1>>
-
-	<<if $genderlvl< 0 >>
-		<<set $genderlvl = 0>>
-	<<elseif $genderlvl> 5>>
-		<<set $genderlvl = 5>>
-	<</if>>
-
-	<<if $x>0 +1/5 *$genderlvl>>
-		<<set _handle.penisCor = _handle.penis - 0.083*$x*(_handle.penis-1)>>
-		<<if  _handle.penisCor<1>>
-			<<set _handle.penisCor =1>>
-		<</if>>
-	<</if>>
-
-	<<if _handle.curses.some(e=> e.name === "Colossal-able")>>
-		<<set _handle.penisCor = _handle.penisCor*70>>
-	<</if>>
-
-	<<if _handle.curses.some(e=> e.name === "Minish-ish")>>
-		<<set _handle.penisCor=_handle.penisCor/10>>
-	<</if>>
-<<else>>
-	<<set _handle.penisCor=0>>
-<</if>>
-
-
-:: Change Gender [widget nobr]
+:: GenderCorrected [widget nobr]
 <<widget "GenderCorrected">>
-<<AgeCorrected>>
-<<for _i=0; _i<=$hiredCompanions.length; _i++>>
-	<<if _i==$hiredCompanions.length>>
-		<<set _handle = $app>>
-		<<set _GenderLog = $GenderLog>>
-	<<else>>
-		<<if $hiredCompanions[_i].name == $companionTwin.name >>
-			<<set _tempName = "Twin">>
-		<<else>>
-			<<set _tempName = $hiredCompanions[_i].name>>
-		<</if>>
-		<<print "<<set _handle  = $companion"+ _tempName +" >>">>
-		<<print "<<set _GenderLog  = $GenderLog"+ _tempName +" >>">>
-	<</if>>
+<<capture
+	_assetMod
+	_event
+	_eventAge
+	_eventVariation
+	_fullyGrownAge
+	_handle
+	_lastBirth
+	_logName
+	_name
+	_newTime
+	_oldTime
+	_robustBreasts
+	_wombEvents
+>>
+	<<for _handle range $hiredCompanions.concat($app)>>
+		<<set _name = _handle != $companionTwin ? _handle.name : 'Twin'>>
+		<<set _logName = _handle === $app ? 'Log' : `Log${_name}`>>
 
-	<<set _handle.sex = _handle.osex>>
-	<<set _handle.gender = _handle.ogender>>
-	<<set _handle.modgender = 0>>
-	<<set _handle.modpenis = 0>>
-	<<set _handle.modbreasts = 0>>
-	<<set _handle.penis = _handle.openis>>
-	<<set _handle.breasts = _handle.obreasts>>
-	<<set _handle.lactation = 0>>
+		/* ------------------------------------ Compute age (real and apparent) ------------------------------------- */
 
-	<<if _handle.sex == "male">>
-		<<set _handle.vagina = 0>>
-		<<if _i==$hiredCompanions.length>>
-			<<set $menCycleFlag = false>>
-		<</if>>
-		<<set _handle.womb = 0 >>
-	<<else>>
-		<<set _handle.vagina = 1>>
-		<<set _handle.womb = 1>>
-		<<if _i==$hiredCompanions.length>>
-			<<if $app.pregnantT==9999>>
-				<<set $menCycleFlag = true>>
-			<</if>>
-			<<if $menCycleT_flag == false>>
-				<<set $menCycleT_flag = true>>
-				<<set $menCycleT = $time - 7>>
-				<<set $heatCycleT = $time -7>>
-			<</if>>
-		<</if>>
-	<</if>>
-	<<for _genderEvent range _GenderLog>>
-		<<include "BreastCorrected">>
-		<<if _genderEvent.name == "Gender Reversal A" || _genderEvent.name == "Gender Reversal B" || _genderEvent.name == "Gender Reversal C" || _genderEvent.name == "Gender Reversal D" || _genderEvent.name == "Gender Reversal E" || _genderEvent.name == "Gender Reversal F" || _genderEvent.name == "Gender Reversal G" >>
-			<<set _handle.modgender += 1>>
-			<<if _handle.osex == "male">>
-				<<set _handle.gender += 1>>
-			<<else>>
-				<<set _handle.gender -= 1>>
-			<</if>>
-		<</if>>
-	
-		<<if _genderEvent.name == "Asset Robustness A" >>
-			<<set _handle.modpenis += 1>>
-			<<set _handle.modbreasts += 1>>
-			<<if _handle.penis>0>>
-				<<set _handle.penis += 1>>
-			<</if>>
-				<<if _handle.breasts >0 || _GenderLog.some(e=> e==="Interact A")>>
-				<<set _handle.breasts += 1>>
-			<</if>>
-		<</if>>
+		<<print `<<set _log = $Age${_logName}>>`>>
 
-		<<if _genderEvent.name == "Asset Robustness B">>
-			<<set _handle.modpenis += 2>>
-			<<set _handle.modbreasts += 2>>
-			<<if _handle.penis>0>>
-				<<set _handle.penis += 2>>
+		<<set _oldTime = 0>>
+		<<set _eventAge = _handle.age>>
+		<<for _event range _log>>
+			/* If this is an age event with a recorded time, add the elapsed time to the subject's age. */
+			<<if _event.variation>>
+				<<set _newTime = _event.variation>>
+				/* If we're adjusting the mc with eternal youth, only age them until they drank from the fountain. */
+				<<if _handle === $app && _newTime > $eternalYouth>>
+					<<set _newTime = $eternalYouth>>
+				<</if>>
+				<<if _oldTime < _newTime>>
+					<<set _eventAge += (_newTime - _oldTime) / 365.2425>>
+				<</if>>
+				<<set _oldTime = _event.variation>>
 			<</if>>
-			<<if _handle.breasts >0 ||  _GenderLog.some(e=> e==="Interact B")>>
-					<<set _handle.breasts += 2>>
-			<</if>>
-		<</if>>
-
-		<<if _genderEvent.name == "Asset Robustness C">>
-			<<set _handle.modpenis += 4>>
-			<<set _handle.modbreasts += 4>>
-
-			<<if _handle.penis>0>>
-				<<set _handle.penis += 4>>
-			<</if>>
-			<<if _handle.breasts >0 || _GenderLog.some(e=> e==="Interact C")>>
-				<<set _handle.breasts += 4>>
-			<</if>>
-		<</if>>
-
-		<<if _genderEvent.name == "Asset Robustness D">>
-			<<set _handle.modpenis += 6>>
-			<<set _handle.modbreasts += 6>>
-
-			<<if _handle.penis>0>>
-				<<set _handle.penis += 6>>
-			<</if>>
-
-			<<if _handle.breasts >0 || _GenderLog.some(e=> e==="Interact D")>>
-				<<set _handle.breasts += 6>>
-			<</if>>
-		<</if>>
-
-		<<if _genderEvent.name == "Asset Robustness E">>
-			<<set _handle.modpenis += 8>>
-			<<set _handle.modbreasts += 8>>
-			<<if _handle.penis>0>>
-				<<set _handle.penis += 8>>
-			<</if>>
-			<<if _handle.breasts >0 || _GenderLog.some(e=> e==="Interact E")>>
-				<<set _handle.breasts += 8>>
-			<</if>>
-		<</if>>
-
-		<<if _genderEvent.name == "Asset Robustness F">>
-			<<set _handle.modpenis += 16>>
-			<<set _handle.modbreasts += 16>>
-			<<if _handle.penis>0>>
-				<<set _handle.penis += 16>>
-			<</if>>
-			<<if _handle.breasts >0 || _GenderLog.some(e=> e==="Interact F")>>
-				<<set _handle.breasts += 16>>
-			<</if>>
-		<</if>>
-
-		<<if _genderEvent.name == "Asset Robustness G">>
-			<<set _handle.modpenis += 32>>
-			<<set _handle.modbreasts += 32>>
-			<<if _handle.penis>0>>
-				<<set _handle.penis += 32>>
-			<</if>>
-			<<if _handle.breasts >0 || _GenderLog.some(e=> e==="Interact G")>>
-				<<set _handle.breasts += 32>>
-			<</if>>
-		<</if>>
-
-		<<if  _genderEvent.name == "Sex Switcheroo">>
-			<<if _handle.osex == "male">>
-				<<set _handle.breasts += 3 + _handle.modbreasts>>
-				<<set _handle.penis = 0>>
-				<<set _handle.penisCor = 0>>
-				<<set _handle.vagina = 1>>
-				<<set _handle.sex = "female">>
-				<<set _handle.womb += 1>>
-				<<if _i==$hiredCompanions.length>>
-					<<if $app.pregnantT==9999>>
-						<<set $menCycleFlag = true>>
+			/* Now apply the effect of the age event. */
+			<<switch _event.name>>
+				<<case 'Age Reduction A'>>
+					<<if _eventAge > 22>>
+						<<set _eventAge = 20>>
+					<<else>>
+						<<set _eventAge -= 2>>
 					<</if>>
-					<<if $menCycleT_flag == false>>
-						<<set $menCycleT_flag = true>>
-						<<set $heatCycleT_flag = true>>
-						<<set $menCycleT = $time - 7>>
-						<<set $heatCycleT = $time -7>>
+				<<case 'Age Reduction B'>>
+					<<if _eventAge > 23>>
+						<<set _eventAge = 20>>
+					<<else>>
+						<<set _eventAge -= 3>>
 					<</if>>
+				<<case 'Age Reduction C'>>
+					<<if _eventAge > 24>>
+						<<set _eventAge = 20>>
+					<<else>>
+						<<set _eventAge -= 4>>
+					<</if>>
+				<<case 'Doll Transformation'>>
+					<<if _eventAge > 19>>
+						<<set _eventAge = 17>>
+					<<else>>
+						<<set _eventAge -= 2>>
+					<</if>>
+				<<case '1 Day Food Forage Minor Impact'>>
+					<<set _eventAge -= 0.08>>
+				<<case '1 Day Food Forage Major Impact'>>
+					<<set _eventAge -= 1>>
+			<</switch>>
+		<</for>>
+
+		/* Add any additional elapsed time to the subject's age. */
+		<<set _newTime = $time>>
+		/* If we're adjusting the MC and MC has eternal youth, only age them until they drank from the fountain. */
+		<<if _handle === $app && _newTime > $eternalYouth>>
+			<<set _newTime = $eternalYouth>>
+		<</if>>
+		<<if _oldTime < _newTime>>
+			<<set _eventAge += (_newTime - _oldTime) / 365.2425>>
+		<</if>>
+
+		/* Update the subject's apparent age. */
+		<<set _handle.appAge = Math.round(_eventAge)>>
+
+		/* Also set the subject's real age depending on the elapsed time. */
+		<<set _handle.realAge = Math.round(_handle.age + _newTime / 365.2425)>>
+
+		/* ----------------------------------- Compute apparent gender and assets ----------------------------------- */
+
+		<<print `<<set _log = $Gender${_logName}>>`>>
+
+		/* Set sex and asset size depending on original sex and sex changing curses. */
+		<<set _robustBreasts = false>>
+		<<if _log.some(event => event.name == 'Null')>>
+			<<if _log.some(event => event.name == 'Futa Fun')>>
+				<<if _handle.osex == 'male'>>
+					<<set _handle.breasts = _handle.openis / 2>>
+				<<else>>
+					<<set _handle.breasts = _handle.obreasts>>
+				<</if>>
+				/* No penis and maybe no breasts, but asset expansion goes to breasts. */
+				<<set _robustBreasts = true>>
+			<<elseif _log.some(event => event.name == 'Sex Switcheroo')>>
+				<<if _handle.osex == 'male'>>
+					<<set _handle.breasts = _handle.openis / 2>>
+				<<else>>
+					<<set _handle.breasts = 0>>
+					/* No penis or breasts, but asset expansion goes to breasts. */
+					<<set _robustBreasts = true>>
 				<</if>>
 			<<else>>
-				<<set _handle.penis = 6 + _handle.modpenis>>
-				<<set _handle.vagina = 0>>
-				<<set _handle.sex = "male">>
-				<<set _handle.womb -= 1>>
+				<<if _handle.osex == 'male'>>
+					<<set _handle.breasts = 0>>
+					/* No penis or breasts, but asset expansion goes to breasts. */
+					<<set _robustBreasts = true>>
+				<<else>>
+					<<set _handle.breasts = _handle.obreasts>>
+				<</if>>
+			<</if>>
+			<<set _handle.penis = 0, _handle.vagina = 0>>
+			<<set _handle.sex = 'doll-like'>>
+		<<elseif _log.some(event => event.name == 'Futa Fun')>>
+			<<if _handle.osex == 'male'>>
+				<<set _handle.breasts = _handle.openis / 2>>
+				<<set _handle.penis = _handle.openis>>
+			<<else>>
+				<<set _handle.breasts = _handle.obreasts>>
+				<<set _handle.penis = Math.max(_handle.obreasts * 2, 1)>>
+			<</if>>
+			<<set _handle.vagina = 1>>
+			<<set _handle.sex = 'futa'>>
+		<<elseif _log.some(event => event.name == 'Sex Switcheroo')>>
+			<<if _handle.osex == 'male'>>
+				<<set _handle.breasts = _handle.openis / 2>>
+				<<set _handle.penis = 0>>
+				<<set _handle.vagina = 1>>
+				<<set _handle.sex = 'female'>>
+			<<else>>
 				<<set _handle.breasts = 0>>
-				<<if _i==$hiredCompanions.length && _handle.womb == 0>>
-					<<set $menCycleFlag = false>>
-				<</if>>
-			<</if>>
-		<</if>>
-
-		<<if _genderEvent.name == "Futa Fun">>
-			<<if _handle.osex == "male">>
-				<<set _handle.vagina = 1>>
-				<<set _handle.womb += 1>>
-				<<if _i==$hiredCompanions.length>>
-					<<if $app.pregnantT==9999>>
-						<<set $menCycleFlag = true>>
-					<</if>>
-					<<if $menCycleT_flag == false>>
-						<<set $menCycleT_flag = true>>
-						<<set $heatCycleT_flag = true>>
-						<<set $menCycleT = $time - 7>>
-						<<set $heatCycleT = $time -7>>
-					<</if>>
-				<</if>>
-				<<set _handle.breasts += 3 + _handle.modbreasts>>
-			<<else>>
-				<<set _handle.penis = 3 + _handle.modpenis>>
-			<</if>>
-			<<set _handle.sex = "futa">>
-		<</if>>
-
-		<<if _genderEvent.name == "A Little Extra">>
-			<<if _handle.vagina > 0 && ($curse107.variation != "penis" && _handle.sex == "futa")>>
-				<<set _handle.vagina += 1>>
-				<<set _handle.womb += 1>>
-			<<elseif _handle.penisCor > 0 && ($curse107.variation !="vagina"  && _handle.sex == "futa")>>
-				<<set _handle.doublePenis = true>>
-			<</if>>
-		<</if>>
-
-		<<if _genderEvent.name == "Null">>
-			<<if _handle.penisCor > 0>>
-				<<set _handle.penis = 0>>
-				<<if _GenderLog.some(e=> e==="Interact A")>>
-					<<set _handle.breasts -= 1>>
-				<<elseif _GenderLog.some(e=> e==="Interact B")>>
-					<<set _handle.breasts -= 2>>
-				<<elseif _GenderLog.some(e=> e==="Interact C")>>
-					<<set _handle.breasts -= 4>>
-				<<elseif _GenderLog.some(e=> e==="Interact D")>>
-					<<set _handle.breasts -= 6>>
-				<<elseif _GenderLog.some(e=> e==="Interact E")>>
-					<<set _handle.breasts -= 8>>
-				<<elseif _GenderLog.some(e=> e==="Interact F")>>
-					<<set _handle.breasts -= 16>>
-				<<elseif _GenderLog.some(e=> e==="Interact G")>>
-					<<set _handle.breasts -= 32>>																							
-				<</if>>
-				<<set _handle.breasts += _handle.modbreasts>>
-			<</if>>
-			<<if _handle.vagina > 0>>
+				<<set _handle.penis = Math.max(_handle.obreasts * 2, 1)>>
 				<<set _handle.vagina = 0>>
-				<<set _handle.womb -= 1 >>
-				<<if _i==$hiredCompanions.length && _handle.womb == 0>>
-					<<set $menCycleFlag = false>>
-				<</if>>
+				<<set _handle.sex = 'male'>>
 			<</if>>
-			<<set _handle.sex = "doll-like">>
-		<</if>>
-
-		<<if _genderEvent.name == "Wacky Wombs">>
-			<<if (_handle.womb == 0 && _handle.sex=="male")||(_handle.womb == 1 && _handle.sex!="male")>>
-				<<set _handle.womb1 = $curse35.variation1>>
-				<<if _i==$hiredCompanions.length>>
-					<<if $app.pregnantT==9999>>
-						<<set $menCycleFlag = true>>
-					<</if>>
-					<<if $menCycleT_flag == false>>
-						<<set $menCycleT_flag = true>>
-						<<set $heatCycleT_flag = true>>
-						<<set $menCycleT = $time - 7>>
-						<<set $heatCycleT = $time -7>>
-					<</if>>
-				<</if>>
+		<<else>>
+			<<if _handle.osex == 'male'>>
+				<<set _handle.breasts = 0>>
+				<<set _handle.penis = _handle.openis>>
+				<<set _handle.vagina = 0>>
+				<<set _handle.sex = 'male'>>
 			<<else>>
-				<<set _handle.womb2 = $curse35.variation2>>
-			<</if>>
-			<<set _handle.womb += 1>>
-		<</if>>
-
-		<<if _genderEvent.name == "1 Day Water Forage Major Impact" >>
-			<<set _handle.modpenis += 1>>
-			<<set _handle.modbreasts += 1>>
-			<<if _handle.penis>0>>
-				<<set _handle.penis += 1>>
-			<</if>>
-
-			<<if _handle.breasts >0 || _handle.breastsCor > 0 >>
-				<<set _handle.breasts += 1>>
+				<<set _handle.breasts = _handle.obreasts>>
+				<<set _handle.penis = 0>>
+				<<set _handle.vagina = 1>>
+				<<set _handle.sex = 'female'>>
 			<</if>>
 		<</if>>
 
-		<<if _genderEvent.name == "1 Day Food Forage Major Impact" >>
-			<<set _handle.modgender += 1>>
-			<<if _handle.osex == "male">>
-				<<set _handle.gender += 1>>
-			<<else>>
-				<<set _handle.gender -= 1>>
-			<</if>>
-		<</if>>
+		/* Number of wombs initially matches number of vaginas. */
+		<<set _handle.womb = _handle.vagina>>
 
-		<<if _genderEvent.name == "Doll Transformation">>
+		/* At most one penis initially and no additional wombs. */
+		<<set _handle.doublePenis = false>>
+		<<set _handle.womb1 = '', _handle.womb2 = ''>>
+
+		/* Set gender based on original gender and gender reversal curses. */
+		/* Note: Not purely psychological as it has a minor effect on age-based adjustments. */
+		<<set _handle.gender = _handle.ogender>>
+		<<for _event range _log>>
+			<<switch _event.name>>
+				<<case
+					'Gender Reversal A' 'Gender Reversal B' 'Gender Reversal C' 'Gender Reversal D'
+					'Gender Reversal E' 'Gender Reversal F' 'Gender Reversal G'
+					'1 Day Food Forage Major Impact'
+				>>
+					<<set _handle.gender += _handle.osex == 'male' ? 1 : -1>>
+				<<case 'Doll Transformation'>>
+					/* Note: Event can take place multiple times. */
+					<<set _handle.gender += 1>>
+			<</switch>>
+		<</for>>
+
+		/* Make pregnant characters more feminine. */
+		<<if setup.daysConsideredPregnant(_handle) >= 90 && setup.daysUntilDue(_handle) > 0>>
 			<<set _handle.gender += 1>>
-			<<if _handle.doublePenis==true >>
-				<<set _handle.doublePenis = false>>
-			<<elseif _handle.penis>0 >>
-				<<set _handle.penis -=1>>
-			<<elseif _handle.vagina>0>>
-				<<set _handle.sex = "female">>
-				<<if _handle.appAge< 10 >>
-					<<set _handle.vagina -=1>>
-					<<set _handle.womb -= 1>>
-					<<if _handle.womb == 0>>
-						<<set $menCycleFlag = false>>
+		<</if>>
+
+		/* Clamp gender between 1 (= fully masculine) and 6 (= fully feminine). */
+		<<set _handle.gender = Math.clamp(_handle.gender, 1, 6)>>
+
+		/* For younger characters, compute breast size reduction according to age. */
+		/* Note: Asset robustness does not affect breasts if _handle.breastsCor == 0 unless _robustBreasts == true. */
+		<<set _handle.breastsCor = _handle.breasts>>
+		<<set _fullyGrownAge = 18 - (_handle.gender - 1) / 5>> /* 1 year lower for fully feminine characters. */
+		<<if _handle.appAge < _fullyGrownAge>>
+			<<set _handle.breastsCor = _handle.breasts * Math.max(1 - (_fullyGrownAge - _handle.appAge) / 10, 0)>>
+		<</if>>
+
+		/* Get all the extra womb events since it can be taken multiple times with different variations. */
+		<<set _wombEvents = _log.filter(event => event.name == 'Wacky Wombs')>>
+
+		<<for _event range _log>>
+			<<switch _event.name>>
+				<<case 'Shrunken Assets'>>
+					/* Note: Handled in the main loop because doll transformation is sensitive to ordering. */
+					<<if _handle.penis > 1>><<set _handle.penis = 1>><</if>>
+					<<if _handle.breasts > 1>><<set _handle.breasts = 1>><</if>>
+				<<case
+					'Asset Robustness A' 'Asset Robustness B' 'Asset Robustness C' 'Asset Robustness D'
+					'Asset Robustness E' 'Asset Robustness F' 'Asset Robustness G'
+				>>
+					/* 'A'.codePointAt(0) - 65 == 0, 'B'.codePointAt(0) - 65 == 1 etc. */
+					<<set _assetMod = 2**(_event.name.at(-1).codePointAt(0) - 65)>>
+					<<if _handle.penis > 0>><<set _handle.penis += _assetMod>><</if>>
+					<<if _handle.breastsCor > 0 || _robustBreasts>><<set _handle.breasts += _assetMod>><</if>>
+				<<case 'A Little Extra'>>
+					/* Check what to double. */
+					<<if _handle.vagina > 0 && _handle.penis > 0>>
+						/* Character has both, so check curse variation. */
+						<<if _event.variation == 'vagina'>>
+							<<set _handle.vagina += 1>>
+							<<set _handle.womb += 1>>
+						<<elseif _event.variation == 'penis'>>
+							<<set _handle.doublePenis = true>>
+						<</if>>
+					<<else>>
+						/* Double the genitals that the character actually has. */
+						<<if _handle.vagina > 0>>
+							<<set _handle.vagina += 1>>
+							<<set _handle.womb += 1>>
+						<<elseif _handle.penis > 0>>
+							<<set _handle.doublePenis = true>>
+						<</if>>
 					<</if>>
-					<<if _handle.vagina == 0>>
-						<<set _handle.sex = "doll-like">>
+				<<case 'Wacky Wombs'>>
+					/* Curse may be taken multiple times, so check the index to get the right variation. */
+					<<set _eventVariation = _event[`variation${_wombEvents.indexOf(_event) + 1}`]>>
+					<<if !_handle.womb1>>
+						<<if _eventVariation != 'vagina' || _handle.vagina > 0>>
+							<<set _handle.womb1 = _eventVariation>>
+							<<set _handle.womb += 1>>
+						<</if>>
+					<<elseif !_handle.womb2>>
+						<<if _eventVariation != 'vagina' || _handle.vagina > 0>>
+							<<set _handle.womb2 = _eventVariation>>
+							<<set _handle.womb += 1>>
+						<</if>>
 					<</if>>
+				<<case '1 Day Water Forage Major Impact'>>
+					<<if _handle.penis > 0>><<set _handle.penis += 1>><</if>>
+					<<if _handle.breastsCor > 0 || _robustBreasts>><<set _handle.breasts += 1>><</if>>
+				<<case 'Doll Transformation'>>
+					/* Note: Event can take place multiple times. */
+					<<if _handle.doublePenis>>
+						<<set _handle.doublePenis = false>>
+					<<elseif _handle.penis > 0>>
+						<<set _handle.penis -= 1>>
+						<<if _handle.penis < 1>>
+							<<set _handle.sex = _handle.vagina > 0 ? 'female' : 'doll-like'>>
+						<</if>>
+					<<elseif _handle.vagina > 0>>
+						<<if _handle.appAge < 10>>
+							<<set _handle.vagina -= 1>>
+							<<set _handle.womb -= 1>>
+							<<if _handle.vagina < 1>>
+								<<if _handle.womb2 == 'vagina'>>
+									<<set _handle.womb2 = ''>>
+									<<set _handle.womb -= 1>>
+								<</if>>
+								<<if _handle.womb1 == 'vagina'>>
+									<<set _handle.womb1 = _handle.womb2>>
+									<<set _handle.womb2 = ''>>
+									<<set _handle.womb -= 1>>
+								<</if>>
+								<<set _handle.sex = 'doll-like'>>
+							<</if>>
+							<<set _handle.sex = _handle.vagina > 0 ? 'female' : 'doll-like'>>
+						<</if>>
+					<</if>>
+			<</switch>>
+		<</for>>
+
+		<<if _handle.womb < 1 && setup.isPregnant(_handle)>> 
+			<<set setup.setNotPregnant(_handle)>> /* Can't be pregnant without a womb. */
+		<</if>>
+
+		<<if _handle.curses.some(e => e.name === 'Eggxellent')>>
+			/* If character has a penis and no urethral wombs, add one. */
+			<<if _handle.penis > 0 && !_wombEvents.some((event, i) => event[`variation${i + 1}`] == 'urethra')>>
+				<<if !_handle.womb1>>
+					<<set _handle.womb1 = 'urethra'>>
+				<<elseif !_handle.womb2>>
+					<<set _handle.womb2 = 'urethra'>>
 				<</if>>
-			<<else>>
-				<<set _handle.sex = "doll-like">>
-				/*
-				<<if _handle.vagina<1>>
-					<<set _handle.vagina=1>>
-					<<set _handle.womb += 1>>
-					<<if $app.pregnantT==9999>>
-						<<set $menCycleFlag = true>>
-					<</if>>
-					<<if $menCycleT_flag == false>>
-						<<set $menCycleT_flag = true>>
-						<<set $heatCycleT_flag = true>>
-						<<set $menCycleT = $time - 7>>
-						<<set $heatCycleT = $time -7>>
-					<</if>>
-
-				
-				<</if>> */
+				<<set _handle.womb += 1>>
 			<</if>>
 		<</if>>
-			
-	<</for>>
-	<<if _handle.womb == 0 && _tempPreg != 9999>> 
-		<<print "<<set $lastBirth" + _tempName + " = 9999>>">>
-		<<if _i==$hiredCompanions.length>>
-			<<set $due=9999>>
-			<<set $app.pregnantT=9999>>
-		<<else>>
-			<<print "<<set $lastBirth" + _tempName + " = 9999>>">>
-		<</if>>
-	<</if>>
 
-	<<if _GenderLog.some(e => e.name === "Shrunken Assets")>>
-		<<if _handle.sex == "male">>
-			<<set _handle.penis = 1>>
-			<<set _handle.breasts = 0>>
-		<<elseif _handle.sex == "female">>
-			<<set _handle.penis = 0>>
-			<<set _handle.breasts = 1>>
-		<<else>>
-			<<set _handle.penis = 1>>
-			<<set _handle.breasts = 1>>
-		<</if>>
-	<</if>>
-
-	<<if _handle.curses.some(e => e.name === "Leaky")>>
-
-		<<if _handle.vagina > 0 && _handle.penis > 0>>
-			<<set $curse80.appDesc = "Your pussy is always glistening with lubrication and your penis is always leaking precum, so it only takes a little motivation to get a real stream going down there.">>
-		<<elseif _handle.vagina > 0>>
-			<<set $curse80.appDesc = "Your pussy is always glistening with lubrication and it only takes a little motivation to get a real stream going down there.">>
-		<<elseif _handle.penis > 0>>
-			<<set $curse80.appDesc = "Your cock is always leaking precum and it only takes a little motivation to get a real stream going down there.">>
-		<</if>>
-
-	<</if>>
-
-	<<if _handle.curses.some(e => e.name === "Eggxellent")>>
-		<<if _i==$hiredCompanions.length>>
-			<<if $app.pregnantT==9999>>
-				<<set $menCycleFlag = true>>
-			<</if>>
-			<<if $menCycleT_flag == false>>
-				<<set $menCycleT_flag = true>>
-				<<set $heatCycleT_flag = true>>
+		/* Set menstruation cycle flags for mc. */
+		<<if _handle === $app>>
+			<<set $menCycleFlag = _handle.womb >= 1 && !setup.isPregnant(_handle)>>
+			<<if $menCycleFlag && !$menCycleT_flag>>
 				<<set $menCycleT = $time - 7>>
-				<<set $heatCycleT = $time -7>>
+				<<set $menCycleT_flag = true>>
+				/* If mc has the Heat/Rut curse, make them go into heat when their cycle starts. */
+				<<set $heatCycleT = $menCycleT>>
+				<<set $heatCycleT_flag = true>>
 			<</if>>
 		<</if>>
-		<<if _handle.penisCor>0>>
-			<<set _handle.womb += 1>>
+
+		/* Update Leaky curse description. */
+		<<if _handle.curses.some(e => e.name === 'Leaky')>>
+			<<if _handle.vagina > 0 && _handle.penis > 0>>
+				<<set $curse80.appDesc = 'Your pussy is always glistening with lubrication and your penis is always leaking precum, so it only takes a little motivation to get a real stream going down there.'>>
+			<<elseif _handle.vagina > 0>>
+				<<set $curse80.appDesc = 'Your pussy is always glistening with lubrication and it only takes a little motivation to get a real stream going down there.'>>
+			<<elseif _handle.penis > 0>>
+				<<set $curse80.appDesc = 'Your cock is always leaking precum and it only takes a little motivation to get a real stream going down there.'>>
+			<<else>>
+				<<set $curse80.appDesc = ''>>
+			<</if>>
 		<</if>>
-	<</if>>
-<</for>>
+
+		/* ------------------------------- Compute corrected breast size and lactation ------------------------------ */
+
+		<<set _handle.lactation = 0>>
+		<<set _handle.breastsCor = _handle.breasts>>
+
+		/* For younger characters, compute breast size reduction according to age. */
+		<<set _fullyGrownAge = 18 - (_handle.gender - 1) / 5>> /* 1 year lower for fully feminine characters. */
+		<<if _handle.appAge < _fullyGrownAge>>
+			<<set _handle.breastsCor = _handle.breasts * Math.max(1 - (_fullyGrownAge - _handle.appAge) / 10, 0)>>
+		<</if>>
+
+		/* Boost lactation for each curse. */
+		<<if _handle.curses.some(e => e.name === 'Lactation Rejuvenation A')>><<set _handle.lactation += 1>><</if>>
+		<<if _handle.curses.some(e => e.name === 'Lactation Rejuvenation B')>><<set _handle.lactation += 1>><</if>>
+
+		<<if setup.isPregnant(_handle)>>
+			/* Boost breast size during pregnancy. */
+			<<if 90 <= setup.daysConsideredPregnant(_handle) && setup.daysConsideredPregnant(_handle) < 120>>
+				<<set _handle.breastsCor += 0.5>>
+			<<elseif setup.daysConsideredPregnant(_handle) >= 120 && setup.daysUntilDue(_handle) > 0>>
+				<<set _handle.breastsCor += 1>>
+			<</if>>
+			/* Boost lactation in the last stages of pregnancy. */
+			<<if 240 <= setup.daysConsideredPregnant(_handle) && setup.daysConsideredPregnant(_handle) < 270>>
+				<<set _handle.lactation += 1>>
+			<<elseif setup.daysConsideredPregnant(_handle) >= 270 && setup.daysUntilDue(_handle) > 0>>
+				<<set _handle.lactation += 2>>
+			<</if>>
+		<<elseif _handle === $app>>
+			<<if $menCycleFlag>>
+				/* Boost breast size after day 20 of the menstruation cycle. */
+				<<if $time - $menCycleT - $menCycleVar > 20>>
+					<<set _handle.breastsCor += 0.5>>
+				<</if>>
+				/* Boost lactation and breast size after giving birth until the next menstruation cycle. */
+				<<if $menCycleT - $time > 30>>
+					<<set _handle.breastsCor += 1>>
+					<<set _handle.lactation += 2>>
+				<<elseif $menCycleT - $time > 0>>
+					<<set _handle.breastsCor += 0.5>>
+					<<set _handle.lactation += 1>>
+				<</if>>
+			<</if>>
+		<<else>>
+			<<print `<<set _lastBirth = $lastBirth${_name}>>`>>
+			<<if _lastBirth <= $time>>
+				/* Boost lactation and breast size for a while after giving birth. */
+				<<if $time - _lastBirth < 30>>
+					<<set _handle.breastsCor += 1>>
+					<<set _handle.lactation += 2>>
+				<<elseif $time - _lastBirth < 60>>
+					<<set _handle.breastsCor += 0.5>>
+					<<set _handle.lactation += 1>>
+				<</if>>
+			<</if>>
+		<</if>>
+
+		/* Maximize Lily's lactation if you're breastfeeding from her. */
+		<<if _handle === $companionLily && $LilyConvoLac>>
+			<<set _handle.lactation += 2>> 
+		<</if>>
+
+		<<if _handle.sex == 'doll-like'>>
+			<<set _handle.lactation = 0>> /* Can't lactate without nipples! */
+		<<elseif _handle.lactation > 2>>
+			<<set _handle.lactation = 2>> /* Cap lactation at +2. */
+		<</if>>
+
+		/* Boost breast size in accordance with lactation. */
+		<<set _handle.breastsCor += _handle.lactation>>
+
+		<<if _handle.curses.some(e => e.name === 'Double Pepperoni') && _handle.breastsCor < 1>>
+			<<set _handle.breastsCor += 1>> /* You can't look entirely flat with such puffy nipples. */
+		<</if>>
+
+		/* Now set the label depending on the corrected breast size. */
+		<<if _handle.breastsCor < 1>>
+			<<set _handle.breastsLabel = 'flat'>>
+		<<elseif _handle.breastsCor < 2>>
+			<<set _handle.breastsLabel = 'AA'>>
+		<<elseif _handle.breastsCor >= 20>>
+			<<set _handle.breastsLabel = 'S'>> /* Max supported label. */
+		<<else>>
+			/* String.fromCodePoint(63 + 2) == 'A', String.fromCodePoint(63 + 3) == 'B' etc. */
+			<<set _handle.breastsLabel = String.fromCodePoint(63 + Math.floor(_handle.breastsCor))>>
+		<</if>>
+
+		/* -------------------------------------- Compute corrected penis size -------------------------------------- */
+
+		<<set _handle.penisCor = _handle.penis>>
+		<<if _handle.penis > 0>>
+			/* For younger characters, compute penis size reduction according to age. */
+			<<set _fullyGrownAge = 16 - (_handle.gender - 1) / 5>> /* 1 year lower for fully feminine characters. */
+			<<if _handle.appAge < _fullyGrownAge>>
+				<<set _handle.penisCor = _handle.penis * Math.max(1 - (_fullyGrownAge - _handle.appAge) / 12, 1)>>
+			<</if>>
+
+			<<if _handle.curses.some(e => e.name === "Colossal-able")>>
+				<<set _handle.penisCor *= 70>>
+			<</if>>
+
+			<<if _handle.curses.some(e => e.name === "Minish-ish")>>
+				<<set _handle.penisCor /= 10>>
+			<</if>>
+		<</if>>
+	<</for>>
+<</capture>>
 
 <<checkTime>>
 
-<<for _i=0; _i<=$hiredCompanions.length; _i++>>
-	<<if _i==$hiredCompanions.length>>
-		<<set _handle = $app>>
-	<<else>>
-		<<if $hiredCompanions[_i].name == $companionTwin.name >>
-			<<set _tempName = "Twin">>
-		<<else>>
-			<<set _tempName = $hiredCompanions[_i].name>>
-		<</if>>
-		<<print "<<set _handle  = $companion"+ _tempName +" >>">>
-	<</if>>
-
-	<<if $time - _tempPreg>= 90 && $time - _tempPreg<=_due >>
-		<<set _handle.gender += 1>>
-	<</if>>
-	<<include "BreastCorrected">>
-	<<include "PenisCorrected">>
-<</for>>
-
 <<LibidoCorrected>>
 <<Update_MC_Speech>>
+
 <</widget>>
 
 :: Appearance widgets [widget nobr]
@@ -644,88 +513,6 @@
 	<<print (Math.round($app.heightCor)*(_meters ? 0.01 : 1)).toFixed(_meters ? 2 : 1) + (_meters ? " meters" : " cm")>>\
 <</widget>>
 
-:: Age widget [widget nobr]
-<<widget "AgeCorrected">>
-<<capture _handle _AgeLog>>
-	<<for _handle range $hiredCompanions>>
-		<<set _tempName = _handle.name != $companionTwin.name ? _handle.name : "Twin">>
-		<<set _AgeLog = State.variables["AgeLog" + (_handle.name != $companionTwin.name ? _handle.name : "Twin")]>>
-		<<include "CorrectAge">>
-	<</for>>
-	<<set _handle = $app>>
-	<<set _AgeLog = $AgeLog>>
-	<<include "CorrectAge">>
-<</capture>>
-<</widget>>
-
-:: CorrectAge [nobr]
-<<capture _oldTime _eventAge _ageEvent _newTime>>
-	<<set _oldTime = 0>>
-	<<set _eventAge = _handle.age>>
-	<<for _ageEvent range _AgeLog>>
-		/* If this is an age event with a recorded time, add the elapsed time to the subject's age. */
-		<<if _ageEvent.variation>>
-			<<set _newTime = _ageEvent.variation>>
-			/* If we're adjusting the MC and MC has eternal youth, only age them until they drank from the fountain. */
-			<<if _handle === $app && _newTime > $eternalYouth>>
-				<<set _newTime = $eternalYouth>>
-			<</if>>
-			<<if _oldTime < _newTime>>
-				<<set _eventAge += (_newTime - _oldTime) / 365.2425>>
-			<</if>>
-			<<set _oldTime = _ageEvent.variation>>
-		<</if>>
-		/* Now apply the effect of the age event. */
-		<<switch _ageEvent.name>>
-			<<case "Age Reduction A">>
-				<<if _eventAge > 22>>
-					<<set _eventAge = 20>>
-				<<else>>
-					<<set _eventAge -= 2>>
-				<</if>>
-			<<case "Age Reduction B">>
-				<<if _eventAge > 23>>
-					<<set _eventAge = 20>>
-				<<else>>
-					<<set _eventAge -= 3>>
-				<</if>>
-			<<case "Age Reduction C">>
-				<<if _eventAge > 24>>
-					<<set _eventAge = 20>>
-				<<else>>
-					<<set _eventAge -= 4>>
-				<</if>>
-			<<case "Doll Transformation">>
-				<<if _eventAge > 19>>
-					<<set _eventAge = 17>>
-				<<else>>
-					<<set _eventAge -= 2>>
-				<</if>>
-			<<case "1 Day Food Forage Minor Impact">>
-				<<set _eventAge -= 0.08>>
-			<<case "1 Day Food Forage Major Impact">>
-				<<set _eventAge -= 1>>
-		<</switch>>
-	<</for>>
-
-	/* Add any additional elapsed time to the subject's age. */
-	<<set _newTime = $time>>
-	/* If we're adjusting the MC and MC has eternal youth, only age them until they drank from the fountain. */
-	<<if _handle === $app && _newTime > $eternalYouth>>
-		<<set _newTime = $eternalYouth>>
-	<</if>>
-	<<if _oldTime < _newTime>>
-		<<set _eventAge += (_newTime - _oldTime) / 365.2425>>
-	<</if>>
-
-	/* Update the subject's apparent age. */
-	<<set _handle.appAge = Math.round(_eventAge)>>
-
-	/* Also set the subject's real age depending on the elapsed time. */
-	<<set _handle.realAge = Math.round(_handle.age + _newTime / 365.2425)>>
-<</capture>>
-
-
 :: Libido widget [widget nobr]
 <<widget "LibidoCorrected">>
 <<for _i=0; _i<=$hiredCompanions.length; _i++>>
@@ -734,12 +521,12 @@
 		<<set _LibidoLog = $LibidoLog>>
 	<<else>>
 		<<if $hiredCompanions[_i].name == $companionTwin.name >>
-			<<set _tempName = "Twin">>
+			<<set _name = "Twin">>
 		<<else>>
-			<<set _tempName = $hiredCompanions[_i].name>>
+			<<set _name = $hiredCompanions[_i].name>>
 		<</if>>
-		<<print "<<set _handle  = $companion"+ _tempName +" >>">>
-		<<print "<<set _LibidoLog  = $LibidoLog"+ _tempName +" >>">>
+		<<print "<<set _handle  = $companion"+ _name +" >>">>
+		<<print "<<set _LibidoLog  = $LibidoLog"+ _name +" >>">>
 	<</if>>
 	<<set _handle.libido = 2>>
 	<<set _handle.subdom = 0>>
@@ -787,7 +574,7 @@
 		<</if>>
 
 		<<if $playerCurses.some(e => e.name === "Heat/Rut")>>
-			<<if $heatCycleT_flag == false>>	
+			<<if !$heatCycleT_flag>>	
 				<<if $menCycleT_flag == true>>
 					<<set $heatCycleT = $menCycleT>>
 				<<else>>
@@ -878,11 +665,11 @@
 		<<set _handle = $app>>
 	<<else>>
 		<<if $hiredCompanions[_i].name == $companionTwin.name >>
-			<<set _tempName = "Twin">>
+			<<set _name = "Twin">>
 		<<else>>
-			<<set _tempName = $hiredCompanions[_i].name>>
+			<<set _name = $hiredCompanions[_i].name>>
 		<</if>>
-		<<print "<<set _handle  = $companion"+ _tempName +" >>">>
+		<<print "<<set _handle  = $companion"+ _name +" >>">>
 	<</if>>
 
 	<<set _penisCorTemp = _handle.penisCor>>
@@ -1084,11 +871,11 @@
 		<<set _handle = $app>>
 	<<else>>
 		<<if $hiredCompanions[_i].name == $companionTwin.name >>
-			<<set _tempName = "Twin">>
+			<<set _name = "Twin">>
 		<<else>>
-			<<set _tempName = $hiredCompanions[_i].name>>
+			<<set _name = $hiredCompanions[_i].name>>
 		<</if>>
-		<<print "<<set _handle  = $companion"+ _tempName +" >>">>
+		<<print "<<set _handle  = $companion"+ _name +" >>">>
 	<</if>>
 	<<set _handle.inhuman =0>>
 	<<if _handle.ears != "normal human">>
@@ -1165,12 +952,12 @@
 		<<set $ConvoHandicapFood = false>>
 	<<else>>
 		<<if $hiredCompanions[_i].name == $companionTwin.name >>
-			<<set _tempName = "Twin">>
+			<<set _name = "Twin">>
 		<<else>>
-			<<set _tempName = $hiredCompanions[_i].name>>
+			<<set _name = $hiredCompanions[_i].name>>
 		<</if>>
-		<<print "<<set _handle  = $companion"+ _tempName +" >>">>
-		<<print "<<set _HandicapLog  = $HandicapLog"+ _tempName +" >>">>
+		<<print "<<set _handle  = $companion"+ _name +" >>">>
+		<<print "<<set _HandicapLog  = $HandicapLog"+ _name +" >>">>
 	<</if>>
 
 	<<set _handle.HandicapThreat =0>>
@@ -1347,27 +1134,27 @@
 			
 	<<if _i==$hiredCompanions.length>>
 		<<if $menstruating == true>>
-			<<set _handle.HandicapThreat -=2>>
+			<<set _handle.HandicapThreat -= 2>>
 		<</if>>
 
-		<<if $time - $app.pregnantT< 45 && $time - $app.pregnantT>= 35>>
-			<<set _handle.HandicapMovement -=2>>
-		<<elseif $time - $app.pregnantT< 90 && $time - $app.pregnantT>= 45>>
-			<<set _handle.HandicapThreat -=2>>
-			<<set _handle.HandicapMovement -=4>>
-			<<set _handle.HandicapCarry -=3>>
-		<<elseif $time - $app.pregnantT< 180 && $time - $app.pregnantT>= 120>>
-			<<set _handle.HandicapThreat -=1>>
-			<<set _handle.HandicapMovement -=2>>
-			<<set _handle.HandicapCarry -=2>>
-		<<elseif $time - $app.pregnantT< 240 && $time - $app.pregnantT>=180>>
-			<<set _handle.HandicapThreat -=2>>
-			<<set _handle.HandicapMovement -=3>>
-			<<set _handle.HandicapCarry -=3>>
-		<<elseif $time - $app.pregnantT< $due && $time - $app.pregnantT>=240>>
-			<<set _handle.HandicapThreat -=4>>
-			<<set _handle.HandicapMovement -=5>>
-			<<set _handle.HandicapCarry -=5>>
+		<<if 35 <= setup.daysConsideredPregnant($app) && setup.daysConsideredPregnant($app) < 45>>
+			<<set _handle.HandicapMovement -= 2>>
+		<<elseif 45 <= setup.daysConsideredPregnant($app) && setup.daysConsideredPregnant($app) < 90>>
+			<<set _handle.HandicapThreat -= 2>>
+			<<set _handle.HandicapMovement -= 4>>
+			<<set _handle.HandicapCarry -= 3>>
+		<<elseif 120 <= setup.daysConsideredPregnant($app) && setup.daysConsideredPregnant($app) < 180>>
+			<<set _handle.HandicapThreat -= 1>>
+			<<set _handle.HandicapMovement -= 2>>
+			<<set _handle.HandicapCarry -= 2>>
+		<<elseif 180 <= setup.daysConsideredPregnant($app) && setup.daysConsideredPregnant($app) < 240>>
+			<<set _handle.HandicapThreat -= 2>>
+			<<set _handle.HandicapMovement -= 3>>
+			<<set _handle.HandicapCarry -= 3>>
+		<<elseif setup.daysConsideredPregnant($app) >= 240 && setup.daysUntilDue($app) > 0>>
+			<<set _handle.HandicapThreat -= 4>>
+			<<set _handle.HandicapMovement -= 5>>
+			<<set _handle.HandicapCarry -= 5>>
 		<</if>>
 		<<if $DaedalusEquip == true && _handle.HandicapMovement < 0>>
 			<<set _handle.HandicapMovement = 0 >>
@@ -1601,16 +1388,14 @@
 		penis: $app.openis,
 		penisCor: $app.openis,
 		doublePenis: false,
-		modpenis: 0,
 		vagina: 0,
 		gender: $app.ogender,
-		modgender:0,
 		switch: false,
 		breasts: $app.obreast,
-		modbreasts: 0,
 		breastsCor: $app.obreast,
 		lactation: 0,
 		pregnantT: $app.pregnantT,
+		due: setup.dueDate($app),
 		ears: "normal human",
 		height: $app.oheight,
 		modheight: 0,
@@ -1635,14 +1420,14 @@
 		}>>
 	
 
-	<<if $app.osex=="male">>
+	<<if $app.osex == "male">>
 		<<set $companionTwin.osex = "female">>
 		<<set $companionTwin.ogender = 6>>
-		<<set $companionTwin.oheight = $app.oheight -0.01525*$app.oheight*5 >>
+		<<set $companionTwin.oheight = $app.oheight * (1 - 0.01525 * 5)>>
 	<<else>>
 		<<set $companionTwin.osex = "male">>
 		<<set $companionTwin.ogender = 1>>
-		<<set $companionTwin.oheight = $app.oheight +0.01525*$app.oheight*5>>
+		<<set $companionTwin.oheight = $app.oheight * (1 + 0.01525 * 5)>>
 	<</if>>
 	<<if $app.sex=="male">>
 		<<set $companionTwin.sex = "female">>
@@ -1689,16 +1474,14 @@
 		penis: $app.openis,
 		penisCor: $app.openis,
 		doublePenis: false,
-		modpenis: 0,
 		vagina: 0,
 		gender: $app.ogender,
-		modgender:0,
 		switch: false,
 		breasts: $app.obreast,
-		modbreasts: 0,
 		breastsCor: $app.obreast,
 		lactation: 0,
 		pregnantT: $app.pregnantT,
+		due: setup.dueDate($app),
 		ears: "normal human",
 		height: $app.oheight,
 		modheight: 0,
@@ -1784,16 +1567,14 @@
 		penis: 6,
 		penisCor: 6,
 		doublePenis: false,
-		modpenis: 0,
 		vagina: 0,
 		gender: 1,
-		modgender:0,
 		switch: false,
 		breasts: 0,
-		modbreasts: 0,
 		breastsCor: 0,
 		lactation: 0,
-		pregnantT: 9999,
+		pregnantT: setup.never,
+		due: setup.never,
 		ears: "",
 		height: 170,
 		modheight: 0,
@@ -1916,16 +1697,14 @@
 		penis: 0,
 		penisCor: 0,
 		doublePenis: false,
-		modpenis: 0,
 		vagina: 1,
 		gender: 6,
-		modgender:0,
 		switch: false,
 		breasts: 3,
-		modbreasts: 0,
 		breastsCor: 3,
 		lactation: 0,
-		pregnantT: 9999,
+		pregnantT: setup.never,
+		due: setup.never,
 		ears: "",
 		height: 163,
 		modheight: 0,
@@ -2037,33 +1816,33 @@
 	@@.alert2; You are currently injured, increasing your next $status.duration travel times by $status.penalty days each. @@<br><br>
 <</if>>
 
-<<if $Maru_LastT<$time-7>>
+<<if $time > $Maru_LastT + 7>>
 <<set $companionMaru.affec+=(1+$hsswear + $maruPangea)>>
-<<set $Maru_LastT=$time>>
+<<set $Maru_LastT = $time>>
 <<if $MaruConvo1 && $forageFood == 0>>
 	<<set $items[1].count +=1 >>
 	@@.alert1; Maru cooked an especially delicious meal granting you an extra day worth of food!<br><br>
 <</if>>
 <</if>>
 
-<<if $Lily_LastT<$time-7>>
+<<if $time > $Lily_LastT + 7>>
 <<set $companionLily.affec+=(1+$hsswear + $maruPangea)>>
-<<set $Lily_LastT=$time>>
+<<set $Lily_LastT = $time>>
 <</if>>
 
-<<if $Khemia_LastT<$time-7>>
+<<if $time > $Khemia_LastT + 7>>
 <<set $companionKhemia.affec+=(1+$hsswear + $maruPangea)>>
-<<set $Khemia_LastT=$time>>
+<<set $Khemia_LastT = $time>>
 <</if>>
 
-<<if $Cherry_LastT<$time-7>>
+<<if $time > $Cherry_LastT + 7>>
 <<set $companionCherry.affec+=(1+$hsswear + $maruPangea)>>
-<<set $Cherry_LastT=$time>>
+<<set $Cherry_LastT = $time>>
 <</if>>
 
-<<if $Cloud_LastT<$time-7>>
+<<if $time > $Cloud_LastT + 7>>
 <<set $companionCloud.affec+=(1+$hsswear + $maruPangea)>>
-<<set $Cloud_LastT=$time>>
+<<set $Cloud_LastT = $time>>
 <<set $altCloud = random(0,3)>>
 <<if $CloudConvo1>>
 	<<if $altCloud == 1>>
@@ -2078,17 +1857,17 @@
 <</if>>
 <</if>>
 
-<<if $Saeko_LastT<$time-7>>
+<<if $time > $Saeko_LastT + 7>>
 <<set $companionSaeko.affec+=(1+$hsswear + $maruPangea)>>
-<<set $Saeko_LastT=$time>>
+<<set $Saeko_LastT = $time>>
 <</if>>
 
-<<if $Twin_LastT<$time-7>>
+<<if $time > $Twin_LastT + 7>>
 <<set $companionTwin.affec+=(1+$hsswear + $maruPangea)>>
-<<set $Twin_LastT=$time>>
+<<set $Twin_LastT = $time>>
 <</if>>
 
-<<if $fit_adjustLastT<$time-20>>
+<<if $time > $fit_adjustLastT + 20>>
 	<<if $fit>8>>
 	<<set $fit-=1>>
 	@@.alert1; Your lack of an intensive work-out reduces your fitness to somewhat more average levels<br><br>
@@ -2141,7 +1920,7 @@
 			<<if $menFirstCycle == true>>
 				<<if $EventHorizonWear== false>>
 					<<set $menFirstCycle = false>>
-					<<if $app.womb1 == "throat">>
+					<<if $app.womb1 == "throat" || $app.womb2 == "throat">>
 						@@.alert1; When you start coughing up $app.blood blood, panic sets in as you fear the worst – some Abyssal lung disease. But as you examine the substance, you realize it's not normal blood, and your lungs feel fine. The truth dawns on you suddenly: you're experiencing your first period. With a uterus now residing in your throat, you feel completely overwhelmed and on the verge of tears. <br><br>
 					<<else>>
 						@@.alert1; The sight of $app.blood bloodstains in your underwear confirms your suspicion – you're having your first period. With a new uterus, you feel overwhelmed and on the verge of tears.<br><br>
@@ -2182,31 +1961,37 @@
 	<</if>>	
 <</if>>
 
-<<if $app.pregnantT <= $time - 14>>
-	<<if $time - $app.pregnantT < 35 && $time - $app.pregnantT >= 28 && $menFirstCycle == false>>
-		@@.alert1; Your heart races as you realize your cycle should have started by now. Perhaps it's simply late, no need to panic just yet, right? The uncertainty lingers.<br><br>
-	<<elseif $time - $app.pregnantT < 45 && $time - $app.pregnantT >= 35 && $menFirstCycle == false>>
-		@@.alert1; Anxiety creeps in as your period remains conspicuously absent. This lateness is unusual for you, and the thought of pregnancy begins to haunt your mind.<br><br>
-	<<elseif $time - $app.pregnantT < 90 && $time - $app.pregnantT >= 45 && $random == 0>>
-		@@.alert1; You find yourself overwhelmed by exhaustion, and bouts of nausea threaten to topple you. This isn't ideal for your travels or facing any threats.
-		<<if $menFirstCycle == false>>
-			@@.alert1; The truth is undeniable – you're pregnant. Now, you must decide what to do next.
-		<<else>>
-			@@.alert1; The miasma could be causing some sort of illness. Maybe it will pass, or perhaps you need medical attention.
+<<if setup.daysConsideredPregnant($app) >= 14>>
+	/* Show symptoms alert once every 3 times, unless it's early in the pregnancy and mc was expecting to start her cycle. */
+	<<if $random == 0 || (!$menFirstCycle && setup.daysConsideredPregnant($app) < 45)>>
+		<<if 28 <= setup.daysConsideredPregnant($app) && setup.daysConsideredPregnant($app) < 35 && !$menFirstCycle>>
+			@@.alert1; Your heart races as you realize your cycle should have started by now. Perhaps it's simply late, no need to panic just yet, right? The uncertainty lingers.<br><br>
+		<<elseif 35 <= setup.daysConsideredPregnant($app) && setup.daysConsideredPregnant($app) < 45 && !$menFirstCycle>>
+			@@.alert1; Anxiety creeps in as your period remains conspicuously absent. This lateness is unusual for you, and the thought of pregnancy begins to haunt your mind.<br><br>
+		<<elseif 45 <= setup.daysConsideredPregnant($app) && setup.daysConsideredPregnant($app) < 90>>
+			@@.alert1; You find yourself overwhelmed by exhaustion, and bouts of nausea threaten to topple you. This isn't ideal for your travels or facing any threats.
+			<<if !$menFirstCycle>>
+				@@.alert1; The truth is undeniable – you're pregnant. Now, you must decide what to do next.<br><br>
+			<<else>>
+				@@.alert1; The miasma could be causing some sort of illness. Maybe it will pass, or perhaps you need medical attention.<br><br>
+			<</if>>
+		<<elseif  90 <= setup.daysConsideredPregnant($app) && setup.daysConsideredPregnant($app) < 120 && !$menFirstCycle>>
+			@@.alert1; Your pregnancy occupies your thoughts, but aside from that, you feel relatively fine. You notice your breasts and butt have grown a little, and a hint of fatigue lingers, but there's nothing too concerning.<br><br>
+		<<elseif 120 <= setup.daysConsideredPregnant($app) && setup.daysConsideredPregnant($app) < 180>>
+			<<if !$menFirstCycle>>
+				@@.alert1; Your pregnant belly is now round and prominent. You occasionally feel a gentle kick from within, but your growing belly begins to hinder your travels more and more.<br><br>
+			<<else>>
+				@@.alert1; You've gained considerable weight, especially around your belly, which sometimes experiences a peculiar tickling sensation. Your butt, thighs, and <<if $app.breastsCor<3 && $app.sex=="male">>pecs<<else>>breasts<</if>> have also accumulated some fat. This extra weight will slow you down during your travels.<br><br>
+			<</if>>
+		<<elseif 180 <= setup.daysConsideredPregnant($app) && setup.daysConsideredPregnant($app) < 240>>
+			<<if !$menFirstCycle>>
+				@@.alert1; It's impossible to deny your pregnancy now. Your child's movements inside your swollen belly have become more frequent. But the added weight and energy-draining nature of pregnancy make navigating the Abyss increasingly difficult.<br><br>
+			<<else>>
+				@@.alert1; You can no longer ignore the truth – you're pregnant and have been for some time. Your child's movements within your belly are unmistakable. Your energy is drained more quickly than usual, whether from the added weight or the pregnancy itself. With a large, round belly and about half your normal energy, navigating the Abyss has become significantly more challenging.<br><br>
+			<</if>>
+		<<elseif setup.daysConsideredPregnant($app) >= 240 && setup.daysUntilDue($app) > 0>>
+			@@.alert2; Your advanced pregnancy has made even simple tasks feel like monumental challenges. Standing, sitting, bending, and sleeping require great effort. Walking is limited to short distances, while running and fighting are out of the question. <<if $app.lactation > 0>>Milk stains from your breasts mar your clothes, reminding you of your impending labor.<</if>> Your ability to traverse the Abyss is severely limited. Ensure you have enough supplies for the days you'll be immobilized after giving birth!<br><br>
 		<</if>>
-		<br><br>
-	<<elseif $time - $app.pregnantT < 120 && $time - $app.pregnantT >= 90 && $menFirstCycle == false && $random == 0>>
-		@@.alert1; Your pregnancy occupies your thoughts, but aside from that, you feel relatively fine. You notice your breasts and butt have grown a little, and a hint of fatigue lingers, but there's nothing too concerning.<br><br>
-	<<elseif $time - $app.pregnantT < 180 && $time - $app.pregnantT >= 120 && $menFirstCycle == false && $random == 0>>
-		@@.alert1; Your pregnancy belly is now round and prominent. You occasionally feel a gentle kick from within, but your growing belly begins to hinder your travels more and more.<br><br>
-	<<elseif $time - $app.pregnantT < 180 && $time - $app.pregnantT >= 120 && $menFirstCycle == true && $random == 0>>
-		@@.alert1; You've gained considerable weight, especially around your belly, which sometimes experiences a peculiar tickling sensation. Your butt, thighs, and <<if $app.breastsCor<3 && $app.sex=="male">>pecs<<else>>breasts<</if>> have also accumulated some fat. This extra weight will slow you down during your travels.<br><br>
-	<<elseif $time - $app.pregnantT < 240 && $time - $app.pregnantT >=180 && $menFirstCycle == false && $random == 0>>
-		@@.alert1; It's impossible to deny your pregnancy now. Your child's movements inside your swollen belly have become more frequent. But the added weight and energy-draining nature of pregnancy make navigating the Abyss increasingly difficult.<br><br>
-	<<elseif $time - $app.pregnantT < 240 && $time - $app.pregnantT >=180 && $menFirstCycle == true && $random == 0>>
-		@@.alert1; You can no longer ignore the truth – you're pregnant and have been for some time. Your child's movements within your belly are unmistakable. Your energy is drained more quickly than usual, whether from the added weight or the pregnancy itself. With a large, round belly and about half your normal energy, navigating the Abyss has become significantly more challenging.<br><br>
-	<<elseif $time - $app.pregnantT < $due && $time - $app.pregnantT >=240 && $random == 0>>
-		@@.alert2; Your advanced pregnancy has made even simple tasks feel like monumental challenges. Standing, sitting, bending, and sleeping require great effort. Walking is limited to short distances, while running and fighting are out of the question. Milk stains from your breasts mar your clothes, reminding you of your impending labor. Your ability to traverse the Abyss is severely limited. Ensure you have enough supplies for the days you'll be immobilized after giving birth!<br><br>
 	<</if>>
 <</if>>
 
@@ -2292,7 +2077,7 @@
 	<<set $app.oeyeColor = $PulseBloomStorage.oeyeColor>>
 	<<set $app.desc = "">>
 	<<set $app.fit -= $PulseBloomStorage.fit>>
-	<<set $PulseBloomDate = 9999>>
+	<<set $PulseBloomDate = setup.never>>
 	<<set $PulseBloomUse="">>
 	<<Update_MC_Speech>>
 <</if>>
@@ -2302,13 +2087,12 @@
 <<widget "PregCheck">>
 <<set _temp = random(0,100)>>
 
-<<if _temp <= $pregChance*100 && $app.pregnantT==9999 && $menCycleFlag == true >>
-	<<if  $playerCurses.some(e => e.name === "Eggxellent")>>
+<<if _temp <= 100 * $pregChance && !setup.isPregnant($app) && $menCycleFlag>>
+	<<if $playerCurses.some(e => e.name === "Eggxellent")>>
 		<<set $EggsFertilized = true>>
 	<<else>>
-		<<set $app.pregnantT = $time -14>>
+		<<set setup.setConsideredPregnant($app)>>
 		<<set $menCycleFlag = false>>
-		<<set $due = $app.pregnantT+280+random(-7,7) >>
 	<</if>>
 <</if>>
 
@@ -2319,7 +2103,7 @@
 <<for _i=0; _i<$hiredCompanions.length; _i++ >>
 	<<set _temp = random(0,100)>>
 	<<if $hiredCompanions[_i].curses.some(e => e.name === "Omnitool") && $hiredCompanions[_i].womb > 0 && (_temp < 20 || $hiredCompanions[_i].curses.some(e => e.name === "Absolute Pregnancy")) && !$hiredCompanions[_i].curses.some(e => e.name === "Absolute Birth Control")>>
-		<<set $hiredCompanions[_i].pregnantT = $time-14>>
+		<<set setup.setConsideredPregnant($hiredCompanions[_i])>>
 	<</if>>
 <</for>>
 <</widget>>
@@ -2408,17 +2192,16 @@
 <<for _i=0; _i<=$hiredCompanions.length; _i++>>
 	<<if _i==$hiredCompanions.length>>
 		<<set _handle = $app>>
-		<<set _GenderLog = $GenderLog>>
 	<<else>>
 		<<if $hiredCompanions[_i].name == $companionTwin.name >>
-			<<set _tempName = "Twin">>
+			<<set _name = "Twin">>
 		<<else>>
-			<<set _tempName = $hiredCompanions[_i].name>>
+			<<set _name = $hiredCompanions[_i].name>>
 		<</if>>
-		<<print "<<set _handle  = $companion"+ _tempName +" >>">>
+		<<print "<<set _handle  = $companion"+ _name +" >>">>
 	<</if>>
 	<<set _handle.hair = _handle.ohair>> 
-	<<if _tempName != "Golem">>
+	<<if _name != "Golem">>
 		<<set _handle.ears= "normal human">>
 	<</if>>
 
@@ -2839,7 +2622,7 @@
 	<<elseif $TwinConvo2==false && $companionTwin.affec>15 && $TwinConvo1 && 0>>
 		<<set _temp += 1 >>
 	<</if>>
-	<<if $TwinConvoPreg==false && $time - $companionTwin.pregnantT > 120>>
+	<<if $TwinConvoPreg==false && setup.daysConsideredPregnant($companionTwin) > 120>>
 		<<set _temp += 1 >>
 	<</if>>
 <</if>>


### PR DESCRIPTION
Marking this as a draft as I need to give it some more testing, but I wanted to get this up.

This cleans up GenderCorrected widget, the BreastCorrected widget, the PenisCorrected widget and the HeightCorrected widget. It also folds AgeCorrected, BreastCorrected and PenisCorrected into GenderCorrected. Eventually I'd like to combine more of them, but the amount of changes was getting too large.

In addition to restructuring the aforementioned widgets, I also added a bunch of helpers functions to deal with pregnancy and tidied up all the checks around that. `$due` is gone - instead, each character now tracks their own due date which can be queried whenever.

I also added `setup.never` to replace the use of `9999` to indicate "far into the future". I made the number a lot bigger - you never know what players might end up doing, especially if they want to experience a whole bunch of pregnancies. It shouldn't impact any existing saves - there were some checks against 9999, but I was able to replace them with checks against `$time`.

`widgets.twee` is probably impossible to review by looking at the changeset - it's much easier to just look at the result. I tried to keep the widget ordering the same, but because I folded things into GenderCorrected there's still a bunch of code motion.