### PR TITLE
Consolidate attribute widgets, separate checkTime calls out

### DIFF
--- a/src/companionConversations.twee
+++ b/src/companionConversations.twee
@@ -929,9 +929,10 @@ Lily spends some time discussing the importance of respecting boundaries and app
 The moment she hears you speak, Lily makes a high pitched squeak and jumps up, startled. She then drops the World Stone she was holding.
 
 <<say $companionLily>>Don't sneak up on me like that!<</say>>
-<<if $app.fit<4>>\
+<<set _fitCor = $app.curses.some(e => e.name === "Weakling") ? 0 : $app.fit>>
+<<if _fitCor < 4>>\
 You chuckle a little at the fact that you made a woman who could easily outmatch you physically squeak like a little girl.
-<<elseif $app.fit<=7>>\
+<<elseif _fitCor <= 7>>\
 You chuckle a little at the fact that you made a woman who may be stronger than you squeak like a little girl.
 <<else>>\
 You chuckle a little at the fact that you made a woman who could give you a fair physical competition squeak like a little girl.
@@ -1140,7 +1141,6 @@ She lets out a small giggle as she strokes your $app.hair hair softly as you con
 <</if>>
 
 :: Khemia Convo0
-<<appGender>>\
 <<say $companionKhemia>>Yo, I'm Khemia, nice to meet you.<</say>>
 <<ConversationChoices
 	[[Greet him warmly with a hug|Khemia Convo0 Hug]]
@@ -2896,7 +2896,6 @@ Saeko meticulously guides you through a comprehensive timetable, detailing every
 <</if>>
 
 :: Twin Convo1
-<<Update_MC_Speech>>\
 You see your twin sitting down staring into the distance, seemingly lost in thought. You sit down next to <<if $companionTwin.sex=='male'>>him <<else>>her <</if>> also in silence. You have an idea what's on <<if $companionTwin.sex=='male'>>his <<else>>her <</if>>mind because you have also been thinking about it. The moment you want to say something $companionTwin.name speaks up.
 <<say $companionTwin>>You know when I obtained the twin Curse first I was sort of happy, I've sort of always wondered what it would be like to have a twin. But very quickly afterwards I honestly got scared that you might replace me or something. Is that weird?<</say>>
 <<ConversationChoices
@@ -3580,7 +3579,9 @@ With a mutual understanding, you and your twin join forces once more, ready to t
 :: Pulse Bloom Forced
 <<print "<<set _companion  = $companion"+ $PulseBloomUse +" >>">> 	<<set _string = "Layer" + $currentLayer + " Hub">>
 Silently, you approach _companion.name,  moving stealthily to catch them off guard. You aim to coax <<if _companion.sex=="male">>him<<else>>her<</if>> into a subdued state and wrestle <<if _companion.sex=="male">>him<<else>>her<</if>> into submission.
-<<if $app.HandicapThreat + $app.fit > _companion.HandicapThreat + _companion.fit>>
+<<set _appFitCor = $playerCurses.some(e => e.name === "Weakling") ? 0 : $app.fit>>
+<<set _companionFitCor = _companion.curses.some(e => e.name === "Weakling") ? 0 : _companion.fit>>
+<<if $app.HandicapThreat + _appFitCor > _companion.HandicapThreat + _companionFitCor>>
 <<say _companion>>What are you..? Please don't...<</say>>
 You ignore the soft, trembling pleas echoing in the cold air, your eyes locked on the task at hand. The Pulse Bloom, vibrant and robust, rests within your grip, ready to perform its unusual magic. An uncanny silence punctuates your forceful extraction of the life fluid, the bloom absorbing it greedily, a vampire of the plant kingdom.
 <<link "Use the Pulse Bloom" "Pulse Bloom Transformation" >>
@@ -3597,8 +3598,8 @@ You ignore the soft, trembling pleas echoing in the cold air, your eyes locked o
 		<<set $PulseBloomStorage.penisCor = $app.penisCor>>
 		<<set $PulseBloomStorage.breastsCor = $app.breastsCor>>
 		<<set $PulseBloomStorage.vagina = $app.vagina>>
-		<<set $PulseBloomStorage.height = $app.height>>
-		<<set $PulseBloomStorage.fit = _companion.fit - $app.fit>>
+		<<set $PulseBloomStorage.heightCor = $app.heightCor>>
+		<<set $PulseBloomStorage.fit = _companionFitCor - _appFitCor>>
 
 		<<set $app.osex = _companion.osex>>
 		<<set $app.obreasts = _companion.obreasts>>
@@ -3612,7 +3613,6 @@ You ignore the soft, trembling pleas echoing in the cold air, your eyes locked o
 		<<set $app.desc += _companion.appDesc>>
 		<<set $app.fit += $PulseBloomStorage.fit>>
 		<<set $PulseBloomDate = $time>>
-		<<Update_MC_Speech>>
 		<<CarryAdjust>>
 	<</link>>
 <<else>>
@@ -3645,6 +3645,9 @@ You produce the unusual flower, the crimson hue glimmering in the light.
 	You ready the Pulse Bloom, your heart racing with anticipation.
 
 	<<link "Extract the blood to use the Pulse Bloom" "Pulse Bloom Transformation" >>
+		<<set _appFitCor = $playerCurses.some(e => e.name === "Weakling") ? 0 : $app.fit>>
+		<<set _companionFitCor = _companion.curses.some(e => e.name === "Weakling") ? 0 : _companion.fit>>
+
 		<<set _companion.affec -= 2 - $hsswear>>
 		<<set $PulseBloomStorage.osex = $app.osex>>
 		<<set $PulseBloomStorage.obreasts = $app.obreasts>>
@@ -3659,7 +3662,7 @@ You produce the unusual flower, the crimson hue glimmering in the light.
 		<<set $PulseBloomStorage.breastsCor = $app.breastsCor>>
 		<<set $PulseBloomStorage.vagina = $app.vagina>>
 		<<set $PulseBloomStorage.heightCor = $app.heightCor>>
-		<<set $PulseBloomStorage.fit = _companion.fit - $app.fit>>
+		<<set $PulseBloomStorage.fit = _companionFitCor - _appFitCor>>
 
 		<<set $app.osex = _companion.osex>>
 		<<set $app.obreasts = _companion.obreasts>>
@@ -3673,7 +3676,6 @@ You produce the unusual flower, the crimson hue glimmering in the light.
 		<<set $app.desc += _companion.appDesc>>
 		<<set $app.fit += $PulseBloomStorage.fit>>
 		<<set $PulseBloomDate = $time>>
-		<<Update_MC_Speech>>
 		<<CarryAdjust>>
 	<</link>>
 <<else>>
@@ -4196,7 +4198,6 @@ You start to pry out the Omoikane Circuit from your phone, causing it to immedia
 <</nobr>>
 
 :: AI ConvoL1
-<<Update_MC_Speech>>\
 <<say $companionAI>>How can I help you today?<</say>>
 <<ConversationChoices
 	[[Can you give me some more information on threats in this layer?|AI ConvoL1 Threats]]
@@ -4274,7 +4275,6 @@ You start to pry out the Omoikane Circuit from your phone, causing it to immedia
 [[End your conversation|Party overview]]
 
 :: AI ConvoL2
-<<Update_MC_Speech>>\
 <<say $companionAI>>How can I help you today?<</say>>
 <<ConversationChoices
 	[[Can you give me some more information on threats in this layer?|AI ConvoL2 Threats]]
@@ -4416,7 +4416,7 @@ You start to pry out the Omoikane Circuit from your phone, causing it to immedia
 
 :: AI switch end
 <<nobr>>
-<<Update_MC_Speech>>
+<<CarryAdjust>>
 <<set $companionAI.name= $app.name>>
 <<set $mc.name= 'Ai'>>
 <</nobr>>
@@ -4481,7 +4481,6 @@ But unfortunately, this is no longer your story, it's hers.
 @@.layerTitle;GAME OVER@@
 
 :: AI ConvoL3
-<<Update_MC_Speech>>\
 <<say $companionAI>>How can I help you today?<</say>>
 <<ConversationChoices
 	[[Can you give me some more information on threats in this layer?|AI ConvoL3 Threats]]
@@ -5672,7 +5671,6 @@ Her words are logical, practical, and yet, underneath it all, you can't help but
 
 
 :: Saeko Increased Sensitivity
-<<GenderCorrected>>
 The first layer of the Abyss unfurls around you in an spectacle of slightly alien plant life. The air, thick with the scent of unknown flora, fills your lungs with an intoxicating sweetness. The shadows cast by the towering plants dance and sway. You can feel the tickle of the wind on your recently sensitized skin.
 
 <<say $companionSaeko>>You've been acting differently since yesterday, you know. Unusual physiological responses, heightened skin reactivity, and your pupils are noticeably dilated... It's fascinating.<</say>>

--- a/src/companionSetup.twee
+++ b/src/companionSetup.twee
@@ -66,7 +66,6 @@ lactation: 0,
 pregnantT: setup.never,
 due: setup.never,
 ears: "normal human",
-height: 144,
 modheight: 0,
 bodyHair: 0,
 skinType: "",
@@ -128,7 +127,6 @@ lactation: 0,
 pregnantT: setup.never,
 due: setup.never,
 ears: "normal human",
-height: 168,
 modheight: 0,
 bodyHair: 0,
 skinType: "",
@@ -190,7 +188,6 @@ lactation: 0,
 pregnantT: setup.never,
 due: setup.never,
 ears: "normal human",
-height: 185,
 modheight: 0,
 bodyHair: 1,
 skinType: "",
@@ -252,7 +249,6 @@ lactation: 0,
 pregnantT: setup.never,
 due: setup.never,
 ears: "normal human",
-height: 165,
 modheight: 0,
 bodyHair: 0,
 skinType: "",
@@ -314,7 +310,6 @@ lactation: 0,
 pregnantT: setup.never,
 due: setup.never,
 ears: "normal human",
-height: 175,
 modheight: 0,
 bodyHair: 1,
 skinType: "",
@@ -376,7 +371,6 @@ lactation: 0,
 pregnantT: setup.never,
 due: setup.never,
 ears: "normal human",
-height: 160,
 modheight: 0,
 bodyHair: 0,
 skinType: "",
@@ -650,7 +644,6 @@ The rest of the world just sees you as a pair of twins who did everything togeth
 
 :: Party overview [nobr]
 <<CarryAdjust>>
-<<Update_MC_Speech>>
 <<AppearanceCorrect>>
 <<Inhuman>> 
 <br>The following companions are a part of your expedition's party and have the associated affection values with you.<br><br>
@@ -702,7 +695,6 @@ The rest of the world just sees you as a pair of twins who did everything togeth
 
 :: Party Sidebar [nobr noreturn]
 <<CarryAdjust>>
-<<Update_MC_Speech>>
 <<AppearanceCorrect>>
 <<Inhuman>> 
 

--- a/src/curses.twee
+++ b/src/curses.twee
@@ -2068,7 +2068,7 @@ The final stage of your transformation leaves you feeling wholly masculine. Your
 
 :: Gender Curse [nobr]
 
-<<GenderCorrected>>
+<<CarryAdjust>>
 <<if $app.osex == "male">>
     <<if $app.gender == 2>>
         <<include "Gender MtF1">>
@@ -2185,7 +2185,7 @@ The prospect of your future feels oddly insignificant. With your mind and body e
 
 :: Libido Curse [nobr]
 
-<<LibidoCorrected>>
+<<CarryAdjust>>
 <<if $app.libido == 3>>
     <<include "Libido Increase 1">>
 <<elseif $app.libido == 4>>

--- a/src/global.twee
+++ b/src/global.twee
@@ -2157,10 +2157,10 @@ How many dubloons would you like to pay back?
 						<<elseif $items[13].count && $items[20].count >= 1>>
 							<<set $items[20].count -= 1>>
 						<<else>>
-							<<set $LibidoLog.push($ForageFoodMajor)>>
+							<<set $LibidoLog.push($ForageFoodMajor)>> /* Unripe flanberries */
 						<</if>>
 					<<else>>
-						<<set $LibidoLog.push($ForageFoodMajor)>>
+						<<set $LibidoLog.push($ForageFoodMajor)>> /* Unripe flanberries */
 					<</if>>
 				<<case 3>>
 					<<set $foodL3 += 1>>
@@ -2230,10 +2230,10 @@ How many dubloons would you like to pay back?
 						<<elseif $items[13].count && $items[20].count >= 1>>
 							<<set $items[20].count -= 1>>
 						<<else>>
-							<<set $lastFlan = $time>>
+							<<set $lastFlan = $time>> /* Ripe flanberries */
 						<</if>>
 					<<else>>
-						<<set $lastFlan = $time>>
+						<<set $lastFlan = $time>> /* Ripe flanberries */
 					<</if>>
 				<<case 3>>
 					<<set $foodL3 += 1>>

--- a/src/global.twee
+++ b/src/global.twee
@@ -535,15 +535,28 @@ They are a bit sore at the moment.
 	Your <<if $app.sex == "male">>testicles are<<elseif $app.sex == "female">>clitoris is<<else>>testicles and clitoris are<</if>> approximately <<print (10 * $algalSize)>>% larger than usual due to drinking contaminated melted snow from the fourth layer.<<print " ">>
 <</if>>
 
-<<if $app.fit > 8>>
-Training with the World Stone has granted you a fit physique, particularly well-defined arm muscles. This will allow you to carry more weight and may even marginally decrease your travel time.<br><br>
-<<elseif $app.fit > 6>>
-You possess a well-toned, athletic body. Thus, you might be able to carry slightly more weight and require a bit more time to travel than a regular adventurer.<br><br>
-<<elseif $app.fit > 4>>
-You have an unremarkable yet healthy body. <br><br>
+<<if $playerCurses.some(e => e.name === "Weakling")>>
+	<<if $app.fit > 8>>
+		Training with the World Stone has granted you a fit physique, particularly well-defined arm muscles. If it wasn't for your Curse, this would allow you to carry more weight and might have even marginally decreases your travel time.<br><br>
+	<<elseif $app.fit > 6>>
+		You possess a well-toned, athletic body. If it wasn't for your Curse, you might have been able to carry slightly more weight and required a bit less time to travel than a regular adventurer.<br><br>
+	<<elseif $app.fit > 4>>
+		You have an unremarkable yet healthy body, but thanks to your Curse you are as weak as a babe.<br><br>
+	<<else>>
+		Your body appears rather out of shape - although with your Curse, no amount of exercise would improve your physical ability.<br><br>
+	<</if>>
 <<else>>
-Your body appears rather out of shape, and you could certainly benefit from some exercise. Consequently, you can carry significantly less and must take more frequent breaks while traveling compared to a fit expedition leader.<br><br>
+	<<if $app.fit > 8>>
+		Training with the World Stone has granted you a fit physique, particularly well-defined arm muscles. This will allow you to carry more weight and may even marginally decrease your travel time.<br><br>
+	<<elseif $app.fit > 6>>
+		You possess a well-toned, athletic body. Thus, you might be able to carry slightly more weight and require a bit less time to travel than a regular adventurer.<br><br>
+	<<elseif $app.fit > 4>>
+		You have an unremarkable yet healthy body.<br><br>
+	<<else>>
+		Your body appears rather out of shape, and you could certainly benefit from some exercise. Consequently, you can carry significantly less and must take more frequent breaks while traveling compared to a fit expedition leader.<br><br>
+	<</if>>
 <</if>>
+
 <<if $AegisWear>>Although imperceptible to an outside observer, your natural skeleton has been seamlessly replaced with a lightweight and resilient orichalcum framework.<br><br><</if>>
 
 <<if 120 <= setup.daysConsideredPregnant($app) && setup.daysConsideredPregnant($app) < 180 && !$menFirstCycle>>
@@ -1191,15 +1204,17 @@ If you are over 18, please go back and enter an age above 18 to continue.
 	<</if>>
 <</if>>
 
-
 <<if $ownedRelics.some(e => e.name === "World Stone")>>
-	<<if $app.fit>=10>>
-		<br>You don't think you would get anymore fit than you are from working out with the World Stone. Your fitness has reached near peak human levels, and while you might be able to improve a bit more with a dedicated workout period, it's not likely you'll be able to achieve that in the Abyss.<br>
-	<<elseif $LastEx < ($time-1)>>
-		<br> You can make use of the World Stone to make use of a perfect fitness routine, tuned precisely to the needs of your body. If you want to get stronger and more fit, using this Relic is the best way to do it.<br>
-		[[Work out with the World Stone|Use Items and Relics][$app.fit+=1, $LastEx = $time]]<br>
+	<br>
+	<<if $app.fit >= 10>>
+		You don't think you would get anymore fit than you are from working out with the World Stone.
+		Your fitness has reached near peak human levels, and while you might be able to improve a bit more with a dedicated workout period, it's not likely you'll be able to achieve that in the Abyss.<br>
+	<<elseif $time > $LastEx + 1>>
+		You can make use of the World Stone to make use of a perfect fitness routine, tuned precisely to the needs of your body.
+		If you want to get <<if !$playerCurses.some(e => e.name === "Weakling")>>stronger and<</if>> more fit, using this Relic is the best way to do it.<br>
+		[[Work out with the World Stone|Use Items and Relics][$app.fit += 1, $LastEx = $time, $fit_adjustLastT = $time]]<br>
 	<<else>>
-		<br>Your arms are still sore from your last workout with the World Stone, so even with the help of the Relic you won't get much benefit from working out more.<br>
+		Your arms are still sore from your last workout with the World Stone, so even with the help of the Relic you won't get much benefit from working out more.<br>
 	<</if>>
 <</if>>
 
@@ -1262,10 +1277,13 @@ If you are over 18, please go back and enter an age above 18 to continue.
 <</if>>
 
 <<if $ownedRelics.some(e => e.name === "Pulse Bloom")>>
-	<<if $hiredCompanions.length > 0 && $PulseBloomUse=="">>
+	/* $PulseBloomUse used to be initialized as an array, so check carefully. */
+	<<set _pulseBloomInUse = $PulseBloomUse !== "" && !Array.isArray($PulseBloomUse)>>
+
+	<<if $hiredCompanions.length > 0 && !_pulseBloomInUse>>
 		<br>You can use the Pulse Bloom to copy the appearance of one of your companions.<br>
 		[[Use the Pulse Bloom|Pulse Bloom Use]]<br>
-	<<elseif $PulseBloomUse==true >>
+	<<elseif _pulseBloomInUse>>
 		<br>You are already under the effect of the Pulse Bloom.<br>
 	<<else>>
 		<br>You have nobody to use the Pulse Bloom on.<br>
@@ -2480,6 +2498,7 @@ $flaskMatrixLabel[$flaskPref] ($flaskMatrix[$flaskPref] remaining)
 	<<include `"Layer" + $currentLayer + " Travel Events"`>>
 <</if>>
 <<if !setup.passingTime()>>
+	<<checkTime>>
 	You can set up camp and rest here for a while before continuing your journey. You still need to eat and drink and the layer's threats continue to loom over you even as you rest. This won't accomplish much on its own, but if you'd like to spend some time sampling the local cuisine or studying this layer's threats, then this could be a good way to do that.<br><br>
 
 	How many days would you like to rest here?<br>
@@ -2497,10 +2516,8 @@ $flaskMatrixLabel[$flaskPref] ($flaskMatrix[$flaskPref] remaining)
 <<if $playerCurses.length>0>>
 	<<set $temp = random(0,$playerCurses.length - 1)>>
 	<<set $tempCurse = $playerCurses[$temp]>>
-	<<LibidoCorrected>>
-	<<appGender>>
+	<<CarryAdjust>>
 	<<AppearanceCorrect>>
-	<<GenderCorrected>>
 
 <<if $tempCurse.name == "Libido Reinforcement A" || $tempCurse.name == "Libido Reinforcement B" || $tempCurse.name == "Libido Reinforcement C" || $tempCurse.name == "Libido Reinforcement D" || $tempCurse.name == "Libido Reinforcement E">>
 	<<if $app.libido == 3>>

--- a/src/global.twee
+++ b/src/global.twee
@@ -2148,7 +2148,7 @@ How many dubloons would you like to pay back?
 			<<switch $currentLayer>>
 				<<case 1>>
 					<<set $foodL1 += 1>>
-					<<set $GenderLog.push($ForageFoodMajor)>>
+					<<set $GenderLog.push($ForageFoodMajor)>> /* Blisshrooms without knowledge. */
 				<<case 2>>
 					<<set $foodL2 += 1>>
 					<<if $mudHunt>>
@@ -2164,15 +2164,15 @@ How many dubloons would you like to pay back?
 					<</if>>
 				<<case 3>>
 					<<set $foodL3 += 1>>
-					<<set $AgeLog.push($ForageFoodMajor)>>
+					<<set $AgeLog.push($ForageFoodMajor)>> /* Crystalline Confectionaries without knowledge */
 				<<case 4>>
 					<<if $slingshot>>
 						<<set $foodL4 += 1>>
-						<<set $HeightLog.push($ForageFoodMajor)>>
+						<<set $HeightLog.push($ForageFoodMajor)>> /* Flairabou without knowledge */
 					<<elseif $items[13].count && $items[20].count >= Math.max(2 - $bullRed, 1)>>
 						<<set $foodL4 += 1>>
 						<<set $items[20].count -= Math.max(2 - $bullRed, 1)>>
-						<<set $HeightLog.push($ForageFoodMajor)>>
+						<<set $HeightLog.push($ForageFoodMajor)>> /* Flairabou without knowledge */
 					<<else>>
 						/* Cannot forage for food. */
 						<<if $items[1].count >= _consumptionPerDay>>
@@ -2216,7 +2216,7 @@ How many dubloons would you like to pay back?
 					<</if>>
 				<<case 8>>
 					<<set $foodL8 += 1>>
-					<<set $LibidoLog.push($ForageFoodMinor)>>
+					<<set $LibidoLog.push($ForageFoodMinor)>> /* Bedlam's Banquet */
 			<</switch>>
 		<<else>>
 			<<switch $currentLayer>>
@@ -2237,15 +2237,15 @@ How many dubloons would you like to pay back?
 					<</if>>
 				<<case 3>>
 					<<set $foodL3 += 1>>
-					<<set $AgeLog.push($ForageFoodMinor)>>
+					<<set $AgeLog.push($ForageFoodMinor)>> /* Crystalline Confectionaries with knowledge */
 				<<case 4>>
 					<<if $slingshot>>
 						<<set $foodL4 += 1>>
-						<<set $HeightLog.push($ForageFoodMinor)>>
+						<<set $HeightLog.push($ForageFoodMinor)>> /* Flairabou with knowledge */
 					<<elseif $items[13].count && $items[20].count >= Math.max(2 - $bullRed, 1)>>
 						<<set $foodL4 += 1>>
 						<<set $items[20].count -= Math.max(2 - $bullRed, 1)>>
-						<<set $HeightLog.push($ForageFoodMinor)>>
+						<<set $HeightLog.push($ForageFoodMinor)>> /* Flairabou with knowledge */
 					<<else>>
 						/* Cannot forage for food. */
 						<<if $items[1].count >= _consumptionPerDay>>
@@ -2289,7 +2289,7 @@ How many dubloons would you like to pay back?
 					<</if>>
 				<<case 8>>
 					<<set $foodL8 += 1>>
-					<<set $LibidoLog.push($ForageFoodMinor)>>
+					<<set $LibidoLog.push($ForageFoodMinor)>> /* Bedlam's Banquet */
 			<</switch>>
 		<</if>>
 		<<if _ate>><<set $starving -= 1>><</if>>
@@ -2307,7 +2307,7 @@ How many dubloons would you like to pay back?
 			<<switch $currentLayer>>
 				<<case 1>>
 					<<set $waterL1 += 1>>
-					<<set $GenderLog.push($ForageWaterMajor)>>
+					<<set $GenderLog.push($ForageWaterMajor)>> /* Cloudpools without knowledge */
 				<<case 2>>
 					<<set $waterL2 += 1>>
 					<<set $bewitchBabies += 1>>
@@ -2415,7 +2415,7 @@ How many dubloons would you like to pay back?
 
 		<<if $flaskMatrixLabel[$flaskPref] == "Flask with heavily contaiminated water from the first layer">>
 			<<set $waterL1 += 1>>
-			<<set $GenderLog.push($ForageWaterMajor)>>
+			<<set $GenderLog.push($ForageWaterMajor)>> /* Cloudpools without knowledge */
 		<<elseif $flaskMatrixLabel[$flaskPref] == "Flask with heavily contaiminated water from the second layer">>
 			<<set $waterL2 += 1>>
 			<<set $bewitchBabies += 1>>

--- a/src/init.twee
+++ b/src/init.twee
@@ -113,7 +113,6 @@ document.documentElement.setAttribute("lang", "en");
 <<set $coolOverride = false>>
 <<set $rope = 0>>
 <<set $scuba = 0>>
-<<set $height = "0">>
 <<set $torchUse = 0>>
 <<set $purityUsed = 0>>
 <<set $algalSize = 0>>
@@ -191,7 +190,7 @@ document.documentElement.setAttribute("lang", "en");
 <<set $HeightIncrease = 0>>
 <<set $ManagedMisfortuneActive = []>>
 <<set $ManagedMisfortuneMax = 2>>
-<<set $PulseBloomUse = []>>
+<<set $PulseBloomUse = "">>
 <<set $PulseBloomDate = 9999>>
 
 <<set $ConvoHandicapSmall = false>>
@@ -265,7 +264,6 @@ lactation: 0,
 pregnantT: setup.never,
 due: setup.never,
 ears: "normal human",
-height: 170,
 oheight: 170,
 fit: 0,
 modheight: 0,
@@ -551,7 +549,6 @@ pic: "Wonders/puritytree.png"
 		pregnantT: setup.never,
 		due: setup.never,
 		ears: "normal human",
-		height: $app.oheight,
 		modheight: 0,
 		bodyHair: 1,
 		skinType: "",

--- a/src/layer1.twee
+++ b/src/layer1.twee
@@ -31,7 +31,7 @@ Traveling back to the surface from here will take 1 day, and will cost 10 corrup
 	<<masteraudio stop>>
 	<<audio "layer1" volume 0.2 play loop>>
 <</if>>
-<<CarryAdjust>>
+<<CarryAdjust>><<checkTime>>
 
 You find yourself amidst the slightly-off natural splendor of the first layer.<br><br> 
 <<if $visitL1 == 0>>
@@ -109,7 +109,7 @@ What do you want to do while you're here?<br><br>
 
 
 :: Layer1 Relics [layer1 cards nobr]
-<p><<CarryAdjust>></p>
+<p><<CarryAdjust>><<checkTime>></p>
 <h1>Relics</h1>
 
 <p>
@@ -276,7 +276,7 @@ You sit by the fire with your party and chat, the mood is pretty upbeat and opti
 
 	<<if $corruption >= 0 && $debt <= 0>>
 		Note: This ending is simply a possible future for you, assuming you go with the flow for the rest of your life. If you want to avoid them using the Companions, Relics, and Curses you have obtained, then you will be able to, as long as they are within the bounds of the habitation option you have selected.<br><br>
-		<<HeightCorrected>><<Lewdness>> <<Inhuman>>
+		<<CarryAdjust>><<Lewdness>> <<Inhuman>>
 	<<if $lewdness<$lewdCrit && $app.inhuman<$inhumanCrit && $app.appAge>$AgeCrit && ($dubloons + $total_value_relics)>$DubCrit >>
 		[[Choose to settle in Outcast village|L1 LLew LInhum HAge HDub]]
 	<<elseif $lewdness<$lewdCrit && $app.inhuman<$inhumanCrit && $app.appAge>$AgeCrit && ($dubloons + $total_value_relics)<=$DubCrit >>
@@ -760,7 +760,7 @@ You realize the fabric is in fact some kind of long glove. You stick your hand i
 :: Take on Asset Robustness A [layer1]
 <<set $playerCurses.push($curse3)>><<set $corruption += $curse3.corr>><<set $GenderLog.push($curse3)>>\
 [img[setup.ImagePath + $curse3.pic]]
-<<GenderCorrected>>\
+<<CarryAdjust>>\
 <<if $app.penisCor>0 && $app.breastsCor==0 >>
 	The moment the curse grips you, you feel a surge of sensation. Your penis springs to full erection, and then just keeps growing. The base, the shaft, and the tip continue swelling larger than they've ever been before, until you're sporting a $app.penisCor inch long dong.
 

--- a/src/layer2.twee
+++ b/src/layer2.twee
@@ -29,7 +29,7 @@ This layer is filled with a very dense growth of vines, bushes, and other plant 
 	<<masteraudio stop>>
 	<<audio "layer2" volume 0.2 play loop>>
 <</if>>
-<<CarryAdjust>>
+<<CarryAdjust>><<checkTime>>
 
 <</nobr>>\
 <<if $timeL2T1 < 4 || $hiredCompanions.length > 3>><<nobr>>
@@ -218,7 +218,7 @@ After collecting enough berries, you head back to camp with Maru. He mashes the 
 
 
 :: Layer2 Relics [layer2 cards nobr]
-<p><<CarryAdjust>></p>
+<p><<CarryAdjust>><<checkTime>></p>
 <<if $timeL2T1 < 4 || $hiredCompanions.length > 3>>
 
 <h1>Relics</h1>
@@ -621,7 +621,6 @@ How do you feel? Did you ask your companion before the switch? Be prepared for y
 <</if>>
 
 <<CarryAdjust>>
-<<Update_MC_Speech>>
 
 <<set _companionSwapHandle.genderVoice = _companionSwapHandle.gender>>
 <<set $mc.imageIcon = _companionSwapHandle.imageIcon>>
@@ -826,7 +825,7 @@ How do you feel? Did you ask your companion before the switch? Be prepared for y
 :: Take on Asset Robustness B [layer2]
 <<set $playerCurses.push($curse15)>><<set $corruption += $curse15.corr>><<set $GenderLog.push($curse15)>>\
 [img[setup.ImagePath + $curse15.pic]]
-<<GenderCorrected>>
+<<CarryAdjust>>
 <<if $app.penisCor>0 && $app.breastsCor==0 >>
 	The moment the curse grips you, you feel an intense sensation. Your penis springs to full erection, and then continues to grow. The base, the shaft, and the tip swell larger than they've ever been before, until you're sporting a $app.penisCor inch long dong.
 
@@ -985,7 +984,7 @@ You'll need to be particularly careful with alcohol, or any other similar substa
 
 
 :: Take on Sex Switcheroo [layer2]
-<<set $playerCurses.push($curse22)>><<set $corruption += $curse22.corr>><<set $GenderLog.push($curse22)>><<GenderCorrected>>\
+<<set $playerCurses.push($curse22)>><<set $corruption += $curse22.corr>><<set $GenderLog.push($curse22)>><<CarryAdjust>>\
 [img[setup.ImagePath + $curse22.pic]]
 
 <<if $app.osex == "male">>\
@@ -1022,7 +1021,7 @@ Standing tall, you brace yourself for the journey ahead. The Abyss has changed y
 
 
 :: Take on Futa Fun [layer2]
-<<set $playerCurses.push($curse23)>><<set $corruption += $curse23.corr>><<set $GenderLog.push($curse23)>><<GenderCorrected>>\
+<<set $playerCurses.push($curse23)>><<set $corruption += $curse23.corr>><<set $GenderLog.push($curse23)>><<CarryAdjust>>\
 [img[setup.ImagePath + $curse23.pic]]
 
 <<if $app.osex == "male">>\

--- a/src/layer3.twee
+++ b/src/layer3.twee
@@ -30,7 +30,7 @@ The Abyss has various bioluminescent moss, mushrooms, and so on scattered about,
 	<<masteraudio stop>>
 	<<audio "layer3" volume 0.2 play loop>>
 <</if>>
-<<CarryAdjust>>
+<<CarryAdjust>><<checkTime>>
 <<set $forageWater = 0>>
 <</nobr>>\
 <<if $timeL3T1 < 6 && $timeL3T2 < 5>><<nobr>>
@@ -134,7 +134,7 @@ You need empty flasks to fill them with water from the Underground Rivers.<br>
 
 
 :: Layer3 Relics [layer3 cards nobr]
-<p><<CarryAdjust>></p>
+<p><<CarryAdjust>><<checkTime>></p>
 <<if $timeL3T1 < 6 && $timeL3T2 < 5>>
 
 <h1>Relics</h1>
@@ -456,7 +456,7 @@ This may impact how your sexual encounters and conversations with your companion
 
 :: Take on Asset Robustness C [layer3]
 <<set $playerCurses.push($curse27)>><<set $corruption += $curse27.corr>><<set $GenderLog.push($curse27)>>\
-<<GenderCorrected>>\
+<<CarryAdjust>>\
 [img[setup.ImagePath + $curse27.pic]]
 
 <<if $app.penisCor>0 && $app.breastsCor==0 >>\

--- a/src/layer4.twee
+++ b/src/layer4.twee
@@ -44,7 +44,7 @@ She stands at the edge of your peripheral vision, immaterial and seemingly harml
 	<<masteraudio stop>>
 	<<audio "layer4" volume 0.2 play loop>>
 <</if>>
-<<CarryAdjust>>
+<<CarryAdjust>><<checkTime>>
 <<if $visitL4 == 0>><<set $endSpectre = $time>><</if>>
 <</nobr>>\
 <<if $timeL4T1 < 7>><<nobr>>
@@ -189,7 +189,7 @@ Would you like to increase or decrease your height due to eating flairabou meat?
 
 
 :: Layer4 Relics [layer4 cards nobr]
-<p><<CarryAdjust>></p>
+<p><<CarryAdjust>><<checkTime>></p>
 <<if $timeL4T1 < 7>>
 
 <p>
@@ -335,7 +335,7 @@ As you continue your descent into the frost-bitten depths, you ponder your situa
 
 :: Take on Asset Robustness D [layer4]
 <<set $playerCurses.push($curse43)>><<set $corruption += $curse43.corr>><<set $GenderLog.push($curse43)>>\
-<<GenderCorrected>>\
+<<CarryAdjust>>\
 [img[setup.ImagePath + $curse4.pic]]
 
 <<if $app.penisCor>0 && $app.breastsCor==0 >>\
@@ -515,7 +515,7 @@ As you experiment with your newly-acquired teeth, biting down on a piece of leat
 
 
 :: Take on Softie [layer4]
-<<set $playerCurses.push($curse51)>><<set $corruption += $curse51.corr>><<GenderCorrected>>\
+<<set $playerCurses.push($curse51)>><<set $corruption += $curse51.corr>><<CarryAdjust>>\
 [img[setup.ImagePath + $curse51.pic]]
 
 <<if $app.penisCor>0 && $app.breastsCor==0 >>\
@@ -553,7 +553,7 @@ As you experiment with your newly-acquired teeth, biting down on a piece of leat
 
 
 :: Take on Hard Mode [layer4]
-<<set $playerCurses.push($curse52)>><<set $corruption += $curse52.corr>><<GenderCorrected>>\
+<<set $playerCurses.push($curse52)>><<set $corruption += $curse52.corr>><<CarryAdjust>>\
 [img[setup.ImagePath + $curse52.pic]]
 
 <<if $app.penisCor>0 && $app.breastsCor==0 >>\

--- a/src/layer5.twee
+++ b/src/layer5.twee
@@ -28,7 +28,7 @@ For an area that otherwise bears such a strong resemblance to a surface desert, 
 	<<masteraudio stop>>
 	<<audio "layer5" volume 0.2 play loop>>
 <</if>>
-<<CarryAdjust>>
+<<CarryAdjust>><<checkTime>>
 
 <</nobr>>\
 <<if $timeL5T1 < 8 && $timeL5T2 < 11>><<nobr>>
@@ -283,7 +283,7 @@ The radiant sun empowers your Breathless Exhale Relic, its energy pulsating with
 
 
 :: Layer5 Relics [layer5 cards nobr]
-<p><<CarryAdjust>></p>
+<p><<CarryAdjust>><<checkTime>></p>
 <<if $timeL5T1 < 8 && $timeL5T2 < 11>>
 
 <p>

--- a/src/layer6.twee
+++ b/src/layer6.twee
@@ -27,7 +27,7 @@ They grow taller as you proceed, until you're wading through a thicket or navel-
 	<<masteraudio stop>>
 	<<audio "layer6" volume 0.2 play loop>>
 <</if>>
-<<CarryAdjust>>
+<<CarryAdjust>><<checkTime>>
 
 <<if $timeL6T1 < 15 && ($timeL6T2 < 8 || $dragonKill > 4)>>
 <<if $visitL6 == 0>>
@@ -147,7 +147,7 @@ If you decide to start foraging for food or water, it means that you will not co
 
 
 :: Layer6 Relics [layer6 cards nobr]
-<p><<CarryAdjust>></p>
+<p><<CarryAdjust>><<checkTime>></p>
 <<if $timeL6T1 < 7>>
 
 <p>[[Continue exploring the sixth layer|Layer6 Hub]]</p>

--- a/src/layer7.twee
+++ b/src/layer7.twee
@@ -78,7 +78,7 @@ Threats:
 	<<masteraudio stop>>
 	<<audio "layer7" volume 0.2 play loop>>
 <</if>>
-<<CarryAdjust>>
+<<CarryAdjust>><<checkTime>>
 
 <</nobr>>\
 <<if $dubloons < 0 && $easymode==false>>[img[setup.ImagePath+'Threats/taxdrone.png']]
@@ -212,7 +212,7 @@ It is reccomended that you get creative with your Relics and think of more effic
 
 
 :: Layer7 Relics [layer7 cards nobr]
-<p><<CarryAdjust>></p>
+<p><<CarryAdjust>><<checkTime>></p>
 <<if $dubloons < 0>>
 
 <p>[img[setup.ImagePath+'Threats/taxdrone.png']]</p>
@@ -838,7 +838,7 @@ Dubloons:
 <<set $playerCurses.push($curse87)>><<set $corruption += $curse87.corr>><<set $GenderLog.push($curse87)>>\
 [img[setup.ImagePath + $curse87.pic]]
 
-<<GenderCorrected>><<if $app.penisCor>0 && $app.breastsCor==0 >>
+<<CarryAdjust>><<if $app.penisCor>0 && $app.breastsCor==0 >>
 	The strength of this Curse takes you by surprise. our penis surges to full erection and continues to grow in size. The base, shaft, and tip swell at a disconcerting rate. Drops of precum ooze from the tip like thick honey, yet the growth doesn't cease. 
 
 	Finally, the curse releases its grip, but your jaw drops in disbelief as you realize you now possess a $app.penisCor inch long member. The erection lingers for a while longer, and adapting to such a massive endowment without it hindering your movement will surely demand practice. You wince from a pinching sensation as you awkwardly hobble forward.

--- a/src/layer8.twee
+++ b/src/layer8.twee
@@ -88,7 +88,7 @@ Threats:
 	<<masteraudio stop>>
 	<<audio "layer8" volume 0.2 play loop>>
 <</if>>
-<<CarryAdjust>>
+<<CarryAdjust>><<checkTime>>
 <<set $L8loopLim = false>>
 <<set $temp1 = random(0,20)>>
 <<if ($timeL8T2a > 6 && !$hiredCompanions.some(e => e.name === "Maru") && $L8T1aCount < 2) || ($timeL8T2a > 7 && $L8T1aCount < 2)>>
@@ -377,7 +377,7 @@ You can consider your equipment, allies, and general health to take into account
 
 
 :: Layer8 Relics [layer8 cards nobr]
-<p><<CarryAdjust>></p>
+<p><<CarryAdjust>><<checkTime>></p>
 <<if ($timeL8T2a > 6 && !$hiredCompanions.some(e => e.name === "Maru") && $L8T1aCount < 2) || ($timeL8T2a > 7 && $L8T1aCount < 2)>>
 	<p>[img[setup.ImagePath+'Threats/dementialaberrations.png']]</p>
 

--- a/src/layer9.twee
+++ b/src/layer9.twee
@@ -39,7 +39,7 @@ Hopefully you'll be able to get used to it.
 	<<masteraudio stop>>
 	<<audio "layer9" volume 0.2 play loop>>
 <</if>>
-<<CarryAdjust>>
+<<CarryAdjust>><<checkTime>>
 
 <<if $timeL9T1 < 1>>
 <<if $visitL9 == 0>>

--- a/src/script.js
+++ b/src/script.js
@@ -234,7 +234,7 @@ Macro.add('say', {
 		handler: function () {
 			const person = this.args[0];
 			const output =
-				`<div class="say clearfix" style="${person?.style ?? ''}${person?.style1 ?? ''}">` +
+				`<div class="say clearfix" style="${person?.style ?? ''};${person?.style1 ?? ''}">` +
 					`<div class="avatar">` +
 						`<img src="${setup.ImagePath}${person?.imageIcon ?? ''}" style="width:100px;height:100px">` +
 					`</div>` +

--- a/src/start.twee
+++ b/src/start.twee
@@ -136,7 +136,6 @@ Before proceeding, please estimate your carrying capacity (in kg) if you were in
 <<set $app.obreasts = $app.breasts>>
 <<set $app.breastsCor = parseInt($app.breasts)>>
 <<set $app.oheight = parseInt($app.oheight)>>
-<<set $app.height = $app.oheight>>
 <<set $app.age = parseInt($app.age)>>
 <<set $app.fit = parseInt($app.fit)>>
 <<set $ocarryWeight = parseInt($ocarryWeight)>>

--- a/src/surface.twee
+++ b/src/surface.twee
@@ -77,7 +77,7 @@ Now I think you can have a look around the town and choose how to spend your dub
 	<<masteraudio stop>>
 	<<audio "surface" volume 0.2 play loop>>
 <</if>>
-<<CarryAdjust>>
+<<CarryAdjust>><<checkTime>>
 
 <<if $surfaceVisit == 0>>
 	<img src="images/Surface/outsettown.jpeg" width=70%><br>
@@ -86,7 +86,6 @@ Now I think you can have a look around the town and choose how to spend your dub
 <<if $items[22].count>0>>
 	<<set $warmCloth=1>>
 <</if>>
-<<checkTime>>
 <</nobr>><<if $dubloons >= 0 || $hiredCompanions.some(e => e.name === "Cloud")>>Here at Outset Town you can spend your $dubloons dubloons on hiring companions and buying equipment for your journey. On return visits you can also sell Relics you've found in the Abyss or settle down on the surface permanently.
 
 <<nobr>>
@@ -848,7 +847,7 @@ Luckily, this was only a temporary state of affairs and eventually you did reach
 
 :: L0 LLew HInhum HAge HDub [image ending surface]
 
-[img[setup.ImagePath+'Habitation/surfacehabitation.png']]<<appGender>>
+[img[setup.ImagePath+'Habitation/surfacehabitation.png']]
 
 Upon your return from the Abyss, you were a changed person, though some may not consider you to be as much of a person as you were before.
 
@@ -888,7 +887,7 @@ You now spend your days working in the store or participating in movements for f
 
 :: L0 LLew HInhum LAge HDub [image ending surface]
 
-[img[setup.ImagePath+'Habitation/surfacehabitation.png']]<<appGender>>
+[img[setup.ImagePath+'Habitation/surfacehabitation.png']]
 
 Upon your return from the Abyss, you were a changed person, though some may not consider you to be as much of a person as you were before. And of course, you had lost much of your age on the journey.
 
@@ -1099,7 +1098,7 @@ You wake up in a corner of the Relic Workshop with the doll clutched tightly in 
 
 
 :: DollWarning 
-<<Update_MC_Speech>>
+<<CarryAdjust>>
 Suddenly, you start hearing the voice of the doll again, it almost sounds like it's coming from inside your own head.
 
 <<say $creepydoll>> Don't you sometimes get tired of all this adventuring?<</say>>

--- a/src/widgets.twee
+++ b/src/widgets.twee
@@ -1,69 +1,3 @@
-:: HeightCorrected [widget nobr]
-<<widget "HeightCorrected">>
-
-<<GenderCorrected>>
-
-<<capture _handle _log _genderlvl _height_adult _height_change _x _x_rel>>
-	<<for _handle range $hiredCompanions.concat($app)>>
-		<<set _name = _handle != $companionTwin ? _handle.name : 'Twin'>>
-		<<set _logName = _handle === $app ? 'Log' : `Log${_name}`>>
-		<<print `<<set _log = $Height${_logName}>>`>>
-
-		<<set _genderlvl = _handle.gender - 1>>
-
-		<<set _height_change = $HeightIncrease * (
-			5.0 * _log.filter(e => e.name === "Dizzying Heights").length +
-			3.0 * _log.filter(e => e.name === "1 Day Food Forage Major Impact").length +
-			0.5 * _log.filter(e => e.name === "1 Day Food Forage Minor Impact").length
-		)>>
-
-		<<if _log.some(e => e.name === "Colossal-able")>>
-			<<set _height_change = _handle.height * 70 - _handle.height>>
-			<<set $SizeHandicap = 1>>
-		<<elseif _log.some(e => e.name === "Minish-ish")>>
-			<<set _height_change = _handle.height / 10 - _handle.height>>
-			<<set $SizeHandicap = $hiredCompanions.length < 1 ? 1 : 0>>
-		<</if>>
-
-		/* Change in height with genderlevel changes and height increases/decreases; it is modeled such that */
-		/* 5 cm is always 5 cm with respect to your starting height and irrespective of starting gender.     */
-		<<set _height_adult = 
-			_handle.oheight * (1 - 0.01525 * (_genderlvl - (_handle.osex == "female" ? 5 : 0))) +
-			_height_change  * (1 - 0.01525 * (_handle.osex == "female" ? 5 : 0))
-		>>
-
-		<<set _x = 18 - _handle.appAge>>
-
-		<<if _x <= 0.2 * _genderlvl>>
-			<<set _handle.heightCor = _height_adult>>
-		<<elseif 0.2 * _genderlvl < _x && _x <= 6>>
-			/* Puberty phase: It shifts for females as theirs ends earlier; for simplicity */
-			/* I assumed the start is the same regardless although this is not entirely    */
-			/* correct. I used a polynomial here to simulate the 'reverse growth spurt'.   */
-			<<set _x_rel = _x - 0.2 * _genderlvl>>
-			<<set _handle.heightCor = _height_adult * (1 -
-				( 4.70611e-3 - 8.1433e-4 * _genderlvl) * _x_rel -
-				( 1.1049e-4  - 1.140e-5  * _genderlvl) * _x_rel**2 -
-				( 1.6698e-3  - 1.3722e-4 * _genderlvl) * _x_rel**3 -
-				(-1.7701e-4  + 2.114e-5  * _genderlvl) * _x_rel**4
-			)>>
-		<<elseif 6 < _x && _x <= 15>>
-			/* The second phase of linear growth or decline, it's a decent approximation without making things too     */
-			/* complicated. It ends at age 3 (originally 4, but changed it to not break the rest of the code). The     */
-			/* calculation for the puberty growth spurt is in here to provide a starting point for the linear decline. */
-			<<set _x_rel = 6 - 0.2 * _genderlvl>>
-			<<set _handle.heightCor = _height_adult * (1 -
-				( 4.70611e-3 - 8.1433e-4 * _genderlvl) * _x_rel -
-				( 1.1049e-4  - 1.140e-5  * _genderlvl) * _x_rel**2 -
-				( 1.6698e-3  - 1.3722e-4 * _genderlvl) * _x_rel**3 -
-				(-1.7701e-4  + 2.114e-5  * _genderlvl) * _x_rel**4 -
-				(0.033 + 0.0009 * _genderlvl) * (_x - 6)
-			)>>
-		<</if>>
-	<</for>>
-<</capture>>
-<</widget>>
-
 :: GenderCorrected [widget nobr]
 <<widget "GenderCorrected">>
 <<capture
@@ -254,11 +188,12 @@
 
 		/* Clamp gender between 1 (= fully masculine) and 6 (= fully feminine). */
 		<<set _handle.gender = Math.clamp(_handle.gender, 1, 6)>>
+		<<set _genderlvl = _handle.gender - 1>>
 
 		/* For younger characters, compute breast size reduction according to age. */
 		/* Note: Asset robustness does not affect breasts if _handle.breastsCor == 0 unless _robustBreasts == true. */
 		<<set _handle.breastsCor = _handle.breasts>>
-		<<set _fullyGrownAge = 18 - (_handle.gender - 1) / 5>> /* 1 year lower for fully feminine characters. */
+		<<set _fullyGrownAge = 18 - _genderlvl / 5>> /* 1 year lower for fully feminine characters. */
 		<<if _handle.appAge < _fullyGrownAge>>
 			<<set _handle.breastsCor = _handle.breasts * Math.max(1 - (_fullyGrownAge - _handle.appAge) / 10, 0)>>
 		<</if>>
@@ -400,7 +335,7 @@
 		<<set _handle.breastsCor = _handle.breasts>>
 
 		/* For younger characters, compute breast size reduction according to age. */
-		<<set _fullyGrownAge = 18 - (_handle.gender - 1) / 5>> /* 1 year lower for fully feminine characters. */
+		<<set _fullyGrownAge = 18 - _genderlvl / 5>> /* 1 year lower for fully feminine characters. */
 		<<if _handle.appAge < _fullyGrownAge>>
 			<<set _handle.breastsCor = _handle.breasts * Math.max(1 - (_fullyGrownAge - _handle.appAge) / 10, 0)>>
 		<</if>>
@@ -486,27 +421,203 @@
 		<<set _handle.penisCor = _handle.penis>>
 		<<if _handle.penis > 0>>
 			/* For younger characters, compute penis size reduction according to age. */
-			<<set _fullyGrownAge = 16 - (_handle.gender - 1) / 5>> /* 1 year lower for fully feminine characters. */
+			<<set _fullyGrownAge = 16 - _genderlvl / 5>> /* 1 year lower for fully feminine characters. */
 			<<if _handle.appAge < _fullyGrownAge>>
 				<<set _handle.penisCor = _handle.penis * Math.max(1 - (_fullyGrownAge - _handle.appAge) / 12, 1)>>
 			<</if>>
 
-			<<if _handle.curses.some(e => e.name === "Colossal-able")>>
+			<<if _handle.curses.some(e => e.name === 'Colossal-able')>>
 				<<set _handle.penisCor *= 70>>
 			<</if>>
 
-			<<if _handle.curses.some(e => e.name === "Minish-ish")>>
+			<<if _handle.curses.some(e => e.name === 'Minish-ish')>>
 				<<set _handle.penisCor /= 10>>
 			<</if>>
 		<</if>>
+
+		/* ---------------------------------------- Compute corrected height ---------------------------------------- */
+
+		<<print `<<set _log = $Height${_logName}>>`>>
+
+		<<set _height_change = $HeightIncrease * (
+			5.0 * _log.filter(e => e.name === 'Dizzying Heights').length +
+			3.0 * _log.filter(e => e.name === '1 Day Food Forage Major Impact').length +
+			0.5 * _log.filter(e => e.name === '1 Day Food Forage Minor Impact').length
+		)>>
+
+		<<if _log.some(e => e.name === 'Colossal-able')>>
+			<<set _height_change = _handle.oheight * 70 - _handle.oheight>>
+			<<set $SizeHandicap = 1>>
+		<<elseif _log.some(e => e.name === 'Minish-ish')>>
+			<<set _height_change = _handle.oheight / 10 - _handle.oheight>>
+			<<set $SizeHandicap = $hiredCompanions.length < 1 ? 1 : 0>>
+		<</if>>
+
+		/* Change in height with genderlevel changes and height increases/decreases; it is modeled such that */
+		/* 5 cm is always 5 cm with respect to your starting height and irrespective of starting gender.     */
+		<<set _height_adult = 
+			_handle.oheight * (1 - 0.01525 * (_genderlvl - (_handle.osex == 'female' ? 5 : 0))) +
+			_height_change  * (1 - 0.01525 * (_handle.osex == 'female' ? 5 : 0))
+		>>
+
+		<<set _x = 18 - _handle.appAge>>
+
+		<<if _x <= 0.2 * _genderlvl>>
+			<<set _handle.heightCor = _height_adult>>
+		<<elseif 0.2 * _genderlvl < _x && _x <= 6>>
+			/* Puberty phase: It shifts for females as theirs ends earlier; for simplicity */
+			/* I assumed the start is the same regardless although this is not entirely    */
+			/* correct. I used a polynomial here to simulate the 'reverse growth spurt'.   */
+			<<set _x_rel = _x - 0.2 * _genderlvl>>
+			<<set _handle.heightCor = _height_adult * (1 -
+				( 4.70611e-3 - 8.1433e-4 * _genderlvl) * _x_rel -
+				( 1.1049e-4  - 1.140e-5  * _genderlvl) * _x_rel**2 -
+				( 1.6698e-3  - 1.3722e-4 * _genderlvl) * _x_rel**3 -
+				(-1.7701e-4  + 2.114e-5  * _genderlvl) * _x_rel**4
+			)>>
+		<<elseif 6 < _x && _x <= 15>>
+			/* The second phase of linear growth or decline, it's a decent approximation without making things too     */
+			/* complicated. It ends at age 3 (originally 4, but changed it to not break the rest of the code). The     */
+			/* calculation for the puberty growth spurt is in here to provide a starting point for the linear decline. */
+			<<set _x_rel = 6 - 0.2 * _genderlvl>>
+			<<set _handle.heightCor = _height_adult * (1 -
+				( 4.70611e-3 - 8.1433e-4 * _genderlvl) * _x_rel -
+				( 1.1049e-4  - 1.140e-5  * _genderlvl) * _x_rel**2 -
+				( 1.6698e-3  - 1.3722e-4 * _genderlvl) * _x_rel**3 -
+				(-1.7701e-4  + 2.114e-5  * _genderlvl) * _x_rel**4 -
+				(0.033 + 0.0009 * _genderlvl) * (_x - 6)
+			)>>
+		<</if>>
+
+		/* ---------------------------------------- Compute corrected libido ---------------------------------------- */
+
+		<<print `<<set _log = $Libido${_logName}>>`>>
+
+		/* Initialize libido and sub/dom leaning. */
+		<<set _handle.libido = 2, _handle.subdom = 0>>
+
+		/* Reset lowered standards. */
+		<<if _handle === $app>><<set $standardsLower = 0>><</if>>
+
+		<<for _event range _log>>
+			<<switch _event.name>>
+				<<case
+					'Libido Reinforcement A' 'Libido Reinforcement B' 'Libido Reinforcement C' 'Libido Reinforcement D'
+					'Libido Reinforcement E' 'Libido Reinforcement F' 'Libido Reinforcement G'
+					'1 Day Food Forage Major Impact'
+				>>
+					<<set _handle.libido += 1>>
+				<<case '1 Day Food Forage Minor Impact'>> /* Bedlam's Banquet */
+					<<set _handle.libido += 0.2>>
+					<<if _handle === $app>>
+						<<set $standardsLower += 1>>
+					<</if>>
+				<<case 'DoM' 'Submissiveness Rectification A' 'Submissiveness Rectification B'>>
+					<<set _handle.subdom += 1>>
+				<<case 'DoS' 'Power Dom'>>
+					<<set _handle.subdom -= 1>>
+			<</switch>>
+		<</for>>
+		
+		/* Apply player specific effects. */
+		<<if _handle === $app>>
+			/* Boost libido if unripe flans were eaten within the last day. */
+			<<if $lastFlan !== undefined && $time < $lastFlan + 1>><<set _handle.libido += 1>><</if>>
+
+			<<if $menCycleFlag>>
+				/* Libido boost around 14 days into the cycle. */
+				<<if 13 <= $time - $menCycleT && $time - $menCycleT <= 15>><<set $app.libido += 1>><</if>>
+				/* Libido penalty around 22 days into the cycle. */
+				<<if 20 <= $time - $menCycleT && $time - $menCycleT <= 24>><<set $app.libido -= 1>><</if>>
+			<</if>>
+
+			<<if $playerCurses.some(e => e.name === 'Heat/Rut')>>
+				<<if !$heatCycleT_flag>>
+					<<set $heatCycleT = $time - 7>>
+					<<set $heatCycleT_flag = true>>
+				<</if>>
+
+				/* Libido boost on day 14 of the cycle (coincides with day 14 of menstruation cycle if active). */
+				<<if $time - $heatCycleT == 14>><<set $app.libido += 2>><</if>>
+			<</if>>
+		<</if>>
+
+		/* Undo effects of Colossal-able and Minish-ish on penis size for the calculation below. */
+		<<set _penisCorTemp = _handle.penisCor>>
+		<<if _handle.curses.some(e => e.name === 'Colossal-able')>><<set _penisCorTemp /= 70>><</if>>
+		<<if _handle.curses.some(e => e.name === 'Minish-ish')>><<set _penisCorTemp *= 10>><</if>>
+
+		/* Set appGender. Note 1: Companions also have this. */
+		/* Note 2: Uses *apparent* fitness, so ignores the Weakling curse. */
+		<<set _handle.appGender = 0
+			+ 2 * _genderlvl
+			- 0.25 * (_penisCorTemp - 4)
+			+ 0.5 * (_handle.breastsCor - 3)
+			- (_handle.fit > 7)
+		>>
+		<<if _handle === $app>>
+			/* Apply adjustments from Chain of Lorelei, Seafoam scent and Solace Lace. */
+			<<set _handle.appGender += 0.5 * $colwear + 0.25 * $scent + 0.5 * $slwear>>
+			/* mc looks more feminine if wearing the Creepy Doll's tattered pink dress. */
+			<<if $dollevent2>><<set _handle.appGender += 1>><</if>>
+		<</if>>
 	<</for>>
+
+	/* ---------------------------------------------- Update mc object ---------------------------------------------- */
+
+	<<if $app.appAge > 18>>
+		<<set _boxShadowOpacity = 1.0>>
+	<<elseif $app.appAge > 15>>
+		<<set _boxShadowOpacity = 0.8>>
+	<<elseif $app.appAge > 12>>
+		<<set _boxShadowOpacity = 0.6>>
+	<<elseif $app.appAge > 9>>
+		<<set _boxShadowOpacity = 0.4>>
+	<<else>>
+		<<set _boxShadowOpacity = 0.2>>
+	<</if>>
+
+	<<switch $app.gender>>
+		<<case 1>><<set _boxShadowColor = [ 40,  40, 255]>>
+		<<case 2>><<set _boxShadowColor = [ 80,  80, 240]>>
+		<<case 3>><<set _boxShadowColor = [120, 100, 230]>>
+		<<case 4>><<set _boxShadowColor = [165, 120, 220]>>
+		<<case 5>><<set _boxShadowColor = [210, 140, 210]>>
+		<<case 6>><<set _boxShadowColor = [255, 160, 200]>>
+	<</switch>>
+
+	<<set $boxColor = [
+			`box-shadow: 0 0 10px 2px rgba(${_boxShadowColor.concat(_boxShadowOpacity).join(', ')})`,
+			'background-color: black',
+		].join(';')
+	>>
+
+	<<set $mc = {
+		name: $app.name,
+		genderVoice: $app.gender,
+		style: 'border: 2px solid rgb(1, 0, 0);',
+		style1: $boxColor
+	}>>
+
+	/* $PulseBloomUse used to be initialized as an array, so check carefully. */
+	<<set _pulseBloomInUse = $PulseBloomUse !== "" && !Array.isArray($PulseBloomUse)>>
+
+	<<if !_pulseBloomInUse && !$app.switch && !$starUsed>>
+		<<if $app.appGender <= 5 >>
+			<<set $mc.imageIcon = 'Player Icons/playerM.png'>>
+		<<else>>
+			<<set $mc.imageIcon = 'Player Icons/playerF.png'>>
+		<</if>>
+	<<elseif _pulseBloomInUse>>
+		<<print `<<set _handle = $companion${$PulseBloomUse}>>`>>
+		<<set $mc.imageIcon = _handle.imageIcon>>
+	<<elseif $app.switch>>
+		<<print `<<set _handle = $companion${$companionSwitched}>>`>>
+		<<print `<<set $mc.imageIcon = 'Icons/${$companionSwitched}Icon.png'>>`>>
+	<</if>>
+
+	<<set $mc.genderVoice = $colwear ? 99 : $app.gender>>
 <</capture>>
-
-<<checkTime>>
-
-<<LibidoCorrected>>
-<<Update_MC_Speech>>
-
 <</widget>>
 
 :: Appearance widgets [widget nobr]
@@ -517,85 +628,6 @@
 <<widget "BodyHeightText">>
 	<<set _meters = ($app.heightCor > 100)>>
 	<<print (Math.round($app.heightCor)*(_meters ? 0.01 : 1)).toFixed(_meters ? 2 : 1) + (_meters ? " meters" : " cm")>>\
-<</widget>>
-
-:: Libido widget [widget nobr]
-<<widget "LibidoCorrected">>
-<<for _i=0; _i<=$hiredCompanions.length; _i++>>
-	<<if _i==$hiredCompanions.length>>
-		<<set _handle = $app>>
-		<<set _LibidoLog = $LibidoLog>>
-	<<else>>
-		<<if $hiredCompanions[_i].name == $companionTwin.name >>
-			<<set _name = "Twin">>
-		<<else>>
-			<<set _name = $hiredCompanions[_i].name>>
-		<</if>>
-		<<print "<<set _handle  = $companion"+ _name +" >>">>
-		<<print "<<set _LibidoLog  = $LibidoLog"+ _name +" >>">>
-	<</if>>
-	<<set _handle.libido = 2>>
-	<<set _handle.subdom = 0>>
-	<<for _libidoEvent range _LibidoLog>>
-
-		<<if _libidoEvent.name == "Libido Reinforcement A" || _libidoEvent.name == "Libido Reinforcement B" || _libidoEvent.name == "Libido Reinforcement C" || _libidoEvent.name == "Libido Reinforcement D" || _libidoEvent.name == "Libido Reinforcement E" || _libidoEvent.name == "Libido Reinforcement F" || _libidoEvent.name == "Libido Reinforcement G"  >>
-			<<set _handle.libido += 1>>
-		<</if>>
-
-
-		<<if _libidoEvent.name == "DoM" || _libidoEvent.name == "Submissiveness Rectification A" || _libidoEvent.name == "Submissiveness Rectification B" >>
-			<<set _handle.subdom += 1>>
-		<</if>>
-
-		<<if _libidoEvent.name == "DoS" || _libidoEvent.name == "Power Dom">>
-			<<set _handle.subdom -= 1>>
-		<</if>>
-
-		<<if _libidoEvent.name == "1 Day Food Forage Major Impact" >>
-			<<set _handle.libido += 1>>
-		<</if>>
-
-		<<if _libidoEvent.name == "1 Day Food Forage Minor Impact" >>
-			<<set _handle.libido += 0.2>>
-			<<if _i==$hiredCompanions.length>>
-				<<set $standardsLower +=1>>
-			<</if>>
-		<</if>>
-	
-		<<if _i==$hiredCompanions.length>>
-			<<if $lastFlan >0 >>
-				<<if $lastFlan==$time>>
-					<<set _handle.libido += 1>>
-				<</if>>
-			<</if>>
-		<</if>>
-
-	<</for>>
-	
-	<<if _i==$hiredCompanions.length>>
-		<<if $time-$menCycleT<16 && $time-$menCycleT>=13>>
-			<<set $app.libido += 1>>
-		<<elseif $time-$menCycleT<25 && $time-$menCycleT>=20>>
-			<<set $app.libido -= 1>>
-		<</if>>
-
-		<<if $playerCurses.some(e => e.name === "Heat/Rut")>>
-			<<if !$heatCycleT_flag>>	
-				<<if $menCycleT_flag == true>>
-					<<set $heatCycleT = $menCycleT>>
-				<<else>>
-					<<set $heatCycleT = $time -7>>
-				<</if>>
-				<<set $heatCycleT_flag = true>>
-			<</if>>
-
-			<<if $time-$heatCycleT==14 >>
-				<<set $app.libido += 2>>
-			<</if>>
-		<</if>>
-	<</if>>
-
-<</for>>
 <</widget>>
 
 :: Semen Demon Widget [widget nobr]
@@ -664,42 +696,6 @@
 <</widget>>
 
 :: Perceived widgets [widget nobr]
-<<widget "appGender">>
-
-<<for _i=0; _i<=$hiredCompanions.length; _i++>>
-	<<if _i==$hiredCompanions.length>>
-		<<set _handle = $app>>
-	<<else>>
-		<<if $hiredCompanions[_i].name == $companionTwin.name >>
-			<<set _name = "Twin">>
-		<<else>>
-			<<set _name = $hiredCompanions[_i].name>>
-		<</if>>
-		<<print "<<set _handle  = $companion"+ _name +" >>">>
-	<</if>>
-
-	<<set _penisCorTemp = _handle.penisCor>>
-	<<if $playerCurses.some(e => e.name === "Colossal-able")>>
-		<<set _penisCorTemp /= 70>>
-	<</if>>
-
-	<<if $playerCurses.some(e => e.name === "Minish-ish")>>
-		<<set _penisCorTemp *= 10>>
-	<</if>>
-	<<if $app.fit>7>>
-		<<set _handle.appGender = 2*(_handle.gender-1) -0.25*(_penisCorTemp-4) + 0.5*(_handle.breastsCor-3)-1>>
-	<<else>>
-		<<set _handle.appGender = 2*(_handle.gender-1) -0.25*(_penisCorTemp-4) + 0.5*(_handle.breastsCor-3)>>
-	<</if>>
-	<<if _i==$hiredCompanions.length>>
-		<<set _handle.appGender += 0.5*$colwear+0.25*$scent+0.5*$slwear>>
-		<<if $dollevent2>>
-			<<set _handle.appGender += 1>>
-		<</if>>
-	<</if>>
-<</for>>
-<</widget>>
-
 <<widget "mrms">>
 	<<if $app.appGender<=5>>
 		mr.
@@ -1091,12 +1087,10 @@
 		
 	<</if>>
 
-	<<if _handle.curses.some(e => e.name === "Weakling")>>
-		<<set _handle.fit = 0>>
-	<</if>>
+	<<set _fitCor = _handle.curses.some(e => e.name === "Weakling") ? 0 : _handle.fit>>
+	<<set _handle.HandicapThreat += _fitCor / 4 - 1.25>>
+	<<set _handle.HandicapMovement += _fitCor / 4 - 1.25>>
 
-	<<set _handle.HandicapThreat += _handle.fit/4-1.25>>
-	<<set _handle.HandicapMovement += _handle.fit/4-1.25>>
 	<<if _handle.armCount == 1 && (_handle.legCount >1 || $DaedalusEquip)>>
 		<<set _handle.HandicapThreat -=2>>
 		<<set _handle.HandicapMovement -=1>>
@@ -1232,125 +1226,6 @@
 <</if>>
 <</widget>>
 
-
-:: Speech settings [widget nobr]
-<<widget "Update_MC_Speech">>
-<<appGender>>
-	<<if $app.gender<=1 >>
-
-		<<if $app.appAge>18>>
-			<<set $boxColor="box-shadow: 0px 0px 10px 2px rgba(40, 40, 255,1);background-color: black;">>
-		<<elseif $app.appAge>15>>
-			<<set $boxColor="box-shadow: 0px 0px 10px 2px rgba(40, 40, 255,0.8);background-color: black;">>
-		<<elseif $app.appAge>12>>
-			<<set $boxColor="box-shadow: 0px 0px 10px 2px rgba(40, 40, 255,0.6);background-color: black;">>
-		<<elseif $app.appAge>9>>
-			<<set $boxColor="box-shadow: 0px 0px 10px 2px rgba(40, 40, 255,0.4);background-color: black;">>
-		<<else>>
-			<<set $boxColor="box-shadow: 0px 0px 10px 2px rgba(40, 40, 255,0.2);background-color: black;">>
-		<</if>>
-
-	<<elseif $app.gender==2 >>
-
-		<<if $app.appAge>18>>
-			<<set $boxColor="box-shadow: 0px 0px 10px 2px rgba(80, 80, 240,1);background-color: black;">>
-		<<elseif $app.appAge>15>>
-			<<set $boxColor="box-shadow: 0px 0px 10px 2px rgba(80, 80, 240,0.8);background-color: black;">>
-		<<elseif $app.appAge>12>>
-			<<set $boxColor="box-shadow: 0px 0px 10px 2px rgba(80, 80, 240,0.6);background-color: black;">>
-		<<elseif $app.appAge>9>>
-			<<set $boxColor="box-shadow: 0px 0px 10px 2px rgba(80, 80, 240,0.4);background-color: black;">>
-		<<else>>
-			<<set $boxColor="box-shadow: 0px 0px 10px 2px rgba(80, 80, 240,0.2);background-color: black;">>
-		<</if>>
-
-	<<elseif $app.gender==3 >>
-
-		<<if $app.appAge>18>>
-			<<set $boxColor="box-shadow: 0px 0px 10px 2px rgba(120, 100, 230,1);background-color: black;">>
-		<<elseif $app.appAge>15>>
-			<<set $boxColor="box-shadow: 0px 0px 10px 2px rgba(120, 100, 230,0.8);background-color: black;">>
-		<<elseif $app.appAge>12>>
-			<<set $boxColor="box-shadow: 0px 0px 10px 2px rgba(120, 100, 230,0.6);background-color: black;">>
-		<<elseif $app.appAge>9>>
-			<<set $boxColor="box-shadow: 0px 0px 10px 2px rgba(120, 100, 230,0.4);background-color: black;">>
-		<<else>>
-			<<set $boxColor="box-shadow: 0px 0px 10px 2px rgba(120, 100, 230,0.2);background-color: black;">>
-		<</if>>
-
-	<<elseif $app.gender==4 >>
-
-		<<if $app.appAge>18>>
-			<<set $boxColor="box-shadow: 0px 0px 10px 2px rgba(165, 120, 220,1);background-color: black;">>
-		<<elseif $app.appAge>15>>
-			<<set $boxColor="box-shadow: 0px 0px 10px 2px rgba(165, 120, 220,0.8);background-color: black;">>
-		<<elseif $app.appAge>12>>
-			<<set $boxColor="box-shadow: 0px 0px 10px 2px rgba(165, 120, 220,0.6);background-color: black;">>
-		<<elseif $app.appAge>9>>
-			<<set $boxColor="box-shadow: 0px 0px 10px 2px rgba(165, 120, 220,0.4);background-color: black;">>
-		<<else>>
-			<<set $boxColor="box-shadow: 0px 0px 10px 2px rgba(165, 120, 220,0.2);background-color: black;">>
-		<</if>>
-
-	<<elseif $app.gender==5 >>
-
-		<<if $app.appAge>18>>
-			<<set $boxColor="box-shadow: 0px 0px 10px 2px rgba(210, 140, 210,1);background-color: black;">>
-		<<elseif $app.appAge>15>>
-			<<set $boxColor="box-shadow: 0px 0px 10px 2px rgba(210, 140, 210,0.8);background-color: black;">>
-		<<elseif $app.appAge>12>>
-			<<set $boxColor="box-shadow: 0px 0px 10px 2px rgba(210, 140, 210,0.6);background-color: black;">>
-		<<elseif $app.appAge>9>>
-			<<set $boxColor="box-shadow: 0px 0px 10px 2px rgba(210, 140, 210,0.4);background-color: black;">>
-		<<else>>
-			<<set $boxColor="box-shadow: 0px 0px 10px 2px rgba(210, 140, 210,0.2);background-color: black;">>
-		<</if>>
-
-	<<else>>
-		<<if $app.appAge>18>>
-			<<set $boxColor="box-shadow: 0px 0px 10px 2px rgba(255, 160, 200,1);background-color: black;">>
-		<<elseif $app.appAge>15>>
-			<<set $boxColor="box-shadow: 0px 0px 10px 2px rgba(255, 160, 200,1);background-color: black;">>
-		<<elseif $app.appAge>12>>
-			<<set $boxColor="box-shadow: 0px 0px 10px 2px rgba(255, 160, 200,1);background-color: black;">>
-		<<elseif $app.appAge>9>>
-			<<set $boxColor="box-shadow: 0px 0px 10px 2px rgba(255, 160, 200,1);background-color: black;">>
-		<<else>>
-			<<set $boxColor="box-shadow: 0px 0px 10px 2px rgba(255, 160, 200,1);background-color: black;">>
-		<</if>>
-
-	<</if>>
-		<<set $mc = {
-	name: $app.name,
-	genderVoice: $app.gender,
-	style: "border: 2px solid rgb(1,0,0);",
-	style1: $boxColor
-	}>>
-	<<if $PulseBloomUse=="" && $app.switch==false && $starUsed == 0>>
-		<<if $app.appGender<=5 >>
-			<<set $mc.imageIcon="Player Icons/playerM.png">>
-		<<else>>
-			<<set $mc.imageIcon="Player Icons/playerF.png">>
-		<</if>>
-	<<elseif $PulseBloomUse!="">>
-		<<print "<<set _companion  = $companion"+ $PulseBloomUse +" >>">>
-		<<set $mc.imageIcon = _companion.imageIcon>>
-	<<elseif $app.switch==true>>
-		<<print "<<set _companion  = $companion"+ $companionSwitched +" >>">>
-		<<print "<<set $mc.imageIcon = \"Icons/"+ $companionSwitched +"Icon.png\">>">>
-	<</if>>
-
-	<<if $app.gender<1 >>
-		<<set $mc.genderVoice=1>>
-	<<elseif $app.gender>6>>
-		<<set $mc.genderVoice=6>>
-	<</if>>
-
-	<<if $colwear>>
-		<<set $mc.genderVoice=99>>
-	<</if>>
-<</widget>>
-
 :: Doll transformation [widget nobr]
 <<widget "dollTF">>
 <<if $creepydoll.affec == 0>>
@@ -1403,7 +1278,6 @@
 		pregnantT: $app.pregnantT,
 		due: setup.dueDate($app),
 		ears: "normal human",
-		height: $app.oheight,
 		modheight: 0,
 		bodyHair: 1,
 		skinType: "",
@@ -1489,7 +1363,6 @@
 		pregnantT: $app.pregnantT,
 		due: setup.dueDate($app),
 		ears: "normal human",
-		height: $app.oheight,
 		modheight: 0,
 		bodyHair: 1,
 		skinType: "",
@@ -1526,18 +1399,11 @@
 	<</if>>
 <</if>>
 
-<<if $colwear>>
-	<<set $colwear=0>>
-	<<Update_MC_Speech>>
-	<<set $companionTwin.genderVoice = -1*($mc.genderVoice-3.5)+3.5>>
-	<<set $colwear=1>>
-	<<Update_MC_Speech>>
-<<else>>
-	<<set $companionTwin.genderVoice = -1*($mc.genderVoice-3.5)+3.5>>
-<</if>>
+<<set $companionTwin.genderVoice = 7 - $app.gender>>
 
-<<set $companionTwin.name =  $curse111.variation1>>
+<<set $companionTwin.name = $curse111.variation1>>
 <<set $hiredCompanions.push($companionTwin)>>
+<<CarryAdjust>>
 <</widget>>
 
 :: Creating a Golem with Lambent Specter [widget nobr]
@@ -1582,7 +1448,6 @@
 		pregnantT: setup.never,
 		due: setup.never,
 		ears: "",
-		height: 170,
 		modheight: 0,
 		bodyHair: 1,
 		skinType: "",
@@ -1712,7 +1577,6 @@
 		pregnantT: setup.never,
 		due: setup.never,
 		ears: "",
-		height: 163,
 		modheight: 0,
 		bodyHair: 0,
 		skinType: "",
@@ -1823,64 +1687,65 @@
 <</if>>
 
 <<if $time > $Maru_LastT + 7>>
-<<set $companionMaru.affec+=(1+$hsswear + $maruPangea)>>
-<<set $Maru_LastT = $time>>
-<<if $MaruConvo1 && $forageFood == 0>>
-	<<set $items[1].count +=1 >>
-	@@.alert1; Maru cooked an especially delicious meal granting you an extra day worth of food!<br><br>
-<</if>>
+	<<set $companionMaru.affec+=(1+$hsswear + $maruPangea)>>
+	<<set $Maru_LastT = $time>>
+	<<if $MaruConvo1 && $forageFood == 0>>
+		<<set $items[1].count += 1>>
+		@@.alert1; Maru cooked an especially delicious meal granting you an extra day worth of food!<br><br>
+	<</if>>
 <</if>>
 
 <<if $time > $Lily_LastT + 7>>
-<<set $companionLily.affec+=(1+$hsswear + $maruPangea)>>
-<<set $Lily_LastT = $time>>
+	<<set $companionLily.affec+=(1+$hsswear + $maruPangea)>>
+	<<set $Lily_LastT = $time>>
 <</if>>
 
 <<if $time > $Khemia_LastT + 7>>
-<<set $companionKhemia.affec+=(1+$hsswear + $maruPangea)>>
-<<set $Khemia_LastT = $time>>
+	<<set $companionKhemia.affec+=(1+$hsswear + $maruPangea)>>
+	<<set $Khemia_LastT = $time>>
 <</if>>
 
 <<if $time > $Cherry_LastT + 7>>
-<<set $companionCherry.affec+=(1+$hsswear + $maruPangea)>>
-<<set $Cherry_LastT = $time>>
+	<<set $companionCherry.affec+=(1+$hsswear + $maruPangea)>>
+	<<set $Cherry_LastT = $time>>
 <</if>>
 
 <<if $time > $Cloud_LastT + 7>>
-<<set $companionCloud.affec+=(1+$hsswear + $maruPangea)>>
-<<set $Cloud_LastT = $time>>
-<<set $altCloud = random(0,3)>>
-<<if $CloudConvo1>>
-	<<if $altCloud == 1>>
-	<<set $temp = random(2,3) >>
-	<<set $items[20].count += $temp >>
-	@@.alert1; Cloud seems to have been able to scavenge some ammunition somehow. You aren't quite sure whether he found it or made it himself, but either way you've gained $temp bullets.<br><br>
-	<<elseif $altCloud == 2>>
-	<<set $temp = random(2,5) >>
-	<<set $dubloons += $temp >>
-	@@.alert1; Cloud somehow managed to scavenge a bit of cash, perhaps left behind by a previous diver? It's not like dubloons would be down here for any other reason. You've gained $temp dubloons.<br><br>
+	<<set $companionCloud.affec+=(1+$hsswear + $maruPangea)>>
+	<<set $Cloud_LastT = $time>>
+	<<set $altCloud = random(0,3)>>
+	<<if $CloudConvo1>>
+		<<if $altCloud == 1>>
+		<<set $temp = random(2,3) >>
+		<<set $items[20].count += $temp >>
+		@@.alert1; Cloud seems to have been able to scavenge some ammunition somehow. You aren't quite sure whether he found it or made it himself, but either way you've gained $temp bullets.<br><br>
+		<<elseif $altCloud == 2>>
+		<<set $temp = random(2,5) >>
+		<<set $dubloons += $temp >>
+		@@.alert1; Cloud somehow managed to scavenge a bit of cash, perhaps left behind by a previous diver? It's not like dubloons would be down here for any other reason. You've gained $temp dubloons.<br><br>
+		<</if>>
 	<</if>>
-<</if>>
 <</if>>
 
 <<if $time > $Saeko_LastT + 7>>
-<<set $companionSaeko.affec+=(1+$hsswear + $maruPangea)>>
-<<set $Saeko_LastT = $time>>
+	<<set $companionSaeko.affec+=(1+$hsswear + $maruPangea)>>
+	<<set $Saeko_LastT = $time>>
 <</if>>
 
 <<if $time > $Twin_LastT + 7>>
-<<set $companionTwin.affec+=(1+$hsswear + $maruPangea)>>
-<<set $Twin_LastT = $time>>
+	<<set $companionTwin.affec+=(1+$hsswear + $maruPangea)>>
+	<<set $Twin_LastT = $time>>
 <</if>>
 
 <<if $time > $fit_adjustLastT + 20>>
-	<<if $fit>8>>
-	<<set $fit-=1>>
-	@@.alert1; Your lack of an intensive work-out reduces your fitness to somewhat more average levels<br><br>
-	<<elseif $fit<5>>
-	<<set $fit+=1>>
-	@@.alert1; The constant physical activity of the expedition increases your fitness closer to average levels<br><br>
+	<<if $app.fit > 8>>
+		<<set $app.fit -= 1>>
+		@@.alert1; Your lack of an intensive work-out reduces your fitness to somewhat more average levels<br><br>
+	<<elseif $app.fit < 5>>
+		<<set $app.fit += 1>>
+		@@.alert1; The constant physical activity of the expedition increases your fitness closer to average levels<br><br>
 	<</if>>
+	<<set $fit_adjustLastT = $time>>
 <</if>>
 
 <<if $app.appAge <= 13>>
@@ -2071,7 +1936,10 @@
 
 <</if>>
 
-<<if $PulseBloomUse!="" && $time-2 > $PulseBloomDate >>
+/* $PulseBloomUse used to be initialized as an array, so check carefully. */
+<<set _pulseBloomInUse = $PulseBloomUse !== "" && !Array.isArray($PulseBloomUse)>>
+
+<<if _puseBloomInUse && $time-2 > $PulseBloomDate >>
 	<<set $app.osex = $PulseBloomStorage.osex>>
 	<<set $app.obreasts = $PulseBloomStorage.obreasts>>
 	<<set $app.openis = $PulseBloomStorage.openis>>
@@ -2085,7 +1953,7 @@
 	<<set $app.fit -= $PulseBloomStorage.fit>>
 	<<set $PulseBloomDate = setup.never>>
 	<<set $PulseBloomUse="">>
-	<<Update_MC_Speech>>
+	<<CarryAdjust>>
 <</if>>
 <</widget>>
 
@@ -2118,19 +1986,18 @@
 <<widget "CarryAdjust">>
 <<Equipment>>
 <<Handicap>>
-<<HeightCorrected>>
+<<GenderCorrected>>
 <<Update_Misc_Stat>>
-
-/*<<set $totalCarry -= $carryWeight>>*/
 
 <<if $playerCurses.some(e => e.name === "Weakling")>>
 	<<set $ocarryWeight = 7.5>>
 <</if>>
 
-<<if $app.osex=='male'>>
-	<<set $carryWeight = $app.heightCor / $app.oheight * ($ocarryWeight + 0.5*($app.fit-5-$app.gender+1) )>>
+<<set _fitCor = $app.curses.some(e => e.name === "Weakling") ? 0 : $app.fit>>
+<<if $app.osex == 'male'>>
+	<<set $carryWeight = $app.heightCor / $app.oheight * ($ocarryWeight + 0.5 * (_fitCor - 5 - $app.gender + 1))>>
 <<else>>
-	<<set $carryWeight = $app.heightCor / $app.oheight * ($ocarryWeight + 0.5*($app.fit-5+6-$app.gender) )>>
+	<<set $carryWeight = $app.heightCor / $app.oheight * ($ocarryWeight + 0.5 * (_fitCor - 5 - $app.gender + 6))>>
 <</if>>
 
 <<set $carryWeight = $carryWeight*(1+ $app.HandicapCarry/10)>>

--- a/src/widgets.twee
+++ b/src/widgets.twee
@@ -542,6 +542,8 @@
 			<</if>>
 		<</if>>
 
+		/* ----------------------------------------- Compute apparent gender ---------------------------------------- */
+
 		/* Undo effects of Colossal-able and Minish-ish on penis size for the calculation below. */
 		<<set _penisCorTemp = _handle.penisCor>>
 		<<if _handle.curses.some(e => e.name === 'Colossal-able')>><<set _penisCorTemp /= 70>><</if>>

--- a/src/widgets.twee
+++ b/src/widgets.twee
@@ -508,7 +508,7 @@
 				<<case
 					'Libido Reinforcement A' 'Libido Reinforcement B' 'Libido Reinforcement C' 'Libido Reinforcement D'
 					'Libido Reinforcement E' 'Libido Reinforcement F' 'Libido Reinforcement G'
-					'1 Day Food Forage Major Impact'
+					'1 Day Food Forage Major Impact' /* Unripe flanberries */
 				>>
 					<<set _handle.libido += 1>>
 				<<case '1 Day Food Forage Minor Impact'>> /* Bedlam's Banquet */
@@ -525,7 +525,7 @@
 		
 		/* Apply player specific effects. */
 		<<if _handle === $app>>
-			/* Boost libido if unripe flans were eaten within the last day. */
+			/* Boost libido if ripe flanberries were eaten within the last day. */
 			<<if $lastFlan !== undefined && $time < $lastFlan + 1>><<set _handle.libido += 1>><</if>>
 
 			<<if $menCycleFlag>>

--- a/src/widgets.twee
+++ b/src/widgets.twee
@@ -68,9 +68,9 @@
 					<<else>>
 						<<set _eventAge -= 2>>
 					<</if>>
-				<<case '1 Day Food Forage Minor Impact'>>
+				<<case '1 Day Food Forage Minor Impact'>> /* Layer 3 Crystalline Confectionaries with knowledge */
 					<<set _eventAge -= 0.08>>
-				<<case '1 Day Food Forage Major Impact'>>
+				<<case '1 Day Food Forage Major Impact'>> /* Layer 3 Crystalline Confectionaries without knowledge */
 					<<set _eventAge -= 1>>
 			<</switch>>
 		<</for>>
@@ -176,7 +176,7 @@
 				<<case
 					'Gender Reversal A' 'Gender Reversal B' 'Gender Reversal C' 'Gender Reversal D'
 					'Gender Reversal E' 'Gender Reversal F' 'Gender Reversal G'
-					'1 Day Food Forage Major Impact'
+					'1 Day Food Forage Major Impact' /* Layer 1 Blisshrooms without knowledge. */
 				>>
 					<<set _handle.gender += _handle.osex == 'male' ? 1 : -1>>
 				<<case 'Doll Transformation'>>
@@ -260,7 +260,7 @@
 						<</if>>
 						<<set _handle.womb += 1>>
 					<</if>>
-				<<case '1 Day Water Forage Major Impact'>>
+				<<case '1 Day Water Forage Major Impact'>> /* Layer 1 Cloudpools without knowledge */
 					<<if _handle.penis > 0>><<set _handle.penis += 1>><</if>>
 					<<if _handle.breastsCor > 0 || _robustBreasts>><<set _handle.breasts += 1>><</if>>
 				<<case 'Doll Transformation'>>
@@ -443,11 +443,17 @@
 
 		<<print `<<set _log = $Height${_logName}>>`>>
 
-		<<set _height_change = $HeightIncrease * (
-			5.0 * _log.filter(e => e.name === 'Dizzying Heights').length +
-			3.0 * _log.filter(e => e.name === '1 Day Food Forage Major Impact').length +
-			0.5 * _log.filter(e => e.name === '1 Day Food Forage Minor Impact').length
-		)>>
+		<<set _height_change = 0>>
+		<<for _event range _log>>
+			<<switch _event.name>>
+				<<case 'Dizzying Heights'>>
+					<<set _height_change += 5 * $HeightIncrease>>
+				<<case '1 Day Food Forage Major Impact'>> /* Layer 4 Flairabou without knowledge */
+					<<set _height_change += 3 * $HeightIncrease>>
+				<<case '1 Day Food Forage Minor Impact'>> /* Layer 4 Flairabou with knowledge */
+					<<set _height_change += 0.5 * $HeightIncrease>>
+			<</switch>>
+		<</for>>
 
 		<<if _log.some(e => e.name === 'Colossal-able')>>
 			<<set _height_change = _handle.oheight * 70 - _handle.oheight>>
@@ -508,10 +514,10 @@
 				<<case
 					'Libido Reinforcement A' 'Libido Reinforcement B' 'Libido Reinforcement C' 'Libido Reinforcement D'
 					'Libido Reinforcement E' 'Libido Reinforcement F' 'Libido Reinforcement G'
-					'1 Day Food Forage Major Impact' /* Unripe flanberries */
+					'1 Day Food Forage Major Impact' /* Layer 2 unripe flanberries */
 				>>
 					<<set _handle.libido += 1>>
-				<<case '1 Day Food Forage Minor Impact'>> /* Bedlam's Banquet */
+				<<case '1 Day Food Forage Minor Impact'>> /* Layer 8 Bedlam's Banquet */
 					<<set _handle.libido += 0.2>>
 					<<if _handle === $app>>
 						<<set $standardsLower += 1>>
@@ -525,7 +531,7 @@
 		
 		/* Apply player specific effects. */
 		<<if _handle === $app>>
-			/* Boost libido if ripe flanberries were eaten within the last day. */
+			/* Boost libido if ripe flanberries from layer 2 were eaten within the last day. */
 			<<if $lastFlan !== undefined && $time < $lastFlan + 1>><<set _handle.libido += 1>><</if>>
 
 			<<if $menCycleFlag>>

--- a/src/widgets.twee
+++ b/src/widgets.twee
@@ -518,7 +518,6 @@
 				>>
 					<<set _handle.libido += 1>>
 				<<case '1 Day Food Forage Minor Impact'>> /* Layer 8 Bedlam's Banquet */
-					<<set _handle.libido += 0.2>>
 					<<if _handle === $app>>
 						<<set $standardsLower += 1>>
 					<</if>>

--- a/src/widgets.twee
+++ b/src/widgets.twee
@@ -1682,6 +1682,12 @@
 
 <<set $random = Math.random(0,3)>>
 
+<<if $totalCarry * 1.1 < setup.carriedWeight>>
+	@@.alert2; You are severely overburdened!@@<br><br>
+<<elseif $totalCarry * 1 < setup.carriedWeight>>
+	@@.alert1; You are overburdened!@@<br><br>
+<</if>>
+
 <<if $status.duration > 0>>
 	@@.alert2; You are currently injured, increasing your next $status.duration travel times by $status.penalty days each. @@<br><br>
 <</if>>
@@ -2049,13 +2055,6 @@
 <<if $playerCurses.some(e => e.name === "Double Trouble")>>
 	/*<<set $totalCarry += $companionTwin.carry>>*/
 	<<set $totalCarry +=$carryWeight>>
-<</if>>
-
-<<set _carriedWeight = setup.carriedWeight>>
-<<if $totalCarry*1.1 < _carriedWeight >>
-	@@.alert2; You are severely overburdened!@@<br><br>
-<<elseif $totalCarry*1 < _carriedWeight  >>
-	@@.alert1; You are overburdened!@@<br><br>
 <</if>>
 
 <</widget>>

--- a/src/widgets.twee
+++ b/src/widgets.twee
@@ -1,17 +1,21 @@
-:: GenderCorrected [widget nobr]
-<<widget "GenderCorrected">>
+:: UpdateAttributes [widget nobr]
+<<widget "UpdateAttributes">>
 <<capture
 	_assetMod
+	_boxShadowColor
+	_boxShadowOpacity
 	_event
 	_eventAge
 	_eventVariation
 	_fullyGrownAge
+	_genderlvl
 	_handle
 	_lastBirth
 	_logName
 	_name
 	_newTime
 	_oldTime
+	_pulseBloomInUse
 	_robustBreasts
 	_wombEvents
 >>
@@ -1994,7 +1998,7 @@
 <<widget "CarryAdjust">>
 <<Equipment>>
 <<Handicap>>
-<<GenderCorrected>>
+<<UpdateAttributes>>
 <<Update_Misc_Stat>>
 
 <<if $playerCurses.some(e => e.name === "Weakling")>>

--- a/t3lt.twee-config.yml
+++ b/t3lt.twee-config.yml
@@ -8,16 +8,8 @@ sugarcube-2:
       name: AffectionChange
       parameters:
         - "string &+ number"
-    AgeCorrected:
-      name: AgeCorrected
-      parameters:
-        - ""
     AppearanceCorrect:
       name: AppearanceCorrect
-      parameters:
-        - ""
-    appGender:
-      name: appGender
       parameters:
         - ""
     BodyHeightText:
@@ -80,10 +72,6 @@ sugarcube-2:
       name: Handicap
       parameters:
         - ""
-    HeightCorrected:
-      name: HeightCorrected
-      parameters:
-        - ""
     HornGrowthDesc:
       name: HornGrowthDesc
       parameters:
@@ -94,10 +82,6 @@ sugarcube-2:
         - ""
     Lewdness:
       name: Lewdness
-      parameters:
-        - ""
-    LibidoCorrected:
-      name: LibidoCorrected
       parameters:
         - ""
     MonsterPregCheckParty:
@@ -183,10 +167,6 @@ sugarcube-2:
        - ""
     Threat1Criterion:
       name: Threat1Criterion
-      parameters:
-        - ""
-    Update_MC_Speech:
-      name: Update_MC_Speech
       parameters:
         - ""
     Update_Misc_Stat:

--- a/t3lt.twee-config.yml
+++ b/t3lt.twee-config.yml
@@ -60,10 +60,6 @@ sugarcube-2:
       name: FlaskFirst
       parameters:
         - ""
-    GenderCorrected:
-      name: GenderCorrected
-      parameters:
-        - ""
     GenderPronoun:
       name: GenderPronoun
       parameters:
@@ -167,6 +163,10 @@ sugarcube-2:
        - ""
     Threat1Criterion:
       name: Threat1Criterion
+      parameters:
+        - ""
+    UpdateAttributes:
+      name: UpdateAttributes
       parameters:
         - ""
     Update_Misc_Stat:


### PR DESCRIPTION
This (mostly) finishes consolidating the attribute adjusting widgets. Most things now go through `<<UpdateAttributes>>` (formerly `<<GenderCorrected>>`), and `<<UpdateAttributes>>` is only called from `<<CarryAdjust>>`.

This means that a bunch of places now call `<<CarryAdjust>>` that used to call something more specific. I think that's better - you don't have to think about what stuff you care about, just make sure it's all synced up.

In addition, `<<checkTime>>` is now called separately, and only from passages that you can normally loop around in, like hubs and relic grids (I also added it to the `CampCode` passage). This can still be improved more, since some checks should probably be moved to `<<PassTime>>` and happen while traveling between layers.

I also fixed up the code for checking character fitness - `<<Handicap>>` set it to 0 if you had the `Weakling` curse, but that indirection was confusing and anyway the lore says you can still *look* ripped while under the curse, you'll just be weak anyway. I adjusted some text to reflect this and fixed up the check in `<<checkTime>>` that referenced `$fit` (which wasn't otherwise used) and `$fit_adjustLastT` (which was never updated).

Finally I clarified some checks for `$PulseBloomUse` which sort of accidentally worked (because `[] == ""` evaluates to `true`) - it was initialized as an empty array, but used as a string. I changed the initial value to the empty string, but for save compatibility I added an explicit array check.