### PR TITLE
Check for layer threats while traveling in more cases

### DIFF
--- a/src/companionConversations.twee
+++ b/src/companionConversations.twee
@@ -4434,7 +4434,7 @@ You start to pry out the Omoikane Circuit from your phone, causing it to immedia
 	<</if>>
 	<<say $mc>> For a complex AI, you can seem pretty simple sometimes.<</say>>
 	<<set $companionAI.imageIcon= "Icons/Ai_neutral_happy.png">>
-	<<set $aiSuggest=true>>
+	<<set $aiSuggest = true>>
 [[End your conversation|Party overview]]
 
 :: AI switch end

--- a/src/companionSetup.twee
+++ b/src/companionSetup.twee
@@ -535,8 +535,8 @@ type: ""
 <<set $LibidoLogTwin = []>>
 <<set $HandicapLogTwin = []>>
 
-<<set $aiMemWipe=0>>
-<<set $aiSuggest=false>>
+<<set $aiMemWipe = 0>>
+<<set $aiSuggest = false>>
 
 <<set $companionsDepartT = 0>>
 <<set $companionsDepartL = 0>>
@@ -560,7 +560,7 @@ type: ""
 				<<print $hiredCompanions[$temp].curses[$i].name>><br>
 		<</for>><br>
 	<</if>>
-	<<if $temp == $swapComp>>
+	<<if $hiredCompanions[$temp].name == $companionSwitched>>
 		$hiredCompanions[$temp].name is in your original body after your bodies were swapped by the Fate-crossing Star!<br><br>
 	<</if>>
 	<</nobr>>
@@ -574,7 +574,7 @@ type: ""
 				<<print $companionTwin.curses[$i].name>><br>
 		<</for>><br>
 	<</if>>
-	<<if $temp == $swapComp>>
+	<<if $companionSwitched == "Twin">>
 		$companionTwin.name is in your original body after your bodies were swapped by the Fate-crossing Star!<<if $curse111.variation2==same>>Not that it makes much of a difference... Fortunately for you, it just means you got some free corruption out of it.<</if>><br><br>
 	<</if>>
 	<</nobr>>

--- a/src/curses.twee
+++ b/src/curses.twee
@@ -1104,17 +1104,18 @@ type: ""
 <<set $playerCurses = []>>
 <<set $StoredCurse = []>>
 
-<<set setup.cursesOnLayer = {
-    1: ["Libido Reinforcement A", "Gender Reversal A", "Asset Robustness A", "Clothing Restriction A", "Shrunken Assets", "Hair Removal", "Perma-dye", "Freckle Speckle", "Knife-ear", "Dizzying Heights", "Increased Sensitivity", "Refractory Refactorization"],
-    2: ["Libido Reinforcement B", "Gender Reversal B", "Asset Robustness B", "Age Reduction A", "Fluffy Ears", "Fluffy Tail", "Maximum Fluff", "Heat/Rut", "Lightweight", "Sex Switcheroo", "Futa Fun", "Blushing Virgin"],
-    3: ["Submissiveness Rectification A", "Gender Reversal C", "Asset Robustness C", "Clothing Restriction B", "Power Dom", "20/20000000", "Comic Relief", "Equal Opportunity", "Absolute Pregnancy", "Absolute Birth Control", "Wacky Wombs", "Omnitool", "Gooey", "Rainbow Swirl", "Double Pepperoni", "Literal Blushing Virgin"],
-    4: ["Libido Reinforcement C", "Lactation Rejuvenation A", "Asset Robustness D", "Age Reduction B", "Sleep Tight", "Sweet Dreams", "Hypno Happytime", "Crossdress Your Heart", "Lie Detector", "Megadontia", "Softie", "Hard Mode", "Lingual Leviathan", "Tipping the Scales", "Reptail", "Cold Blooded"],
-    5: ["Libido Reinforcement D", "Gender Reversal D", "Pleasure Respecification A", "Clothing Restriction C", "Massacre Manicure", "DoS", "DoM", "Hijinks Ensue", "Flower Power", "Cellulose", "Chlorophyll", "Pheromones", "Carapacian", "Hemospectrum", "Wriggly Antennae", "Eggxellent"],
-    6: ["Submissiveness Rectification B", "Lactation Rejuvenation B", "Pleasure Respecification B", "Age Reduction C", "Horny", "Drawing Spades", "Tattoo Tally", "Leaky", "Wandering Hands", "Semen Demon", "Quota", "In the Limelight"],
-    7: ["Libido Reinforcement E", "Gender Reversal E", "Asset Robustness E", "Urine Reamplification A", "Barter System", "Shared Space", "Weakling", "Random Orgasms", "Beastly", "Creature of the Night", "Minish-ish", "Colossal-able"],
-    8: ["Libido Reinforcement F", "Gender Reversal F", "Asset Robustness F", "Urine Reamplification B", "Eye on the Prize", "Deafening Silence", "Taciturn Turnaround", "Ampu-Q-tie", "Nose Goes", "Arm Army", "A Little Extra", "Null", "Seafolk", "Taken for Granite", "Double Trouble", "Conjoined"],
-    9: ["Libido Reinforcement G", "Gender Reversal G", "Asset Robustness G", "Literalization", "Consent Dissent", "The Maxim", "Adverse Possession", "Erased", "Tickly Tentacles", "Eye-scream", "A Mouthful", "Below the Veil"],
-}>>
+<<set setup.cursesOnLayer = [
+    /*  0 */ [], /* Placeholder; no curses on the surface. */
+    /*  1 */ ["Libido Reinforcement A", "Gender Reversal A", "Asset Robustness A", "Clothing Restriction A", "Shrunken Assets", "Hair Removal", "Perma-dye", "Freckle Speckle", "Knife-ear", "Dizzying Heights", "Increased Sensitivity", "Refractory Refactorization"],
+    /*  2 */ ["Libido Reinforcement B", "Gender Reversal B", "Asset Robustness B", "Age Reduction A", "Fluffy Ears", "Fluffy Tail", "Maximum Fluff", "Heat/Rut", "Lightweight", "Sex Switcheroo", "Futa Fun", "Blushing Virgin"],
+    /*  3 */ ["Submissiveness Rectification A", "Gender Reversal C", "Asset Robustness C", "Clothing Restriction B", "Power Dom", "20/20000000", "Comic Relief", "Equal Opportunity", "Absolute Pregnancy", "Absolute Birth Control", "Wacky Wombs", "Omnitool", "Gooey", "Rainbow Swirl", "Double Pepperoni", "Literal Blushing Virgin"],
+    /*  4 */ ["Libido Reinforcement C", "Lactation Rejuvenation A", "Asset Robustness D", "Age Reduction B", "Sleep Tight", "Sweet Dreams", "Hypno Happytime", "Crossdress Your Heart", "Lie Detector", "Megadontia", "Softie", "Hard Mode", "Lingual Leviathan", "Tipping the Scales", "Reptail", "Cold Blooded"],
+    /*  5 */ ["Libido Reinforcement D", "Gender Reversal D", "Pleasure Respecification A", "Clothing Restriction C", "Massacre Manicure", "DoS", "DoM", "Hijinks Ensue", "Flower Power", "Cellulose", "Chlorophyll", "Pheromones", "Carapacian", "Hemospectrum", "Wriggly Antennae", "Eggxellent"],
+    /*  6 */ ["Submissiveness Rectification B", "Lactation Rejuvenation B", "Pleasure Respecification B", "Age Reduction C", "Horny", "Drawing Spades", "Tattoo Tally", "Leaky", "Wandering Hands", "Semen Demon", "Quota", "In the Limelight"],
+    /*  7 */ ["Libido Reinforcement E", "Gender Reversal E", "Asset Robustness E", "Urine Reamplification A", "Barter System", "Shared Space", "Weakling", "Random Orgasms", "Beastly", "Creature of the Night", "Minish-ish", "Colossal-able"],
+    /*  8 */ ["Libido Reinforcement F", "Gender Reversal F", "Asset Robustness F", "Urine Reamplification B", "Eye on the Prize", "Deafening Silence", "Taciturn Turnaround", "Ampu-Q-tie", "Nose Goes", "Arm Army", "A Little Extra", "Null", "Seafolk", "Taken for Granite", "Double Trouble", "Conjoined"],
+    /*  9 */ ["Libido Reinforcement G", "Gender Reversal G", "Asset Robustness G", "Literalization", "Consent Dissent", "The Maxim", "Adverse Possession", "Erased", "Tickly Tentacles", "Eye-scream", "A Mouthful", "Below the Veil"],
+]>>
 
 <<set setup.cursesNegatedByNull = [
     "Double Pepperoni",

--- a/src/global.twee
+++ b/src/global.twee
@@ -336,8 +336,10 @@ You have $app.ears ears.<br>
 You are $app.realAge years old<<if $app.realAge != $app.appAge>>, but you appear to be $app.appAge years old<</if>><<if $eternalYouth < 9999>> and you will never appear to be any older due to your biological immortality granted by the Fountain of Youth<</if>>.
 <br><br>
 <<if $DaedalusEquip==true>> You appear to have two $relic73.variation wings sprouting from your back. However, in reality, this is the Daedalus Mechanism.<br><br><</if>>
-<<if $swapComp > -1>>
-	You are in the body originally belonging to $hiredCompanions[$swapComp].name and $hiredCompanions[$swapComp].name is in your old body.<br><br>
+<<if $companionSwitched == 'Twin'>>
+	You are in the body originally belonging to $companionTwin.name and $companionTwin.name is in your old body.<br><br>
+<<elseif $companionSwitched>>
+	You are in the body originally belonging to $companionSwitched and $companionSwitched is in your old body.<br><br>
 <</if>>
 
 <<if $app.subdom > 0>>
@@ -2018,8 +2020,12 @@ How many dubloons would you like to pay back?
 /* Get the persistent state for the active passage. */
 <<set _state = setup.passingTime()>>
 <<if !_state>>
-	/* If we aren't passing time yet, assume that the number of days was passed in the first argument. */
-	<<set _state = setup.startPassingTime(_args[0])>>
+	/* If we aren't passing time yet, check if the number of days was passed in the first argument. */
+	<<if typeof _args[0] == 'number'>>
+		<<set _state = setup.startPassingTime(passage(), _args[0])>>
+	<<else>> /* Otherwise, just pass 0 days. */
+		<<set _state = setup.startPassingTime(passage(), 0)>>
+	<</if>>
 <</if>>
 
 /* Check event triggers. */
@@ -2311,6 +2317,9 @@ How many dubloons would you like to pay back?
 			<<if $hexflame > 9>>
 				<<set $hexflame -= 1>>
 			<</if>>
+		<<elseif $atWaterSource>>
+			/* If we're currently at a source of clean water (e.g. layer 3 river or layer 5 oasis), drink from it. */
+			<<print `<<set $waterL${$currentLayer} += 1>>`>>
 		<<elseif !$forageWater>>
 			<<include "Drinking code">>
 		<<elseif !$abyssKnow>>
@@ -2390,7 +2399,7 @@ How many dubloons would you like to pay back?
 	<<if Math.round(_state.weightedDay) > Math.round(_state.weightedDayIndex)>>
 		Desperate to stave off starvation and dehydration, you spent an extra
 		<<print Math.round(_state.weightedDay) - Math.round(_state.weightedDayIndex)>>
-		days foraging, extending the time spent to <<print Math.round(_state.weightedDay)>> days!
+		days foraging, extending the time spent to <<print Math.round(_state.weightedDay)>> days!<br>
 	<</if>>
 
 	/* If we ended on a fractional day that should be rounded up, increment the time. */
@@ -2515,7 +2524,7 @@ You will first drink:<br>
 	How many days would you like to rest here?<br>
 	<<textbox "_campTime" "0">><br>
 	<<link "Set up camp and wait" `passage()`>>
-		<<set setup.startPassingTime(parseInt(_campTime, 10) || 0)>>
+		<<set setup.startPassingTime(passage(), Math.max(parseInt(_campTime, 10) || 0, 0))>>
 	<</link>><br><br>
 
 	<<link "Return to exploring the layer without waiting" `"Layer" + $currentLayer + " Hub"`>><</link>>

--- a/src/init.twee
+++ b/src/init.twee
@@ -94,10 +94,9 @@ document.documentElement.setAttribute("lang", "en");
 <<set $waterL7 = 0>> 
 <<set $waterL8 = 0>> 
 <<set $waterL9 = 0>> 
-<<set $iconUsed = 0>>
-<<set $brokerUsed = 0>>
-<<set $starUsed = 0>>
-<<set $swapComp = -1>>
+<<set $iconUsed = false>>
+<<set $brokerUsed = false>>
+<<set $starUsed = false>>
 <<set $mudHunt = 0>>
 <<set $bewitchBabies = 0>>
 <<set $dizzyCount = 0>>
@@ -106,6 +105,7 @@ document.documentElement.setAttribute("lang", "en");
 <<set $skewedForced = 0>>
 <<set $steadyForced = 0>>
 <<set $passTimeState = new Map()>>
+<<set $atWaterSource = false>>
 <<set $riverVisit = 0>>
 <<set $cut = 0>>
 <<set $light = 0>>
@@ -114,11 +114,11 @@ document.documentElement.setAttribute("lang", "en");
 <<set $rope = 0>>
 <<set $scuba = 0>>
 <<set $torchUse = 0>>
-<<set $purityUsed = 0>>
+<<set $purityUsed = false>>
 <<set $algalSize = 0>>
 <<set $oasisVisit = 0>>
 <<set $hexflame = 9>>
-<<set $mawuse = 0>>
+<<set $mawuse = false>>
 <<set $endSpectre = -1>>
 <<set $crumbleFluid = 0>>
 <<set $booby = 0>>

--- a/src/layer1.twee
+++ b/src/layer1.twee
@@ -124,7 +124,7 @@ Certain Relics possess straightforward uses that become readily apparent in spec
 
 <p>[[Continue exploring the first layer|Layer1 Hub]]</p>
 
-<<RelicGrid `["Star Compass", "Rømer Stones", "Creepy Doll", "Giddy Reaper", "Silk Twister", "Vertebra Key", "Chain of Lorelei", "Hive Tassel", "Smitten Mitt"]`>>
+<<RelicGrid `setup.relicsOnLayer[1]`>>
 
 <p>[[Continue exploring the first layer|Layer1 Hub]]</p>
 
@@ -244,13 +244,13 @@ You sit by the fire with your party and chat, the mood is pretty upbeat and opti
 
 <<nobr>>
 <<if $playerCurses.length > 0>>
-	<<if $iconUsed == 0>>
+	<<if !$iconUsed>>
 		Would you like to use the Icon of Mercy?<br><br>
 		[[Yes, use the Icon|Layer1 Icon]]<br>
-		<<else>>
+	<<else>>
 		You have already used the Icon of Mercy, you may not use it again.<br>
 	<</if>>
-	<<else>>
+<<else>>
 	You have no Curses to remove, there's no need to use the Icon.<br>
 <</if>>
 <</nobr>>
@@ -329,7 +329,7 @@ Descending to the next layer will take 2 days. How are your supplies of food and
 
 <<if !setup.passingTime()>>
 	<<AdjustedTravelTime "_travelTime" 2>>
-	<<set setup.startPassingTime(_travelTime)>>
+	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
 <<include "Layer1 Travel Events">>
@@ -480,6 +480,17 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 
 
 :: Layer1 Icon [layer1]
+<<nobr>>
+
+<<if !setup.passingTime()>>
+	<<AdjustedTravelTime "_travelTime" 3>>
+	<<set setup.startPassingTime(passage(), _travelTime)>>
+<</if>>
+
+<<include "Layer1 Travel Events">>
+
+<</nobr>>\
+<<if !setup.passingTime()>>\
 [img[setup.ImagePath+'Wonders/iconofmercy.png']]
 
 As you meander through the lush, verdant slopes of the first layer of the Abyss, your eyes catch a glint of something unusual, and you are drawn to a small clearing where the captivating figure of the Icon of Mercy stands. Awestruck, you approach the statue, taking in the exquisite craftsmanship and the elegant lines of her flowing dress. Her exposed breast seems to represent vulnerability and nurturing, and the feeling of comfort emanating from the statue is palpable.
@@ -490,16 +501,17 @@ A sudden realization dawns upon you: by touching the statue, you can remove one 
 
 Choose the Curse you wish to remove:
 <<nobr>>
-<<for $i = 0; $i < $playerCurses.length; $i++>>
-	<<capture $i>>
-		<<if !($playerCurses[$i].name == "Double Trouble" || $playerCurses[$i].name == "Conjoined")>>
-			<<print "[[$playerCurses[$i].name|Icon Removal][$temp to $i]]">><br>
-		<</if>>
-	<</capture>>
+<<for _i, _curse range $playerCurses>>
+	<<if _curse.name != 'Double Trouble' && _curse.name != 'Conjoined'>>
+		<<capture _i>>
+			&nbsp; [[_curse.name|Icon Removal][$temp = _i]]<br>
+		<</capture>>
+	<</if>>
 <</for>>
 <</nobr>>
 
-<<back>>
+[[Return to exploring layer 1|Layer1 Hub]]
+<</if>>
 
 
 :: Pick up the Star Compass [layer1]
@@ -972,14 +984,13 @@ But gradually, a newfound certainty washes over you - the realization that your 
 <</if>>
 
 
-:: Icon Removal [layer1]
-<<nobr>>
-<<set $corruption -= $playerCurses[$temp].corr>>
-<<set $iconUsed = 1>>
-<<AdjustedTravelTime "$tempTime" 3>><<PassTime $tempTime>>
-The Curse, $playerCurses[$temp].name, has been successfully removed and your corruption has been refunded.<br>
-<<RemoveCurse $playerCurses[$temp]>>
-<</nobr>>
+:: Icon Removal [layer1 nobr]
+<<set _curse = $playerCurses[$temp]>>
+<<set $iconUsed = true>>
+<<set $corruption -= _curse.corr>>
+<<RemoveCurse _curse>>
+The Curse, _curse.name, has been successfully removed and your corruption has been refunded.<br><br>
+
 [[Continue exploring the layer|Layer1 Hub]]
 
 
@@ -1021,7 +1032,7 @@ Traveling back to the surface from here will take 1 day, and will cost 10 corrup
 		<<set _multiplier = 1/2>>
 	<</if>>
 	<<AdjustedTravelTime "_travelTime" 1 false 0 _multiplier>>
-	<<set setup.startPassingTime(_travelTime)>>
+	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
 <<include "Layer1 Travel Events">>

--- a/src/layer2.twee
+++ b/src/layer2.twee
@@ -233,7 +233,7 @@ By default, your companions' reward for coming down here with you is the dubloon
 
 <p>[[Continue exploring the second layer|Layer2 Hub]]</p>
 
-<<RelicGrid `["Firmament Pigment", "Pearly Gates", "World Stone", "Forest's Gift", "Harmless Harmony", "Umbra Trident", "Event Horizon", "Heart-stealing Stole", "Effacing Asperity", "Wholly Ale", "Memoir Remnant", "Gleam Dazer"]`>>
+<<RelicGrid `setup.relicsOnLayer[2]`>>
 
 <p>[[Continue exploring the second layer|Layer2 Hub]]</p>
 
@@ -269,19 +269,19 @@ By default, your companions' reward for coming down here with you is the dubloon
 [img[setup.ImagePath+'Clipped-Fin/Abyss Diver Page 3-wonders.png']]
 
 <<nobr>>
-<<if ($visitL3 == 0) && ($brokerUsed == 0) && ($corruption > -100)>>
+<<if $visitL3 == 0 && !$brokerUsed && $corruption > -100>>
 	Would you like to use the Empty-handed Broker?<br>
 	[[Yes, use the Broker|Layer2 Broker]]
-	<<else>>
+<<else>>
 	You have already used the Empty-handed Broker or traveled further into the Abyss, you may not use it now.<br>
 <</if>>
 <</nobr>>
 
 <<nobr>>
-<<if ($starUsed == 0) && ($hiredCompanions.length > 0)>>
+<<if !$starUsed && $hiredCompanions.length > 0>>
 	Would you like to use the Fate-crossing Star?<br>
 	[[Yes, bathe in the Star's lake|Layer2 Star 1]]<br>
-	<<else>>
+<<else>>
 	You must have companions and have not already used the Fate-crossing Star before if you wish to swap bodies with someone.<br>
 <</if>>
 <</nobr>>
@@ -527,10 +527,20 @@ What type of fur would you like to gain?
 
 :: Layer2 Broker [layer2]
 <<nobr>>
-<<set $corruption += 100>>
-<<set $brokerUsed = 1>>
-<<AdjustedTravelTime "$tempTime" 2>><<PassTime $tempTime>>
-<</nobr>>
+
+<<if !setup.passingTime()>>
+	<<AdjustedTravelTime "_travelTime" 2>>
+	<<set setup.startPassingTime(passage(), _travelTime)>>
+<</if>>
+
+<<include "Layer2 Travel Events">>
+
+<</nobr>>\
+<<if !setup.passingTime()>>\
+<<nobr>>
+	<<set $corruption += 100>>
+	<<set $brokerUsed = true>>
+<</nobr>>\
 [img[setup.ImagePath+'Wonders/empty-handedbroker.png']]
 
 You press forward through the second layer as your seach from the Empty-handed Broker, and as you do, the dewdrops from above accumulate, each one adding to the symphony of droplets cascading down from the treetops. The once gentle drizzle intensifies into a monsoon, pounding against the soil and leaves, filling the air with the deafening roar of water.
@@ -544,9 +554,21 @@ As the chilling rain continues to pour down around you, you realize the weight o
 You have gained 100 corruption points, but you must always keep your corruptions points above 0 from now until the end of your journey. 
 
 [[Continue exploring the second layer|Layer2 Hub]]
+<</if>>
 
 
 :: Layer2 Star 1 [layer2]
+<<nobr>>
+
+<<if !setup.passingTime()>>
+	<<AdjustedTravelTime "_travelTime" 3>>
+	<<set setup.startPassingTime(passage(), _travelTime)>>
+<</if>>
+
+<<include "Layer2 Travel Events">>
+
+<</nobr>>\
+<<if !setup.passingTime()>>\
 [img[setup.ImagePath+'Wonders/fate-crossingstar.png']]
 
 You push through the dense foliage, seeking the site of the pond, until the sight of rugged rocks breaks the monotony of green. As you approach, you find a hidden gem: the Fate-crossing Star's pond. The water is a glistening, crystalline blue, its surface disturbed only by the faintest of ripples. The scent of freshness, a welcome contrast to the cloying jungle air, fills your nostrils.
@@ -558,30 +580,25 @@ As you immerse yourself, the sounds of the jungle seem to fade, replaced by the 
 When morning comes, you find yourself waking to an entirely different reality. The familiar weight of your body is gone, replaced by a foreign, alien sensation. You open your eyes and realize that you have swapped bodies with one of your companions. You look into a puddle on the ground and stare in disbelief at your own face, now looking back at you with equal astonishment.
 
 Whose body do you find yourself in?
-
 <<nobr>>
-<<for $i = 0; $i < $hiredCompanions.length; $i++>>
-	<<capture $i>>
-		<<print $hiredCompanions[$i].name>><<print " ">><<print "[[Switch|Layer2 Star 2][$temp to $i]]">><br>
+<<for _i, _companion range $hiredCompanions>>
+	<<capture _i>>
+		&nbsp; [[_companion.name|Layer2 Star 2][$temp = _i]]<br>
 	<</capture>>
 <</for>>
-<<if $aiSuggest==true>>
-	Ai [[Switch| AI switch end]]
+<<if setup.haveSmartphoneAI && $aiSuggest>>
+	Ai [[Switch|AI switch end]]
 <</if>>
 <</nobr>>
+<</if>>
+
 
 :: Layer2 Star 2 [layer2]
 <<nobr>>
-<<set $temp2 = $ocarryWeight>>
-<<set $ocarryWeight = $hiredCompanions[$temp].carry>>
+<<set $starUsed = true>>
 <<set $corruption += 70>>
-<<set $starUsed = 1>>
-<<set $swapComp = $temp>>
-<<AdjustedTravelTime "$tempTime" 3>><<PassTime $tempTime>>
-<<set $hiredCompanions[$swapComp].carry = $temp2>>
-<<CarryAdjust>>
-<<set _companionSwapHandle = $hiredCompanions[$swapComp]>>
-<</nobr>>
+<<set _companionSwapHandle = $hiredCompanions[$temp]>>
+<</nobr>>\
 You've woken up in the body of _companionSwapHandle.name! And _companionSwapHandle.name has woken up in your body!
 
 How do you feel? Did you ask your companion before the switch? Be prepared for your relationship to change if they didn't want this.
@@ -599,6 +616,7 @@ How do you feel? Did you ask your companion before the switch? Be prepared for y
 <<set _companionSwapHandle.ohair = $app.ohair>>
 <<set _companionSwapHandle.oskinColor = $app.oskinColor>>
 <<set _companionSwapHandle.oeyeColor = $app.oeyeColor>>
+<<set _companionSwapHandle.carry = $ocarryWeight>>
 <<set _companionSwapHandle.switch = true>>
 
 <<set $app.age = _copy.age>>
@@ -610,6 +628,7 @@ How do you feel? Did you ask your companion before the switch? Be prepared for y
 <<set $app.ohair = _copy.ohair>>
 <<set $app.oskinColor = _copy.oskinColor>>
 <<set $app.oeyeColor = _copy.oeyeColor>>
+<<set $ocarryWeight = _copy.carry>>
 <<set $app.switch = true>>
 
 <<set $app.desc += _copy.appDesc>>
@@ -1408,7 +1427,7 @@ A few tests and you can confirm you have pure water to fill your flasks with! No
 		<<set _multiplier = 1/2>>
 	<</if>>
 	<<AdjustedTravelTime "_travelTime" 4 false 0 _multiplier>>
-	<<set setup.startPassingTime(_travelTime)>>
+	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
 <<include "Layer2 Travel Events">>
@@ -1456,7 +1475,7 @@ A few tests and you can confirm you have pure water to fill your flasks with! No
 
 <<if !setup.passingTime()>>
 	<<AdjustedTravelTime "_travelTime" 5>>
-	<<set setup.startPassingTime(_travelTime)>>
+	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
 <<include "Layer2 Travel Events">>

--- a/src/layer3.twee
+++ b/src/layer3.twee
@@ -113,24 +113,45 @@ The Abyss has various bioluminescent moss, mushrooms, and so on scattered about,
 
 
 :: Layer3 Forage [image layer3]
+<<if setup.passingTime()>>
+	<<include "Layer3 Travel Events">>
+<</if>>\
+<<if !setup.passingTime()>>\
+<<checkTime>>
 [img[setup.ImagePath+'Clipped-Fin/Abyss Diver Page 4-foraging.png']]
 
 If you decide to start foraging for food or water, it means that you will not consume your stored food rations or water supply while consuming time on tasks in this layer, but you will not obtain more supplies by starting to forage here.
 
 <<nobr>>
 <<if $forageFood == 0>>
-	<<print "[[Start foraging for Crystalline Confectionaries for food|Layer3 Forage][$forageFood = 1]]">><br>
-	<<else>>
-	<<print "[[Stop foraging for food|Layer3 Forage][$forageFood = 0]]">><br>
+	[[Start foraging for Crystalline Confectionaries for food|Layer3 Forage][$forageFood = 1]]<br><br>
+<<else>>
+	[[Stop foraging for food|Layer3 Forage][$forageFood = 0]]<br><br>
 <</if>>
 <<if $items[2].count > 0>>
-[[Fill your empty flasks with water from Underground Rivers|Layer3 Flasks]]<br>
+	<<if $atWaterSource>>
+		[[Fill your empty flasks with water from the underground river|Layer3 Flasks]]<br><br>
+	<<else>>
+		[[Fill your empty flasks with water from underground rivers|Layer3 Flasks]]<br><br>
+	<</if>>
 <<else>>
-You need empty flasks to fill them with water from the Underground Rivers.<br>
+	<<if $atWaterSource>>
+		You need empty flasks to fill them with water from the underground river.<br><br>
+	<<else>>
+		[[Find an underground river to avoid using your water|Layer3 Flasks]]<br><br>
+	<</if>>
 <</if>>
-<</nobr>>
-
+<<if $atWaterSource>>
+	You can also wait at the underground river if you'd like to pass the time while waiting for something.<br>
+	How many days would you like to wait at the underground river?<br>
+	<<textbox "_waitTime" "0">>
+	<<link "Wait" `passage()`>>
+		<<set setup.startPassingTime(passage(), Math.max(parseInt(_waitTime, 10) || 0, 0))>>
+	<</link>><br><br>
+<</if>>
+<</nobr>>\
 [[Return to exploring the rest of the layer|Layer3 Hub]]
+<</if>>
 
 
 :: Layer3 Relics [layer3 cards nobr]
@@ -147,7 +168,7 @@ The Abyss is a huge place. The Relics listed in these sections are only a small 
 
 <p>[[Continue exploring the third layer|Layer3 Hub]]</p>
 
-<<RelicGrid `["Sibyl Blend", "Pangea Shaker", "From Seafoam", "Orbweaver", "Soulseeker", "Tranquility Knell", "Lightning Rook", "Acrobatic Accord", "Managed Misfortune", "Breathless Exhale", "Sharing Shears", "Rose-tinted Spectacles"]`>>
+<<RelicGrid `setup.relicsOnLayer[3]`>>
 
 <p>[[Continue exploring the third layer|Layer3 Hub]]</p>
 
@@ -197,18 +218,20 @@ Would you like to use the Gossamery Scales to gain dubloons based on your corrup
 Would you like to use the Gossamery Scales to gain corruption based on your dubloons?<br>
 [[Yes, use the Scales to gain corruption|Layer3 Scales 2]]<br><br>
 <<else>>
-You have already used the scales on your journey. You may not use them again.
+You have already used the scales on your journey. You may not use them again.<br><br>
 <</if>>
 <<if !$hiredCompanions.length>>
 	You must have companions if you would like to use the Skewed Shrine.<br><br>
 <<elseif $skewedForced < 4>>
 	Would you like to use the Skewed Shrine to give a Curse to one of your willing companions at the cost of <<print ($skewedUsed * 5)>> dubloons?<br>
 	<<link "Yes, use the Skewed Shrine to transfer a Curse" "Layer3 Skewed1a">>
-		<<AdjustedTravelTime "$tempTime" 3>><<PassTime $tempTime>>
+		<<AdjustedTravelTime "_travelTime" 3>>
+		<<set setup.startPassingTime('Layer3 Skewed1a', _travelTime)>>
 	<</link>><br><br>
 	Would you like to use the Skewed Shrine to force a Curse upon one of your unwilling companions at the cost of <<print ($skewedUsed * 5)>> dubloons?<br>
 	<<link "Yes, use the Skewed Shrine to force a Curse" "Layer3 Skewed 2a">>
-		<<AdjustedTravelTime "$tempTime" 3>><<PassTime $tempTime>>
+		<<AdjustedTravelTime "_travelTime" 3>>
+		<<set setup.startPassingTime('Layer3 Skewed 2a', _travelTime)>>
 	<</link>><br><br>
 <<else>>
 	None of your companions trust you at this shrine anymore. None will get close enough for you to use the shrine with them. They watch you with eyes full of fear and anger, as if they could bolt at any moment and leave you alone in the Abyss.<br><br>
@@ -287,7 +310,7 @@ In the deeper parts of the layer, a cold breeze occasionally blows through the c
 		<<set _multiplier = 1/2>>
 	<</if>>
 	<<AdjustedTravelTime "_travelTime" 6 false 0 _multiplier>>
-	<<set setup.startPassingTime(_travelTime)>>
+	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
 <<include "Layer3 Travel Events">>
@@ -309,11 +332,21 @@ In the deeper parts of the layer, a cold breeze occasionally blows through the c
 
 :: Layer3 Scales 1 [layer3]
 <<nobr>>
-<<set $temp = Math.round($corruption / 5)>>
-<<set $dubloons += $temp>>
-<<set $scalesUsed = 1>>
-<<AdjustedTravelTime "$tempTime" 2>><<PassTime $tempTime>>
-<</nobr>>
+
+<<if !setup.passingTime()>>
+	<<AdjustedTravelTime "_travelTime" 2>>
+	<<set setup.startPassingTime(passage(), _travelTime)>>
+<</if>>
+
+<<include "Layer3 Travel Events">>
+
+<</nobr>>\
+<<if !setup.passingTime()>>\
+<<nobr>>
+	<<set $temp = Math.round($corruption / 5)>>
+	<<set $dubloons += $temp>>
+	<<set $scalesUsed = 1>>
+<</nobr>>\
 [img[setup.ImagePath+'Wonders/gossameryscales.png']]
 
 The moment you touch the scales you feel a slight shock, almost like static. As you flinch away from them you notice a clinking sound of metal hitting metal. After only a blink you see some dubloons on the once-empty scales! After you count them, you find that you have gained $temp dubloons!
@@ -321,14 +354,25 @@ The moment you touch the scales you feel a slight shock, almost like static. As 
 Once you pick them up, the luster of the scales fades, indicating that they will not allow you to use their power again.
 
 [[Continue exploring the layer|Layer3 Hub]]
+<</if>>
 
 
 :: Layer3 Scales 2 [layer3]
 <<nobr>>
-<<set $temp = Math.round($dubloons / 5)>>
-<<set $corruption += $temp>>
-<<set $scalesUsed = 1>>
-<<AdjustedTravelTime "$tempTime" 2>><<PassTime $tempTime>>
+
+<<if !setup.passingTime()>>
+	<<AdjustedTravelTime "_travelTime" 2>>
+	<<set setup.startPassingTime(passage(), _travelTime)>>
+<</if>>
+
+<<include "Layer3 Travel Events">>
+
+<</nobr>>\
+<<if !setup.passingTime()>>\
+<<nobr>>
+	<<set $temp = Math.round($dubloons / 5)>>
+	<<set $corruption += $temp>>
+	<<set $scalesUsed = 1>>
 <</nobr>>
 [img[setup.ImagePath+'Wonders/gossameryscales.png']]
 
@@ -339,9 +383,16 @@ You have gained $temp corruption points!
 As you pick up the dubloons from the scales, you notice that the luster of the scales seems to have faded. Perhaps they only had tht final use left in them or perhaps they will only serve to help you one time. Regardless, you won't be using them again on this journey.
 
 [[Continue exploring the layer|Layer3 Hub]]
+<</if>>
 
 
 :: Layer3 Skewed1a [layer3]
+<<nobr>>
+
+<<include "Layer3 Travel Events">>
+
+<</nobr>>\
+<<if !setup.passingTime()>>\
 [img[setup.ImagePath+'Wonders/slantedshrine.png']]
 
 You turn a corner and suddenly find yourself in a small, dimly lit chamber. The air feels heavier here, as if the weight of the past lingers in every crevice. Before you stands the Skewed Shrine, an ancient and decaying testament to long-forgotten prayers. The wooden structure is warped and leaning, the floor falling away and the roof punctured with a sizable hole.
@@ -397,10 +448,19 @@ Which Curse would you like to transfer to your willing companion? It can't be to
 	<</for>>
 <</if>>
 <</nobr>>
+
 [[On second thought, maybe a more forceful approach is warrented|Layer3 Skewed 2a]]
 [[Return to exploring layer 3|Layer3 Hub]]
+<</if>>
+
 
 :: Layer3 Skewed 2a [layer3]
+<<nobr>>
+
+<<include "Layer3 Travel Events">>
+
+<</nobr>>\
+<<if !setup.passingTime()>>\
 [img[setup.ImagePath+'Wonders/slantedshrine.png']]
 
 You turn a corner and suddenly find yourself in a small, dimly lit chamber. The air feels heavier here, as if the weight of the past lingers in every crevice. Before you stands the Skewed Shrine, an ancient and decaying testament to long-forgotten prayers. The wooden structure is warped and leaning, the floor falling away and the roof punctured with a sizable hole.
@@ -417,15 +477,16 @@ Which Curse would you like to force upon your unwilling companion?
 <<if $dubloons < ($skewedUsed * 5)>>
 	You do not have enough dubloons for an offering.
 <<else>>
-	<<for _curse range $playerCurses>>
-		<<capture _curse>>
-			[[_curse.name|Layer3 Skewed2b][$temp to _curse]]<br>
+	<<for _i, _curse range $playerCurses>>
+		<<capture _i>>
+			[[_curse.name|Layer3 Skewed2b][$temp = _i]]<br>
 		<</capture>>
 	<</for>>
 <</if>>
 <</nobr>>
 
-<<return>>
+[[Return to exploring layer 3|Layer3 Hub]]
+<</if>>
 
 
 :: Take on Submissiveness Rectification A [layer3]
@@ -823,42 +884,49 @@ On the other hand, the idea of each encounter feeling like your first time holds
 
 :: Layer3 Flasks [layer3]
 <<nobr>>
-<<set $tempTime = (Math.max(4 -$abyssKnow - $riverVisit, 0))>>
-<<set $riverVisit = 1>>
 
-<<AdjustedTravelTime "$tempTime" $tempTime>><<PassTime $tempTime>>
+<<if !setup.passingTime() && !$atWaterSource>>
+	<<AdjustedTravelTime "_travelTime" 4 true `-$abyssKnow - $riverVisit`>>
+	<<set setup.startPassingTime(passage(), _travelTime)>>
+<</if>>
 
-<<for _i = 0; _i < 999; _i++>>
-	<<if $items[2].count > 0>>
-		<<set $items[3].count += 1>>
-		<<set $items[2].count -= 1>>
-		<<set $flaskMatrix[0]+=1>>
-		<<set $waterL3 += 1>>
-	<<else>>
-		<<break>>
-	<</if>>
-<</for>>
-<</nobr>>
+<<include "Layer3 Travel Events">>
 
+<</nobr>>\
+<<if !setup.passingTime()>>\
 [img[setup.ImagePath+'Foraging/undergroundrivers.png']]
-
-After spending $tempTime days searching for a river, you manage to eventually find one. In an effort to replenish the water it cost you to get here, you drink your fill and fill all your flasks, taking in the cool, fresh water.
+<<if $atWaterSource>>
+	You drink your fill and fill all your flasks, taking in the cool, fresh water.
+<<else>>
+	After spending several days searching for a river, you manage to eventually find one. In an effort to replenish the water it cost you to get here, you drink your fill and fill all your flasks, taking in the cool, fresh water.
+<</if>>
 
 As predicted, the water is pure and you can drink it without side effects!
-<<set $dehydrated = 0>>
+
 [[Return to exploring your food and water options on this layer|Layer3 Forage]]
+<<nobr>>
+	<<set $atWaterSource = true>>
+	<<set $riverVisit = 1>>
+	<<set _emptyFlasks = setup.item('Empty Flask').count>>
+	<<set setup.item('Filled Flask').count += _emptyFlasks>>
+	<<set $flaskMatrix[0] += _emptyFlasks>>
+	<<set $waterL3 += _emptyFlasks>>
+	<<set setup.item('Empty Flask').count = 0>>
+	<<set $dehydrated = 0>>
+<</nobr>>\
+<</if>>
 
 
 :: Layer3 Skewed2b [layer3]
 [img[setup.ImagePath+'Wonders/slantedshrine.png']]
 
-Which companion would you like to force the Curse of $temp.name upon?
+Which companion would you like to force the Curse of $playerCurses[$temp].name upon?
 
 The magic of the shrine wisps through the air menacingly as your victim struggles helplessly.
 
 <<nobr>>
-<<set _curse = $temp>>
-<<for _companion range $hiredCompanions>>
+<<set _curse = $playerCurses[$temp]>>
+<<for _i, _companion range $hiredCompanions>>
 	<<set _flag = false>>
 	<<set _tempName = _companion.name>>
 
@@ -874,7 +942,7 @@ The magic of the shrine wisps through the air menacingly as your victim struggle
 	<</switch>>
 
 	<<if _flag>>
-		<<capture _companion _tempName>>
+		<<capture _companion _i _tempName>>
 			<<set _choiceText = "Transfer to " + _tempName>>
 			<<link _choiceText "Layer3 Skewed Apply">>
 				<<set _companion.curses.push(_curse)>>
@@ -887,7 +955,7 @@ The magic of the shrine wisps through the air menacingly as your victim struggle
 				<<set $dubloons -= ($skewedUsed * 5)>>
 				<<set $skewedUsed += 1>>
 
-				<<set $temp2 = _companion>>
+				<<set $temp2 = _i>>
 			<</link>><br>
 		<</capture>>
 	<</if>>
@@ -900,7 +968,7 @@ The magic of the shrine wisps through the air menacingly as your victim struggle
 
 <<nobr>>
 <<set $skewedForced += 1>>
-<<set _companionName = $temp2.name>>
+<<set _companionName = $hiredCompanions[$temp2].name>>
 <<set _affectionPenalty = 6 - $hsswear>>
 <<include "Companion Mistreatment Reaction">>
 <</nobr>>
@@ -1082,7 +1150,7 @@ Please enter a new eye color:
 
 <<if !setup.passingTime()>>
 	<<AdjustedTravelTime "_travelTime" 6>>
-	<<set setup.startPassingTime(_travelTime)>>
+	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
 <<include "Layer3 Travel Events">>

--- a/src/layer4.twee
+++ b/src/layer4.twee
@@ -200,7 +200,7 @@ The Brave Vector Relic you can find here is a perfect example of something you m
 
 <p>[[Continue exploring the fourth layer|Layer4 Hub]]</p>
 
-<<RelicGrid `["Ghost-righter Writing Down", "Gilded Prison", "Omoikane Circuit", "Afar Wanderer", "Kin Shifter", "Brave Vector", "Devil's Own", "Verve Cell","Vessel Vivisector", "Sated Artist", "Timekeeper's Keepsake", "Creator's Bolt", "Perpetual Repose", "Toral Wave", "Flamel's Folly"]`>>
+<<RelicGrid `setup.relicsOnLayer[4]`>>
 
 <p>[[Continue exploring the fourth layer|Layer4 Hub]]</p>
 
@@ -240,17 +240,19 @@ The Brave Vector Relic you can find here is a perfect example of something you m
 <<elseif $steadyForced < 4>>
 	Would you like to use the Steady Shrine to copy a Curse to one of your willing companions at the cost of <<print ($skewedUsed * 5)>> dubloons?<br>
 	<<link "Yes, use the Steady Shrine to copy a Curse" "Layer4 Steady1a">>
-		<<AdjustedTravelTime "$tempTime" 3>><<PassTime $tempTime>>
+		<<AdjustedTravelTime "_travelTime" 3>>
+		<<set setup.startPassingTime('Layer4 Steady1a', _travelTime)>>
 	<</link>><br><br>
 	Would you like to use the Steady Shrine to forcibly copy a Curse onto one of your unwilling companions at the cost of <<print ($skewedUsed * 5)>> dubloons?<br>
 	<<link "Yes, use the Steady Shrine to forcibly copy a Curse" "Layer4 Steady 2a">>
-		<<AdjustedTravelTime "$tempTime" 3>><<PassTime $tempTime>>
+		<<AdjustedTravelTime "_travelTime" 3>>
+		<<set setup.startPassingTime('Layer4 Steady 2a', _travelTime)>>
 	<</link>><br><br>
 <<else>>
 	None of your companions trust you at this shrine anymore. None will get close enough for you to use the shrine with them. They watch you with eyes full of fear and anger, as if they could bolt at any moment and leave you alone in the Abyss.<br><br>
 <</if>>
 
-<<if ($purityUsed == 0)>>
+<<if !$purityUsed>>
 	Would you like to travel to the Purity Tree?<br>
 	[[Yes, choose what you want to do with the tree|Layer4 Purity 1]]<br><br>
 	<<else>>
@@ -716,6 +718,12 @@ Using your knowledge of the Abyss, you specifically look to make sure you can ge
 
 
 :: Layer4 Steady1a [layer4]
+<<nobr>>
+
+<<include "Layer4 Travel Events">>
+
+<</nobr>>\
+<<if !setup.passingTime()>>\
 [img[setup.ImagePath+'Wonders/steadyshrine.png']]
 
 As you draw nearer to the shrine, the structure's true nature reveals itself: an ancient, well-preserved shrine. Awe and relief wash over you as you take in the majesty of the Steady Shrine. The wood gleams with a warm, inviting luster, its finely carved details whispering tales of hope and perseverance.
@@ -772,10 +780,19 @@ Which Curse would you like to transfer to your willing companion? It can't be to
 	<</for>>
 <</if>>
 <</nobr>>
+
 [[On second thought, maybe a more forceful approach is warrented|Layer4 Steady 2a]]
 [[Return to exploring layer 4|Layer4 Hub]]
+<</if>>
+
 
 :: Layer4 Steady 2a [layer4]
+<<nobr>>
+
+<<include "Layer4 Travel Events">>
+
+<</nobr>>\
+<<if !setup.passingTime()>>\
 [img[setup.ImagePath+'Wonders/steadyshrine.png']]
 
 As you draw nearer to the shrine, the structure's true nature reveals itself: an ancient, well-preserved shrine. Awe and relief wash over you as you take in the majesty of the Steady Shrine. The wood gleams with a warm, inviting luster, its finely carved details whispering tales of hope and perseverance.
@@ -796,23 +813,30 @@ Which Curse would you like to forcibly copy onto your unwilling companion?
 <<if $dubloons < ($skewedUsed * 5)>>
 	You do not have enough dubloons for an offering.
 <<else>>
-	<<for _curse range $playerCurses>>
-		<<capture _curse>>
-			[[_curse.name|Layer4 Steady2b][$temp to _curse]]<br>
+	<<for _i, _curse range $playerCurses>>
+		<<capture _i>>
+			[[_curse.name|Layer4 Steady2b][$temp = _i]]<br>
 		<</capture>>
 	<</for>>
 <</if>>
 <</nobr>>
 
-<<return>>
-
+[[Return to exploring layer 4|Layer4 Hub]]
+<</if>>
 
 
 :: Layer4 Purity 1 [layer4]
 <<nobr>>
-<<set $purityUsed = 1>>
-<<AdjustedTravelTime "$tempTime" 5>><<PassTime $tempTime>>
-<</nobr>>
+
+<<if !setup.passingTime()>>
+	<<AdjustedTravelTime "_travelTime" 5>>
+	<<set setup.startPassingTime(passage(), _travelTime)>>
+<</if>>
+
+<<include "Layer4 Travel Events">>
+
+<</nobr>>\
+<<if !setup.passingTime()>>\
 [img[setup.ImagePath+'Wonders/puritytree.png']]
 
 As you trudge through the biting cold and the relentless, swirling winds, the endless expanse of snow and ice begins to blur together. The Miasmal light casts eerie shadows across the landscape, and the numbing chill penetrates even the thickest of clothing. Just when hope seems all but lost, you spot a faint glow in the distance, cutting through the thick fog like a beacon.
@@ -826,27 +850,29 @@ You consider your options carefully, knowing that the wood of the Purity Tree ho
 What would you like to do with the Purity Tree?
 <<if setup.haveCuttingTool>>
 You can chop down the dead purity tree and use the 4 pieces to make crude protective gear for a total of +60 corruption immediately.
-[[Chop down the tree and make crude protective gear|Layer4 Hub][$corruption += 60]]
+[[Chop down the tree and make crude protective gear|Layer4 Hub][$purityUsed = true, $corruption += 60]]
 
 You could also chop down the tree and save the wood pieces as Relics, which you can either bring back to the surface and sell for 35 dubloons each or use the Relic Workshop to gain +25 corruption per section of wood (100 total).
-[[Chop down the tree and save the pieces to use them on the surface|Layer4 Hub][$ownedRelics.push($purityPlank), $ownedRelics.push($purityPlank), $ownedRelics.push($purityPlank), $ownedRelics.push($purityPlank)]]
+[[Chop down the tree and save the pieces to use them on the surface|Layer4 Hub][$purityUsed = true, $ownedRelics.push($purityPlank, $purityPlank, $purityPlank, $purityPlank)]]
 <</if>>\
 
 If you can't or don't want to cut down the tree, you can burn it down and bathe in the raw cleansing smoke to gain +20 corruption a single time.
-[[Burn down the tree and bathe in its smoke|Layer4 Hub][$corruption += 20]]
+[[Burn down the tree and bathe in its smoke|Layer4 Hub][$purityUsed = true, $corruption += 20]]
 
-<<back>>
+[[Return to exploring layer 4|Layer4 Hub]]
+<</if>>
+
 
 :: Layer4 Steady2b [layer4]
 [img[setup.ImagePath+'Wonders/steadyshrine.png']]
 
-Which companion would you like to forcibly copy the Curse of $temp.name onto?
+Which companion would you like to forcibly copy the Curse of $playerCurses[$temp].name onto?
 
 The magic of the shrine wisps through the air menacingly as your victim struggles helplessly.
 
 <<nobr>>
-<<set _curse = $temp>>
-<<for _companion range $hiredCompanions>>
+<<set _curse = $playerCurses[$temp]>>
+<<for _i, _companion range $hiredCompanions>>
 	<<set _flag = false>>
 	<<set _tempName = _companion.name>>
 
@@ -862,7 +888,7 @@ The magic of the shrine wisps through the air menacingly as your victim struggle
 	<</switch>>
 
 	<<if _flag>>
-		<<capture _companion _tempName>>
+		<<capture _companion _i _tempName>>
 			<<set _choiceText = "Transfer to " + _tempName>>
 			<<link _choiceText "Layer4 Steady Apply">>
 				<<set _companion.curses.push(_curse)>>
@@ -876,7 +902,7 @@ The magic of the shrine wisps through the air menacingly as your victim struggle
 				<<set $dubloons -= ($skewedUsed * 5)>>
 				<<set $skewedUsed += 1>>
 
-				<<set $temp2 = _companion>>
+				<<set $temp2 = _i>>
 			<</link>><br>
 		<</capture>>
 	<</if>>
@@ -889,7 +915,7 @@ The magic of the shrine wisps through the air menacingly as your victim struggle
 
 <<nobr>>
 <<set $skewedForced += 1>>
-<<set _companionName = $temp2.name>>
+<<set _companionName = $hiredCompanions[$temp2].name>>
 <<set _affectionPenalty = 5 - $hsswear>>
 <<include "Companion Mistreatment Reaction">>
 <</nobr>>
@@ -1234,7 +1260,7 @@ Your hands reach a small crevasse, offering a much-needed respite from the climb
 		<<set _multiplier = 1/2>>
 	<</if>>
 	<<AdjustedTravelTime "_travelTime" 7 false 0 _multiplier>>
-	<<set setup.startPassingTime(_travelTime)>>
+	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
 <<include "Layer4 Travel Events">>
@@ -1259,7 +1285,7 @@ Your hands reach a small crevasse, offering a much-needed respite from the climb
 
 <<if !setup.passingTime()>>
 	<<AdjustedTravelTime "_travelTime" `setup.haveRope ? 8 : 19`>>
-	<<set setup.startPassingTime(_travelTime)>>
+	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
 <<include "Layer4 Travel Events">>

--- a/src/layer5.twee
+++ b/src/layer5.twee
@@ -230,55 +230,44 @@ How would you like to use Cherry's chaotic luck ability?
 
 
 :: Layer5 Forage [image layer5]
-<<if $timeL5T1 < 8 && $timeL5T2 < 11>>[img[setup.ImagePath+'Clipped-Fin/Abyss Diver Page 6-foraging.png']]
+<<if setup.passingTime()>>
+	<<include "Layer5 Travel Events">>
+<</if>>\
+<<if !setup.passingTime()>>\
+<<checkTime>>
+[img[setup.ImagePath+'Clipped-Fin/Abyss Diver Page 6-foraging.png']]
 
 If you decide to start foraging for food or water, it means that you will not consume your stored food rations or water supply while consuming time on tasks in this layer, but you will not obtain more supplies by starting to forage here.
 
 <<nobr>>
 <<if $forageFood == 0>>
-	<<print "[[Start foraging for Crumbleweed for food|Layer5 Forage][$forageFood = 1]]">><br><br>
-	<<else>>
-	<<print "[[Stop foraging for food|Layer5 Forage][$forageFood = 0]]">><br><br>
+	[[Start foraging for Crumbleweed for food|Layer5 Forage][$forageFood = 1]]<br><br>
+<<else>>
+	[[Stop foraging for food|Layer5 Forage][$forageFood = 0]]<br><br>
 <</if>>
 <<if $items[2].count > 0>>
-[[Fill your empty flasks with water from an Oasis|Layer5 Flasks]]<br><br>
-<<else>>
-You need empty flasks to fill them with water from the Oasis.<br><br>
-<</if>>
-You can also wait at the Oasis if you'd like to pass the time while waiting for something. How many days would you like to wait at the oasis?<br>
-<<textbox "$temp" "0">>
-<<nobr>><<link "Wait" "Layer5 Forage">>
-	<<if $items[2].count + $items[3].count >= 5>>
-		<<for $i = 0; $i < 999; $i++>>
-			<<if $items[2].count > 0>>
-				<<set $items[3].count += 1>>
-				<<set $items[2].count -= 1>>
-				<<set $waterL5 += 1>>
-			<<else>>
-				<<break>>
-			<</if>>
-		<</for>>
+	<<if $atWaterSource>>
+		[[Fill your empty flasks with water from the oasis|Layer5 Flasks]]<br><br>
 	<<else>>
-		<<set $items[3].count = $items[2].count + $items[3].count>>
-		<<set $items[2].count = 0>>
-		<<set $items[0].count += (5 - $items[3].count)>>
+		[[Fill your empty flasks with water from an oasis|Layer5 Flasks]]<br><br>
 	<</if>>
-	<<PassTime `parseInt($temp, 10)`>>
-<</link>><br><br><</nobr>>
-<</nobr>>
-
-[[Return to exploring the rest of the layer|Layer5 Hub]]<<elseif $timeL5T1 < 8>>
-<<include "Layer5 Borer Encounter">>
-
-[[Deal with the Dune Devouring Borer|Layer5 Threat2][$returnPassage = "Layer5 Hub"]]
 <<else>>
-When you wake up in the morning, you hear an enormous amount of buzzing in the air, luckily you managed to stay out of the swarm when you woke up, but you'll need to decide what to do with the swarm today.
-
-[[Deal with the Mayfly Scuttler|Layer5 Threat1][$returnPassage = "Layer5 Hub"]]<<if $ownedRelics.some(e => e.name === "Breathless Exhale")>>
-
-The radiant sun empowers your Breathless Exhale Relic, its energy pulsating within your grasp. You can sense the potential of the Relic, trembling with anticipation, ready to alter the wind's course and drive the insects away from you.
-[[Summon a powerful gust to drive the swarm away from you|Layer5 Hub][$timeL5T1 -= 8]]
+	<<if $atWaterSource>>
+		You need empty flasks to fill them with water from the oasis.<br><br>
+	<<else>>
+		[[Find an oasis to avoid using your water|Layer5 Flasks]]<br><br>
+	<</if>>
 <</if>>
+<<if $atWaterSource>>
+	You can also wait at the oasis if you'd like to pass the time while waiting for something.<br>
+	How many days would you like to wait at the oasis?<br>
+	<<textbox "_waitTime" "0">>
+	<<link "Wait" `passage()`>>
+		<<set setup.startPassingTime(passage(), Math.max(parseInt(_waitTime, 10) || 0, 0))>>
+	<</link>><br><br>
+<</if>>
+<</nobr>>\
+[[Return to exploring the rest of the layer|Layer5 Hub]]
 <</if>>
 
 
@@ -309,7 +298,7 @@ You do not have a medkit to cure your status condition.<br>
 
 <div class="cards-grid">
 <<set _totalRelics = $ownedRelics.concat($soldRelics)>>
-<<set _layerRelics = ["Pocket Hoard", "Sunbeam", "Moonwatcher", "Siren's Call", "Zelus Band", "Everhevea", "Reflex Emblem", "Twin Polaris", "Superpositional Skewer", "Empath Coil", "Heavenly Merrymaker", "Vain Sculpt"]>>
+<<set _layerRelics = setup.relicsOnLayer[5]>>
 <<for _i = 0; _i < _layerRelics.length; _i++>>
 <div>
 <<set _name = _layerRelics[_i]>>
@@ -411,8 +400,10 @@ Do you want to walk to the Mirage Vault to activate it for the first time?
 Do you want to check on the Mirage Vault and see if it's open?
 <</if>>
 
-[[Walk to the Mirage Vault door|Layer5 Vault]]
-
+<<link "Walk to the Mirage Vault door" "Layer5 Vault">>
+	<<AdjustedTravelTime "_travelTime" 3>>
+	<<set setup.startPassingTime('Layer5 Vault', _travelTime)>>
+<</link>>
 
 <<back>>
 
@@ -457,34 +448,36 @@ Layer 5 is the last layer that anyone on the surface currently has any reliable 
 
 :: Layer5 Flasks [layer5]
 <<nobr>>
-<<set $oasisVisit = 1>>
-<<if $status.duration > 0>>
-	<<set $status.duration -= 1>>
-	<<else>>
-	<<set $status.penalty = 0>>
+
+<<if !setup.passingTime() && !$atWaterSource>>
+	<<AdjustedTravelTime "_travelTime" 7 true `-$abyssKnow - 2 * $oasisVisit`>>
+	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
-<<set $tempTime = (Math.max(4 - ($oasisVisit * 2) - $abyssKnow, 0))>>
-<<AdjustedTravelTime "$tempTime" $tempTime>><<PassTime $tempTime>>
 
-<<for $i = 0; $i < 999; $i++>>
-	<<if $items[2].count > 0>>
-		<<set $items[3].count += 1>>
-		<<set $items[2].count -= 1>>
-		<<set $waterL5 += 1>>
-		<<set $flaskMatrix[0]+=1>>
-	<<else>>
-		<<break>>
-	<</if>>
-<</for>>
-<</nobr>>
+<<include "Layer5 Travel Events">>
 
+<</nobr>>\
+<<if !setup.passingTime()>>\
 [img[setup.ImagePath+'Foraging/oasis.png']]
-
-After spending $tempTime days searching for an oasis, you manage to eventually find one. In an effort to replenish the water it cost you to get here, you fill all your flasks, taking in the cool, fresh water, a rare relief from the punishing heat and dryness of this layer.
-
+<<if $atWaterSource>>
+	You fill all your flasks, taking in the cool, fresh water, a rare relief from the punishing heat and dryness of this layer.
+<<else>>
+	After spending several days searching for an oasis, you manage to eventually find one. In an effort to replenish the water it cost you to get here, you fill all your flasks, taking in the cool, fresh water, a rare relief from the punishing heat and dryness of this layer.
+<</if>>
 As predicted, the water is pure and you can drink it without side effects!
 
 [[Return to exploring your food and water options on this layer|Layer5 Forage]]
+<<nobr>>
+	<<set $atWaterSource = true>>
+	<<set $oasisVisit = 1>>
+	<<set _emptyFlasks = setup.item('Empty Flask').count>>
+	<<set setup.item('Filled Flask').count += _emptyFlasks>>
+	<<set $flaskMatrix[0] += _emptyFlasks>>
+	<<set $waterL5 += _emptyFlasks>>
+	<<set setup.item('Empty Flask').count = 0>>
+	<<set $dehydrated = 0>>
+<</nobr>>\
+<</if>>
 
 
 :: Layer5 Booby [layer5]
@@ -1360,8 +1353,16 @@ Please enter your new exoskeleton color:
 
 :: Layer5 Tunnel [layer5]
 <<nobr>>
-<<AdjustedTravelTime "$tempTime" 2>><<PassTime $tempTime>>
-<</nobr>>
+
+<<if !setup.passingTime()>>
+	<<AdjustedTravelTime "_travelTime" 2>>
+	<<set setup.startPassingTime(passage(), _travelTime)>>
+<</if>>
+
+<<include "Layer5 Travel Events">>
+
+<</nobr>>\
+<<if !setup.passingTime()>>\
 [img[setup.ImagePath+'Wonders/one-sidedtunnel.png']]
 
 After walking through the tunnel for about 5 or 6 hours (it's hard to precisely keep track in there), you find yourself back at the same entrance you started walking into, despite absolutely never turning around.
@@ -1407,63 +1408,51 @@ Testing your Pocket Hoard, you stick a hand into the pink rucksack, but find you
 	<<set $items[7].count += 1>>
 <</if>>
 <</nobr>>
+<</if>>
 
 
 :: Layer5 Vault [layer5]
-<<if $timeL5T1 < 8 && $timeL5T2 < 11>>[img[setup.ImagePath+'Wonders/miragevault.png']]
 <<nobr>>
-<<if $vaultWait == 0>>
-	<<AdjustedTravelTime "$tempTime" 3>><<PassTime $tempTime>>
-<<else>>
-	<<set $vaultWait = 0>>
-<</if>>
+
+<<include "Layer5 Travel Events">>
+
+<</nobr>>\
+<<if !setup.passingTime()>>\
+[img[setup.ImagePath+'Wonders/miragevault.png']]
+<<nobr>>
 <<if $vaultTimer == 0>>
-<<set $vaultTimer = $time>>
-<br><br> You touch your hand against the ancient door and the number 60 appears on it, as if there was either a very high-resolution LCD inside the glass or some magic inside it had awakened by your touch.
+	<<set $vaultTimer = $time + 60>>
+	<br><br>You touch your hand against the ancient door and the number 60 appears on it, as if there was either a very high-resolution LCD inside the glass or some magic inside it had awakened by your touch.
 <</if>>
 <</nobr>>
-<<if (60 - $time + $vaultTimer) > -6>>
-The timer on the door reads <<print (60 - $time + $vaultTimer)>>.
+<<if $vaultTimer - $time > 0>>
+	The timer on the door reads <<print $vaultTimer - $time>>.
 
-You can wait here for a while if you'd like to check when the door is open. If you'd like to wait, enter the number of days you'd like to wait and choose to wait.
-<<textbox "$temp" "0">>
-<<nobr>><<link "Wait" "Layer5 Vault">>
-	<<set $vaultWait = 1>>
-	<<PassTime `parseInt($temp, 10)`>>
-<</link>><br><br><</nobr>>
+	You can wait here for a while if you'd like to check when the door is open. If you'd like to wait, enter the number of days you'd like to wait and choose to wait.
+	<<textbox "_waitTime" "0">>
+	<<link "Wait" `passage()`>>
+		<<set setup.startPassingTime(passage(), Math.max(parseInt(_waitTime, 10) || 0, 0))>>
+	<</link>>
 
-<<if (60 - $time + $vaultTimer) > 0>>
-The door remains locked. You must wait until the timer is between 0 and -5 for it to open and reveal the treasures within.
-<<elseif (60 - $time + $vaultTimer) < 1 && (60 - $time + $vaultTimer) > -6>>
-The door to the Vault has opened! When you touch the panel, the doors gently open to reveal the treasures within and aid you on our journey.
+	The door remains locked. You must wait until the timer is between 0 and -5 for it to open and reveal the treasures within.
+<<elseif -5 <= $vaultTimer - $time && $vaultTimer - $time <= 0>>
+	The door to the Vault has opened! When you touch the panel, the doors gently open to reveal the treasures within and aid you on our journey.
 
-Inside the vault you find 200 dubloons, 9 days of food rations, 9 days of bottled water, and 3 medkits!
+	Inside the vault you find 200 dubloons, 9 days of food rations, 9 days of bottled water, and 3 medkits!
 
-You pick up your haul and continue forward through the Abyss, morale boosted by the successful vault expedition.
-<<nobr>>
-<<set $items[0].count += 9>>
-<<set $items[1].count += 9>>
-<<set $items[4].count += 3>>
-<<set $dubloons += 200>>
-<<set $vaultFound = 1>>
-<</nobr>>
-<</if>>
+	You pick up your haul and continue forward through the Abyss, morale boosted by the successful vault expedition.
+	<<nobr>>
+		<<set $items[0].count += 9>>
+		<<set $items[1].count += 9>>
+		<<set $items[4].count += 3>>
+		<<set $dubloons += 200>>
+		<<set $vaultFound = 1>>
+	<</nobr>>
 <<else>>
-The timer has passed its endpoint, there is no more door and no more vault that you can find. Was it ever real? There's no way to know, but you can tell it certainly isn't here now.
+	The timer has passed its endpoint, there is no more door and no more vault that you can find. Was it ever real? There's no way to know, but you can tell it certainly isn't here now.
 <</if>>
 
-[[Return to exploring level 5|Layer5 Hub]]<<elseif $timeL5T1 < 8>>
-<<include "Layer5 Borer Encounter">>
-
-[[Deal with the Dune Devouring Borer|Layer5 Threat2][$returnPassage = "Layer5 Hub"]]
-<<else>>
-When you wake up in the morning, you hear an enormous amount of buzzing in the air, luckily you managed to stay out of the swarm when you woke up, but you'll need to decide what to do with the swarm today.
-
-[[Deal with the Mayfly Scuttler|Layer5 Threat1][$returnPassage = "Layer5 Hub"]]<<if $ownedRelics.some(e => e.name === "Breathless Exhale")>>
-
-The radiant sun empowers your Breathless Exhale Relic, its energy pulsating within your grasp. You can sense the potential of the Relic, trembling with anticipation, ready to alter the wind's course and drive the insects away from you.
-[[Summon a powerful gust to drive the swarm away from you|Layer5 Hub][$timeL5T1 -= 8]]
-<</if>>
+[[Return to exploring level 5|Layer5 Hub]]
 <</if>>
 
 
@@ -1499,7 +1488,7 @@ The radiant sun empowers your Breathless Exhale Relic, its energy pulsating with
 		<<set _multiplier = 1/2>>
 	<</if>>
 	<<AdjustedTravelTime "_travelTime" `setup.haveRope ? 11 : 24` false 0 _multiplier>>
-	<<set setup.startPassingTime(_travelTime)>>
+	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
 <<include "Layer5 Travel Events">>
@@ -1520,15 +1509,18 @@ The radiant sun empowers your Breathless Exhale Relic, its energy pulsating with
 
 
 :: Layer5 Threat1 [layer5]
-<<PassTime 1>>\
 <<set $timeL5T1 -= 8>>\
 [img[setup.ImagePath+'Threats/mayflyscuttler.png']]
 
 When you wake up in the morning, you hear an enormous amount of buzzing in the air, luckily you managed to stay out of the swarm when you woke up. They scarlet bugs produce a potent aphrodisiac venom, so if you choose to go out into the swarm, and succumb to the venom to participate in a day of sexual debauchery. On the other hand, you can stay in one of the ruins for the day and avoid the swarms altogether. Either choice will cost you one day.
 
-[[Walk out into the swarm and enjoy the sexual festivities|Layer5 Mayfly Scuttler Sexual Activities]]
+<<link "Walk out into the swarm and enjoy the sexual festivities" "Layer5 Mayfly Scuttler Sexual Activities">>
+	<<PassTime 1>>
+<</link>>
 
-[[Hide out in the ruins for the day|$returnPassage]]
+<<link "Hide out in the ruins for the day" `$returnPassage`>>
+	<<PassTime 1>>
+<</link>>
 
 Use the following option only if you have specifically considered your inventory and made a plan of how to use what you have to rid of or avoid these pests.
 [[Use a combination of Relics not mentioned above you believe would be able to get rid of the swarm|$returnPassage]]
@@ -1539,7 +1531,7 @@ Use the following option only if you have specifically considered your inventory
 
 <<if !setup.passingTime()>>
 	<<AdjustedTravelTime "_travelTime" 13>>
-	<<set setup.startPassingTime(_travelTime)>>
+	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
 <<include "Layer5 Travel Events">>

--- a/src/layer6.twee
+++ b/src/layer6.twee
@@ -152,7 +152,7 @@ If you decide to start foraging for food or water, it means that you will not co
 
 <p>[[Continue exploring the sixth layer|Layer6 Hub]]</p>
 
-<<RelicGrid `["Ring of the Devourer", "Pulse Bloom", "Out of Mind", "Still Film", "Forbidden Grimoire", "Luminous Phantasmagoria", "Relativity Eye", "Return to Sender", "Yliaster Materia", "Aeonglass", "Apparatus Diaboli", "Heavy is the Head"]`>>
+<<RelicGrid `setup.relicsOnLayer[6]`>>
 
 <p>[[Continue exploring the sixth layer|Layer6 Hub]]</p>
 
@@ -193,7 +193,10 @@ If you decide to start foraging for food or water, it means that you will not co
 
 Do you want to approach the Maw of Kimaris to get a copy of a Relic from a higher layer?
 
-[[Approach the Maw|Layer6 Maw1]]
+<<link "Approach the Maw" "Layer6 Maw1">>
+	<<AdjustedTravelTime "_travelTime" 3>>
+	<<set setup.startPassingTime('Layer6 Maw1', _travelTime)>>
+<</link>>
 
 
 <<back>>
@@ -267,38 +270,47 @@ There is a very easily accessible source of water on this layer, the River Dycx,
 
 
 :: Layer6 Maw1 [image layer6]
-[img[setup.ImagePath+'Clipped-Fin/Abyss Diver Page 7-wonders.png']]
 <<nobr>>
-<<set _totalRelics = $ownedRelics.concat($soldRelics)>>
-<<AdjustedTravelTime "$tempTime" 3>><<PassTime $tempTime>>
-<</nobr>><<if $mawUse == 0>>
-As you press through the thicket of incessantly writhing tentacles, the tentacles subtly change their rhythm. The heat has long ago seared your sense of comfort away, replaced with a strange duality of torment and transcendence. The harsh, yet strangely savory, scent of burning flesh punctuates the air, becoming richer and more distinct. Suddenly, the sea of tentacles parts like the Red Sea before Moses, revealing a broad expanse of barren rock.
 
-Before you yawns the Maw of Kimaris, a monstrous mouth carved into the very earth. The sight seizes your breath, casting you into a sudden, terrible silence. The Maw seems to pulse with a horrifying life of its own, promising an eternal fall to any who would dare to trip at its precipice.
+<<include "Layer6 Travel Events">>
+
+<</nobr>>\
+<<if !setup.passingTime()>>\
+[img[setup.ImagePath+'Clipped-Fin/Abyss Diver Page 7-wonders.png']]
+<<if !$mawUse>>
+	As you press through the thicket of incessantly writhing tentacles, the tentacles subtly change their rhythm. The heat has long ago seared your sense of comfort away, replaced with a strange duality of torment and transcendence. The harsh, yet strangely savory, scent of burning flesh punctuates the air, becoming richer and more distinct. Suddenly, the sea of tentacles parts like the Red Sea before Moses, revealing a broad expanse of barren rock.
+
+	Before you yawns the Maw of Kimaris, a monstrous mouth carved into the very earth. The sight seizes your breath, casting you into a sudden, terrible silence. The Maw seems to pulse with a horrifying life of its own, promising an eternal fall to any who would dare to trip at its precipice.
 <<else>>
-With a horrifyingly human-like belch, the Maw spits forth the Relic you requested, now slightly singed at the edges but still perfectly usable. Retrieving it from the edge of the Maw, you approach the Maw once again and consider what you want to do.
+	With a horrifyingly human-like belch, the Maw spits forth the Relic you requested, now slightly singed at the edges but still perfectly usable. Retrieving it from the edge of the Maw, you approach the Maw once again and consider what you want to do.
 <</if>>
 <<nobr>>
+<<set _totalRelics = $ownedRelics.concat($soldRelics)>>
 You may pick up a new Relic for 10 dubloons and 1.5x its corruption cost:<br>
-<<for $i = 0; $i < 59; $i++>>
-	<<capture $i>>
-	<<if !_totalRelics.some(e => e.name === $relics[$i].name) && $relics[$i].name != "Kin Shifter">>
-		<<print "[[$relics[$i].name|Layer6 Maw1][$temp = $i, $dubloons -= 10, $corruption -= Math.round(Math.max(($relics[$i].corr * 3 / 2) - $corRed, 10)), $ownedRelics.push($relics[$i])]]">><<print " ">><<print Math.round(Math.max(($relics[$i].corr * 3 / 2) - $corRed, 10))>><<print " corruption points">><br>
+<<for _relic range $relics>>
+	<<set _foundOnLayer = setup.relicsOnLayer.findIndex(relicsOnLayer => relicsOnLayer.includes(_relic.name))>>
+	<<print `<<set _visitedRelicLayer = $visitL${_foundOnLayer}>>`>>
+	<<if _visitedRelicLayer && _relic.name != 'Kin Shifter' && !_totalRelics.some(e => e.name == _relic.name)>>
+		<<capture _relic>>
+			&nbsp; [[_relic.name|Layer6 Maw1][$dubloons -= 10, $corruption -= Math.max(Math.floor(1.5 * _relic.corr) - $corRed, 10), $ownedRelics.push(_relic)]]
+			for <<print Math.max(Math.floor(1.5 * _relic.corr) - $corRed, 10)>> corruption points<br>
+		<</capture>>
 	<</if>>
-	<</capture>>
 <</for>><br>
 You may pick up a copy of an old Relic for 20 dubloons and 2x its corruption cost:<br>
-<<for $i = 0; $i < 59; $i++>>
-	<<capture $i>>
-	<<if _totalRelics.some(e => e.name === $relics[$i].name) && $relics[$i].name != "Kin Shifter">>
-		<<print "[[$relics[$i].name|Layer6 Maw1][$temp = $i, $dubloons -= 20, $corruption -= Math.round(Math.max(($relics[$i].corr * 2) - $corRed, 10)), $ownedRelics.push($relics[$i])]]">><<print " ">><<print Math.round(Math.max(($relics[$i].corr * 2) - $corRed, 10))>><<print " corruption points">><br>
+<<for _relic range _totalRelics>>
+	<<if _relic.name != 'Kin Shifter'>>
+		<<capture _relic>>
+			&nbsp; [[_relic.name|Layer6 Maw1][$mawUse = true, $dubloons -= 20, $corruption -= Math.max(2 * _relic.corr - $corRed, 10), $ownedRelics.push(_relic)]]
+			for <<print Math.max(2 * _relic.corr - $corRed, 10)>> corruption points<br>
+		<</capture>>
 	<</if>>
-	<</capture>>
 <</for>>
-<<set $mawUse = 0>>
+<<set $mawUse = false>>
 <</nobr>>
 
 [[Return to exploring the sixth layer|Layer6 Hub]]
+<</if>>
 
 
 :: Pick up the Ring of the Devourer [layer6]
@@ -958,7 +970,7 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 		<<set _multiplier = 1/2>>
 	<</if>>
 	<<AdjustedTravelTime "_travelTime" 15 false 0 _multiplier>>
-	<<set setup.startPassingTime(_travelTime)>>
+	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
 <<include "Layer6 Travel Events">>
@@ -983,7 +995,7 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 
 <<if !setup.passingTime()>>
 	<<AdjustedTravelTime "_travelTime" 16>>
-	<<set setup.startPassingTime(_travelTime)>>
+	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
 <<include "Layer6 Travel Events">>

--- a/src/layer7.twee
+++ b/src/layer7.twee
@@ -231,7 +231,7 @@ It is reccomended that you get creative with your Relics and think of more effic
 
 <p>[[Continue exploring the seventh layer|Layer7 Hub]]</p>
 
-<<RelicGrid `["Daedalus Mechanism", "Blind Divine", "Lambent Specter", "Phoenix Obol", "Granted Granite", "Joyous Sunder", "Azure Aozora", "Glare Vantage", "Final Stage", "Solace Lace", "Red Thread Flourish", "Triage Rain"]`>>
+<<RelicGrid `setup.relicsOnLayer[7]`>>
 
 <p>[[Continue exploring the seventh layer|Layer7 Hub]]</p>
 
@@ -1354,7 +1354,7 @@ You have no choice, you gain consciousness a few times to see yourself in a surg
 		<<set _multiplier = 1/2>>
 	<</if>>
 	<<AdjustedTravelTime "_travelTime" 7 false 0 _multiplier>>
-	<<set setup.startPassingTime(_travelTime)>>
+	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
 <<include "Layer7 Travel Events">>
@@ -1381,7 +1381,7 @@ You have no choice, you gain consciousness a few times to see yourself in a surg
 
 <<if !setup.passingTime()>>
 	<<AdjustedTravelTime "_travelTime" 8>>
-	<<set setup.startPassingTime(_travelTime)>>
+	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
 <<include "Layer7 Travel Events">>

--- a/src/layer8.twee
+++ b/src/layer8.twee
@@ -393,7 +393,7 @@ You can consider your equipment, allies, and general health to take into account
 	<p>[[Deal with the Demential Aberrations|Layer 8 Threat 2b]]</p>
 <<else>>
 <p>[[Continue exploring the eighth layer|Layer8 Hub]]</p>
-<<RelicGrid `["Voila Viola", "Between Whispers", "Absolute Oracle", "Memory Reign", "Drifting Aperture", "Aegis Coffin", "Gaia Theory", "Glory's Grasp", "Pneuma Wisp", "World's End Lock", "Fray Goo", "Null Void"]`>>
+<<RelicGrid `setup.relicsOnLayer[8]`>>
 <p>[[Continue exploring the eighth layer|Layer8 Hub]]</p>
 <</if>>
 
@@ -1340,7 +1340,7 @@ Ready? Getting back up out of this terrible prison and back to layer 7 will take
 		<<set _multiplier = 1/2>>
 	<</if>>
 	<<AdjustedTravelTime "_travelTime" 40 false 0 _multiplier>>
-	<<set setup.startPassingTime(_travelTime)>>
+	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
 <<include "Layer8 Travel Events">>
@@ -1376,7 +1376,7 @@ If you continue your descent in spite of everything, descending past this layer'
 
 <<if !setup.passingTime()>>
 	<<AdjustedTravelTime "_travelTime" 45>>
-	<<set setup.startPassingTime(_travelTime)>>
+	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
 <<include "Layer8 Travel Events">>

--- a/src/relics.twee
+++ b/src/relics.twee
@@ -990,6 +990,18 @@ pic: "Relics/starlitconquest.png"
 <<set $innRelics = []>>
 <<set $relicSwap = []>>
 
+<<set setup.relicsOnLayer = [
+    /*  0 */ [], /* Placeholder; no relics on the surface. */
+    /*  1 */ ["Star Compass", "Rømer Stones", "Creepy Doll", "Giddy Reaper", "Silk Twister", "Vertebra Key", "Chain of Lorelei", "Hive Tassel", "Smitten Mitt"],
+    /*  2 */ ["Firmament Pigment", "Pearly Gates", "World Stone", "Forest's Gift", "Harmless Harmony", "Umbra Trident", "Event Horizon", "Heart-stealing Stole", "Effacing Asperity", "Wholly Ale", "Memoir Remnant", "Gleam Dazer"],
+    /*  3 */ ["Sibyl Blend", "Pangea Shaker", "From Seafoam", "Orbweaver", "Soulseeker", "Tranquility Knell", "Lightning Rook", "Acrobatic Accord", "Managed Misfortune", "Breathless Exhale", "Sharing Shears", "Rose-tinted Spectacles"],
+    /*  4 */ ["Ghost-righter Writing Down", "Gilded Prison", "Omoikane Circuit", "Afar Wanderer", "Kin Shifter", "Brave Vector", "Devil's Own", "Verve Cell","Vessel Vivisector", "Sated Artist", "Timekeeper's Keepsake", "Creator's Bolt", "Perpetual Repose", "Toral Wave", "Flamel's Folly"],
+    /*  5 */ ["Pocket Hoard", "Sunbeam", "Moonwatcher", "Siren's Call", "Zelus Band", "Everhevea", "Reflex Emblem", "Twin Polaris", "Superpositional Skewer", "Empath Coil", "Heavenly Merrymaker", "Vain Sculpt"],
+    /*  6 */ ["Ring of the Devourer", "Pulse Bloom", "Out of Mind", "Still Film", "Forbidden Grimoire", "Luminous Phantasmagoria", "Relativity Eye", "Return to Sender", "Yliaster Materia", "Aeonglass", "Apparatus Diaboli", "Heavy is the Head"],
+    /*  7 */ ["Daedalus Mechanism", "Blind Divine", "Lambent Specter", "Phoenix Obol", "Granted Granite", "Joyous Sunder", "Azure Aozora", "Glare Vantage", "Final Stage", "Solace Lace", "Red Thread Flourish", "Triage Rain"],
+    /*  8 */ ["Voila Viola", "Between Whispers", "Absolute Oracle", "Memory Reign", "Drifting Aperture", "Aegis Coffin", "Gaia Theory", "Glory's Grasp", "Pneuma Wisp", "World's End Lock", "Fray Goo", "Null Void"],
+]>>
+
 <<set setup.functionalRelics = [
 		"Star Compass", "Rømer Stones", "Creepy Doll", "Chain of Lorelei", 
         "World Stone", "Forest's Gift", "Heart-stealing Stole", "Gleam Dazer", "Event Horizon", 

--- a/src/script.js
+++ b/src/script.js
@@ -503,7 +503,15 @@ Object.defineProperties(setup, {
 	},
 	// Start passing time for the active passage (initializes state for <<PassTime>>).
 	startPassingTime: {
-		value(days) {
+		value(passage, days) {
+			const vars = variables();
+
+			if (!['Labor Scene', 'Labor Scene Companion'].includes(passage)) {
+				// If we're on a layer without a daily source of water and we're traveling somewhere, reset $atWaterSource.
+				if (vars.currentLayer == 3 && !['Layer3 Camp', 'Layer3 Forage'].includes(passage)) vars.atWaterSource = false;
+				if (vars.currentLayer == 5 && !['Layer5 Camp', 'Layer5 Forage'].includes(passage)) vars.atWaterSource = false;
+			}
+
 			const state = {
 				expectedDays: days, /* The number of days of time to pass, modulo the time weight. */
 				unweightedDayIndex: 0,
@@ -513,7 +521,7 @@ Object.defineProperties(setup, {
 				nextRealDay: 0,
 				energy: temporary().daysOfEnergyRations ?? 0,
 			};
-			variables().passTimeState.set(passage(), state);
+			vars.passTimeState.set(passage, state);
 			return state;
 		},
 	},

--- a/src/widgets.twee
+++ b/src/widgets.twee
@@ -2401,7 +2401,7 @@
 	<<set _relic = _args[0]>>
 	<<if !setup.passingTime()>>
 		<<AdjustedTravelTime "_travelTime" _relic.time false `-$SibylBuff`>>
-		<<set setup.startPassingTime(_travelTime)>>
+		<<set setup.startPassingTime(passage(), _travelTime)>>
 	<</if>>
 	<<include `"Layer" + $currentLayer + " Travel Events"`>>
 	<<if !setup.passingTime()>>


### PR DESCRIPTION
Didn't do layer 7 and 8 yet, but I tested the changes to the other layers so let's get this in.

In addition to what it says in the title, this:
* Adds the ability to wait near a river on layer 3.
* Fixes up the water source finding code for layer 3 and layer 5.
* Cleans up the code for several wonders (notably the vault and the maw).
* Moves the list of relics for each layer into `setup.relicsForLayer`, following the example of `setup.cursesForLayer`, and uses it in the Maw.