### PR TITLE
Finish cleaning up travel time

### DIFF
--- a/src/global.twee
+++ b/src/global.twee
@@ -1829,6 +1829,19 @@ How many dubloons would you like to pay back?
 <</widget>>
 
 :: Widgets for traveling and the passage of time [widget nobr]
+<<widget "WaitAtPassage">>
+/*
+	_args[0]: var|string = As linkText in <<link>>. The text of the link. May contain markup.
+	_args[1]: var|string = As passageName in <<link>>. The name of the passage to go to.
+	_args[2]: var|number = The number of days to wait.
+	_args[3]: [string]   = Set expression to execute (optional).
+*/
+<<link _args[0] _args[1]>>
+	<<if _args[2] > 0>><<set setup.startPassingTime(_args[1], _args[2])>><</if>>
+	<<if _args[3]>><<print `<<set ${_args[3]}>>`>><</if>>
+<</link>>
+<</widget>>
+
 <<widget "TravelToPassage">>
 /*
 	_args[0]: var|string   = As linkText in <<link>>. The text of the link. May contain markup.
@@ -2057,12 +2070,8 @@ How many dubloons would you like to pay back?
 /* Get the persistent state for the active passage. */
 <<set _state = setup.passingTime()>>
 <<if !_state>>
-	/* If we aren't passing time yet, check if the number of days was passed in the first argument. */
-	<<if typeof _args[0] == 'number'>>
-		<<set _state = setup.startPassingTime(passage(), _args[0])>>
-	<<else>> /* Otherwise, just pass 0 days. */
-		<<set _state = setup.startPassingTime(passage(), 0)>>
-	<</if>>
+	/* If we aren't passing time yet, assume that the number of days was passed in the first argument. */
+	<<set _state = setup.startPassingTime(passage(), _args[0])>>
 <</if>>
 
 /* Check event triggers. */
@@ -2558,9 +2567,7 @@ You will first drink:<br>
 
 	How many days would you like to rest here?<br>
 	<<textbox "_campTime" "0">><br>
-	<<link "Set up camp and wait" `passage()`>>
-		<<set setup.startPassingTime(passage(), Math.max(parseInt(_campTime, 10) || 0, 0))>>
-	<</link>><br><br>
+	<<WaitAtPassage 'Set up camp and wait' `passage()` `Math.max(parseInt(_campTime, 10) || 0, 0)`>><br><br>
 
 	<<link "Return to exploring the layer without waiting" `"Layer" + $currentLayer + " Hub"`>><</link>>
 <</if>>

--- a/src/global.twee
+++ b/src/global.twee
@@ -1828,7 +1828,7 @@ How many dubloons would you like to pay back?
 <</capture>>
 <</widget>>
 
-:: Widgets for the passage of time [widget nobr]
+:: Widgets for traveling and the passage of time [widget nobr]
 <<widget "TravelToPassage">>
 /*
 	_args[0]: var|string   = As linkText in <<link>>. The text of the link. May contain markup.
@@ -2015,6 +2015,10 @@ How many dubloons would you like to pay back?
 <<print `<<set ${_args[0]} = ${_inputTime}>>`>>
 
 <</capture>>
+<</widget>>
+
+<<widget "PassTimeWithEvents">>
+	<<if setup.passingTime()>><<include `"Layer" + $currentLayer + " Travel Events"`>><</if>>
 <</widget>>
 
 <<widget "PassTime">>

--- a/src/global.twee
+++ b/src/global.twee
@@ -1829,6 +1829,22 @@ How many dubloons would you like to pay back?
 <</widget>>
 
 :: Widgets for the passage of time [widget nobr]
+<<widget "TravelToPassage">>
+/*
+	_args[0]: var|string   = As linkText in <<link>>. The text of the link. May contain markup.
+	_args[1]: var|string   = As passageName in <<link>>. The name of the passage to go to.
+	_args[2]: var|number   = The raw, unadjusted travel time.
+	_args[3]: [var|number] = Initial additive modifier (optional, can be negative)
+	_args[4]: [var|number] = Initial multiplicative modifier (optional, <1 is a bonus, >1 is a penalty)
+*/
+<<link _args[0] _args[1]>>
+	<<capture _travelTime>>
+		<<AdjustedTravelTime "_travelTime" _args[2] false _args[3] _args[4]>>
+		<<if _travelTime > 0>><<set setup.startPassingTime(_args[1], _travelTime)>><</if>>
+	<</capture>>
+<</link>>
+<</widget>>
+
 <<widget "AdjustedTravelTime">>
 <<capture _additiveModifier _consumptionPerDay _forPreview _inputTime _multiplicativeModifier>>
 /*

--- a/src/global.twee
+++ b/src/global.twee
@@ -2534,9 +2534,7 @@ You will first drink:<br>
 
 
 :: CampCode [nobr]
-<<if setup.passingTime()>>
-	<<include `"Layer" + $currentLayer + " Travel Events"`>>
-<</if>>
+<<PassTimeWithEvents>>
 <<if !setup.passingTime()>>
 	<<checkTime>>
 	You can set up camp and rest here for a while before continuing your journey. You still need to eat and drink and the layer's threats continue to loom over you even as you rest. This won't accomplish much on its own, but if you'd like to spend some time sampling the local cuisine or studying this layer's threats, then this could be a good way to do that.<br><br>

--- a/src/global.twee
+++ b/src/global.twee
@@ -1059,12 +1059,12 @@ A bright flash of light forces you to close your eyes. When you open them, both 
 $hiredCompanions[_temp1].name spends the next few days recovering, with you at her side offering emotional and physical support. Gradually, she starts walking around a little again.
 <<if $hiredCompanions[_temp1].name != "Cherry" && $hiredCompanions.some(e => e.name === "Cherry")>>
 Cherry's medical expertise greatly aids $hiredCompanions[_temp1].name in her recovery. In the end, you don't truly resume your travels in earnest until after 4 days.
-<<set $tempTime=4>>
+<<set _waitTime = 4>>
 <<else>>
 In the end, you don't truly resume your travels in earnest until after 7 days.
-<<set $tempTime=7>>
+<<set _waitTime = 7>>
 <</if>>
-<<PassTime $tempTime>>\
+<<PassTime _waitTime>>\
 
 [[You cast your eyes once more on the central location of this layer, ready to get moving again|_string]]
 
@@ -1834,31 +1834,31 @@ How many dubloons would you like to pay back?
 	_args[0]: var|string   = As linkText in <<link>>. The text of the link. May contain markup.
 	_args[1]: var|string   = As passageName in <<link>>. The name of the passage to go to.
 	_args[2]: var|number   = The raw, unadjusted travel time.
-	_args[3]: [var|number] = Initial additive modifier (optional, can be negative)
-	_args[4]: [var|number] = Initial multiplicative modifier (optional, <1 is a bonus, >1 is a penalty)
+	_args[3]: [var|number] = Initial additive modifier (optional, can be negative).
+	_args[4]: [var|number] = Initial multiplicative modifier (optional, <1 is a bonus, >1 is a penalty).
+	_args[5]: [string]     = Set expression to execute (optional).
 */
 <<link _args[0] _args[1]>>
-	<<capture _travelTime>>
-		<<AdjustedTravelTime "_travelTime" _args[2] false _args[3] _args[4]>>
-		<<if _travelTime > 0>><<set setup.startPassingTime(_args[1], _travelTime)>><</if>>
-	<</capture>>
+	<<StartTraveling _args[2] _args[3] _args[4] _args[1]>>
+	<<if _args[5]>><<print `<<set ${_args[5]}>>`>><</if>>
 <</link>>
 <</widget>>
 
-<<widget "AdjustedTravelTime">>
-<<capture _additiveModifier _consumptionPerDay _forPreview _inputTime _multiplicativeModifier>>
+<<widget "StartTraveling">>
+<<capture _additiveModifier _consumptionPerDay _forPreview _inputTime _multiplicativeModifier _passageOrOutVar>>
 /*
-	_args[0]: string       = the variable to write to, as a string (e.g. "$tempTime")
-	_args[1]: var|number   = the raw, unadjusted travel time
-	_args[2]: [bool]       = whether to avoid adjustments beyond the travel time (optional, defaults to false)
-	_args[3]: [var|number] = initial additive modifier (optional, can be negative)
-	_args[4]: [var|number] = initial multiplicative modifier (optional, <1 is a bonus, >1 is a penalty)
+	_args[0]: var|number   = The raw, unadjusted travel time.
+	_args[1]: [var|number] = Initial additive modifier (optional, can be negative).
+	_args[2]: [var|number] = Initial multiplicative modifier (optional, <1 is a bonus, >1 is a penalty).
+	_args[3]: [string]     = The passage name, or the output variable in preview mode (optional).
+	_args[4]: ['preview']  = If set, no state is modified and the time is written to the variable in the first argument.
 */
-<<set _inputTime = _args[1]>>
-<<set _forPreview = _args[2]>>
+<<set _inputTime = _args[0]>>
+<<set _passageOrOutVar = _args[3] ?? passage()>>
+<<set _forPreview = _args[4]>>
 
 /* Start by computing the overall additive modifier. */
-<<set _additiveModifier = _args[3] ?? 0>>
+<<set _additiveModifier = _args[1] ?? 0>>
 
 /* Apply time reduction from having Khemia with you. */
 <<set _additiveModifier -= $timeRed>>
@@ -1944,7 +1944,7 @@ How many dubloons would you like to pay back?
 
 /* If travel time wasn't eliminated entirely, apply multiplicative modifiers. */
 <<if _inputTime > 0>>
-	<<set _multiplicativeModifier = _args[4] ?? 1>>
+	<<set _multiplicativeModifier = _args[2] ?? 1>>
 	/* Double travel time if player has a size handicap (Colossal-able, or Minish-ish with no one to carry them). */
 	<<if $SizeHandicap>>
 		The burden of your inconvenient size hampers your progress, increasing your travel time.<br>
@@ -2009,12 +2009,29 @@ How many dubloons would you like to pay back?
 		<<set $items[24].count -= _consumptionPerDay * (_daysOfEnergyRations - _inputTime)>>
 		<<set _daysOfEnergyRations = _inputTime>>
 	<</if>>
+
+	/* Actually start passing time. */
+	<<if _inputTime > 0>>
+		<<set setup.startPassingTime(_passageOrOutVar, _inputTime)>>
+	<</if>>
+<<else>>
+	/* Write the adjusted time to the output variable. */
+	<<print `<<set ${_passageOrOutVar} = ${_inputTime}>>`>>
 <</if>>
 
-/* Write to the output variable. */
-<<print `<<set ${_args[0]} = ${_inputTime}>>`>>
-
 <</capture>>
+<</widget>>
+
+<<widget "PreviewTravelTime">>
+/*
+	_args[0]: string       = The output variable.
+	_args[1]: var|number   = The raw, unadjusted travel time.
+	_args[2]: [var|number] = Initial additive modifier (optional, can be negative).
+	_args[3]: [var|number] = Initial multiplicative modifier (optional, <1 is a bonus, >1 is a penalty).
+*/
+<<silently>>
+	<<StartTraveling _args[1] _args[2] _args[3] _args[0] 'preview'>>
+<</silently>>
 <</widget>>
 
 <<widget "PassTimeWithEvents">>

--- a/src/layer1.twee
+++ b/src/layer1.twee
@@ -246,7 +246,7 @@ You sit by the fire with your party and chat, the mood is pretty upbeat and opti
 <<if $playerCurses.length > 0>>
 	<<if !$iconUsed>>
 		Would you like to use the Icon of Mercy?<br><br>
-		[[Yes, use the Icon|Layer1 Icon]]<br>
+		<<TravelToPassage 'Yes, use the Icon' 'Layer1 Icon' 3>><br>
 	<<else>>
 		You have already used the Icon of Mercy, you may not use it again.<br>
 	<</if>>
@@ -321,20 +321,11 @@ You sit by the fire with your party and chat, the mood is pretty upbeat and opti
 Descending to the next layer will take 2 days. How are your supplies of food and water? It's only going to get harder from here.
 
 [[Turn back and continue your business on the first layer|Layer1 Hub]]
-[[Continue your descent to the second layer|Layer1 Exit2]]
+<<TravelToPassage 'Continue your descent to the second layer' 'Layer1 Exit2' 2>>
 
 
 :: Layer1 Exit2 [layer1]
-<<nobr>>
-
-<<if !setup.passingTime()>>
-	<<AdjustedTravelTime "_travelTime" 2>>
-	<<set setup.startPassingTime(passage(), _travelTime)>>
-<</if>>
-
-<<PassTimeWithEvents>>
-
-<</nobr>>\
+<<PassTimeWithEvents>>\
 <<if !setup.passingTime()>>
 	You notice the air is a bit more humid and the plants are a bit greener as you approach the path towards the second layer.
 
@@ -480,16 +471,7 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 
 
 :: Layer1 Icon [layer1]
-<<nobr>>
-
-<<if !setup.passingTime()>>
-	<<AdjustedTravelTime "_travelTime" 3>>
-	<<set setup.startPassingTime(passage(), _travelTime)>>
-<</if>>
-
-<<PassTimeWithEvents>>
-
-<</nobr>>\
+<<PassTimeWithEvents>>\
 <<if !setup.passingTime()>>\
 [img[setup.ImagePath+'Wonders/iconofmercy.png']]
 
@@ -1024,19 +1006,15 @@ Traveling back to the surface from here will take 1 day, and will cost 10 corrup
 
 :: Layer1 Ascend2 [layer1]
 <<nobr>>
-
 <<if !setup.passingTime()>>
 	<<set _multiplier = 1>>
 	<<if $DaedalusFly>>
 		<<include "Companions Stranded">>
 		<<set _multiplier = 1/2>>
 	<</if>>
-	<<AdjustedTravelTime "_travelTime" 1 false 0 _multiplier>>
-	<<set setup.startPassingTime(passage(), _travelTime)>>
+	<<StartTraveling 1 0 _multiplier>>
 <</if>>
-
 <<PassTimeWithEvents>>
-
 <</nobr>>\
 <<if !setup.passingTime()>>
 	<<nobr>>

--- a/src/layer1.twee
+++ b/src/layer1.twee
@@ -332,7 +332,7 @@ Descending to the next layer will take 2 days. How are your supplies of food and
 	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
-<<include "Layer1 Travel Events">>
+<<PassTimeWithEvents>>
 
 <</nobr>>\
 <<if !setup.passingTime()>>
@@ -487,7 +487,7 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
-<<include "Layer1 Travel Events">>
+<<PassTimeWithEvents>>
 
 <</nobr>>\
 <<if !setup.passingTime()>>\
@@ -1035,7 +1035,7 @@ Traveling back to the surface from here will take 1 day, and will cost 10 corrup
 	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
-<<include "Layer1 Travel Events">>
+<<PassTimeWithEvents>>
 
 <</nobr>>\
 <<if !setup.passingTime()>>

--- a/src/layer2.twee
+++ b/src/layer2.twee
@@ -271,7 +271,7 @@ By default, your companions' reward for coming down here with you is the dubloon
 <<nobr>>
 <<if $visitL3 == 0 && !$brokerUsed && $corruption > -100>>
 	Would you like to use the Empty-handed Broker?<br>
-	[[Yes, use the Broker|Layer2 Broker]]
+	<<TravelToPassage 'Yes, use the Broker' 'Layer2 Broker' 2>>
 <<else>>
 	You have already used the Empty-handed Broker or traveled further into the Abyss, you may not use it now.<br>
 <</if>>
@@ -280,7 +280,7 @@ By default, your companions' reward for coming down here with you is the dubloon
 <<nobr>>
 <<if !$starUsed && $hiredCompanions.length > 0>>
 	Would you like to use the Fate-crossing Star?<br>
-	[[Yes, bathe in the Star's lake|Layer2 Star 1]]<br>
+	<<TravelToPassage "Yes, bathe in the Star's lake" 'Layer2 Star 1' 3>><br>
 <<else>>
 	You must have companions and have not already used the Fate-crossing Star before if you wish to swap bodies with someone.<br>
 <</if>>
@@ -331,7 +331,7 @@ Descending to the next layer will take 5 days. As you travel further down, the l
 Accessing drinkable water tends to get a but more difficult from here on out, so having a fair emergency supply of water would be a good idea before continuing onward. At a minimum, about a week's worth of water should be enough to avoid the worst case scenario.
 
 [[Stay on layer 2|Layer2 Hub]]
-[[Descend down to the third layer|Layer2 Exit2]]
+<<TravelToPassage 'Descend down to the third layer' 'Layer2 Exit2' 5>>
 
 
 :: Layer2 Cherry Relic [layer2]
@@ -526,16 +526,7 @@ What type of fur would you like to gain?
 <</nobr>>
 
 :: Layer2 Broker [layer2]
-<<nobr>>
-
-<<if !setup.passingTime()>>
-	<<AdjustedTravelTime "_travelTime" 2>>
-	<<set setup.startPassingTime(passage(), _travelTime)>>
-<</if>>
-
-<<PassTimeWithEvents>>
-
-<</nobr>>\
+<<PassTimeWithEvents>>\
 <<if !setup.passingTime()>>\
 <<nobr>>
 	<<set $corruption += 100>>
@@ -558,16 +549,7 @@ You have gained 100 corruption points, but you must always keep your corruptions
 
 
 :: Layer2 Star 1 [layer2]
-<<nobr>>
-
-<<if !setup.passingTime()>>
-	<<AdjustedTravelTime "_travelTime" 3>>
-	<<set setup.startPassingTime(passage(), _travelTime)>>
-<</if>>
-
-<<PassTimeWithEvents>>
-
-<</nobr>>\
+<<PassTimeWithEvents>>\
 <<if !setup.passingTime()>>\
 [img[setup.ImagePath+'Wonders/fate-crossingstar.png']]
 
@@ -1447,19 +1429,15 @@ A few tests and you can confirm you have pure water to fill your flasks with! No
 
 :: Layer2 Ascend2 [layer2]
 <<nobr>>
-
 <<if !setup.passingTime()>>
 	<<set _multiplier = 1>>
 	<<if $DaedalusFly>>
 		<<include "Companions Stranded">>
 		<<set _multiplier = 1/2>>
 	<</if>>
-	<<AdjustedTravelTime "_travelTime" 4 false 0 _multiplier>>
-	<<set setup.startPassingTime(passage(), _travelTime)>>
+	<<StartTraveling 4 0 _multiplier>>
 <</if>>
-
 <<PassTimeWithEvents>>
-
 <</nobr>>\
 <<if !setup.passingTime()>>
 	<<nobr>>
@@ -1499,16 +1477,7 @@ A few tests and you can confirm you have pure water to fill your flasks with! No
 
 
 :: Layer2 Exit2 [layer2]
-<<nobr>>
-
-<<if !setup.passingTime()>>
-	<<AdjustedTravelTime "_travelTime" 5>>
-	<<set setup.startPassingTime(passage(), _travelTime)>>
-<</if>>
-
-<<PassTimeWithEvents>>
-
-<</nobr>>\
+<<PassTimeWithEvents>>\
 <<if !setup.passingTime()>>
 	Subtle changes in your surroundings continue, large rocks start to appear in your path, and the entire terrain changes from the lush rainforest you previously found yourself in to a more temperate forest. But slowly the trees become more sparse and the rocks become more common.
 

--- a/src/layer2.twee
+++ b/src/layer2.twee
@@ -533,7 +533,7 @@ What type of fur would you like to gain?
 	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
-<<include "Layer2 Travel Events">>
+<<PassTimeWithEvents>>
 
 <</nobr>>\
 <<if !setup.passingTime()>>\
@@ -565,7 +565,7 @@ You have gained 100 corruption points, but you must always keep your corruptions
 	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
-<<include "Layer2 Travel Events">>
+<<PassTimeWithEvents>>
 
 <</nobr>>\
 <<if !setup.passingTime()>>\
@@ -1458,7 +1458,7 @@ A few tests and you can confirm you have pure water to fill your flasks with! No
 	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
-<<include "Layer2 Travel Events">>
+<<PassTimeWithEvents>>
 
 <</nobr>>\
 <<if !setup.passingTime()>>
@@ -1506,7 +1506,7 @@ A few tests and you can confirm you have pure water to fill your flasks with! No
 	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
-<<include "Layer2 Travel Events">>
+<<PassTimeWithEvents>>
 
 <</nobr>>\
 <<if !setup.passingTime()>>

--- a/src/layer3.twee
+++ b/src/layer3.twee
@@ -128,15 +128,15 @@ If you decide to start foraging for food or water, it means that you will not co
 <</if>>
 <<if $items[2].count > 0>>
 	<<if $atWaterSource>>
-		[[Fill your empty flasks with water from the underground river|Layer3 Flasks]]<br><br>
+		<<link 'Fill your empty flasks with water from the underground river' 'Layer3 Flasks'>><</link>><br><br>
 	<<else>>
-		[[Fill your empty flasks with water from underground rivers|Layer3 Flasks]]<br><br>
+		<<TravelToPassage 'Fill your empty flasks with water from underground rivers' 'Layer3 Flasks' 4 `-($abyssKnow + $riverVisit)`>><br><br>
 	<</if>>
 <<else>>
 	<<if $atWaterSource>>
 		You need empty flasks to fill them with water from the underground river.<br><br>
 	<<else>>
-		[[Find an underground river to avoid using your water|Layer3 Flasks]]<br><br>
+		<<TravelToPassage 'Find an underground river to avoid using your water' 'Layer3 Flasks' 4 `-($abyssKnow + $riverVisit)`>><br><br>
 	<</if>>
 <</if>>
 <<if $atWaterSource>>
@@ -212,9 +212,9 @@ The Abyss is a huge place. The Relics listed in these sections are only a small 
 <<nobr>>
 <<if $scalesUsed == 0>>
 Would you like to use the Gossamery Scales to gain dubloons based on your corruption?<br>
-[[Yes, use the Scales to gain dubloons|Layer3 Scales 1]]<br><br>
+<<TravelToPassage 'Yes, use the Scales to gain dubloons' 'Layer3 Scales 1' 2>><br><br>
 Would you like to use the Gossamery Scales to gain corruption based on your dubloons?<br>
-[[Yes, use the Scales to gain corruption|Layer3 Scales 2]]<br><br>
+<<TravelToPassage 'Yes, use the Scales to gain corruption' 'Layer3 Scales 2' 2>><br><br>
 <<else>>
 You have already used the scales on your journey. You may not use them again.<br><br>
 <</if>>
@@ -272,7 +272,7 @@ Easily-accessible foraged food isn't guaranteed from here on. Taking a gun with 
 In the deeper parts of the layer, a cold breeze occasionally blows through the caverns, hinting at something frigid deeper below.
 
 [[Turn back and continue your business on the third layer|Layer3 Hub]]
-[[Continue your descent to the fourth layer|Layer3 Exit2]]
+<<TravelToPassage 'Continue your descent to the fourth layer' 'Layer3 Exit2' 6>>
 
 
 :: Layer3 Travel Events [layer3 nobr]
@@ -294,19 +294,15 @@ In the deeper parts of the layer, a cold breeze occasionally blows through the c
 
 :: Layer3 Ascend2 [layer3]
 <<nobr>>
-
 <<if !setup.passingTime()>>
 	<<set _multiplier = 1>>
 	<<if $DaedalusFly>>
 		<<include "Companions Stranded">>
 		<<set _multiplier = 1/2>>
 	<</if>>
-	<<AdjustedTravelTime "_travelTime" 6 false 0 _multiplier>>
-	<<set setup.startPassingTime(passage(), _travelTime)>>
+	<<StartTraveling 6 0 _multiplier>>
 <</if>>
-
 <<PassTimeWithEvents>>
-
 <</nobr>>\
 <<if !setup.passingTime()>>
 	<<nobr>>
@@ -323,16 +319,7 @@ In the deeper parts of the layer, a cold breeze occasionally blows through the c
 
 
 :: Layer3 Scales 1 [layer3]
-<<nobr>>
-
-<<if !setup.passingTime()>>
-	<<AdjustedTravelTime "_travelTime" 2>>
-	<<set setup.startPassingTime(passage(), _travelTime)>>
-<</if>>
-
-<<PassTimeWithEvents>>
-
-<</nobr>>\
+<<PassTimeWithEvents>>\
 <<if !setup.passingTime()>>\
 <<nobr>>
 	<<set $temp = Math.round($corruption / 5)>>
@@ -350,16 +337,7 @@ Once you pick them up, the luster of the scales fades, indicating that they will
 
 
 :: Layer3 Scales 2 [layer3]
-<<nobr>>
-
-<<if !setup.passingTime()>>
-	<<AdjustedTravelTime "_travelTime" 2>>
-	<<set setup.startPassingTime(passage(), _travelTime)>>
-<</if>>
-
-<<PassTimeWithEvents>>
-
-<</nobr>>\
+<<PassTimeWithEvents>>\
 <<if !setup.passingTime()>>\
 <<nobr>>
 	<<set $temp = Math.round($dubloons / 5)>>
@@ -867,16 +845,7 @@ On the other hand, the idea of each encounter feeling like your first time holds
 
 
 :: Layer3 Flasks [layer3]
-<<nobr>>
-
-<<if !setup.passingTime() && !$atWaterSource>>
-	<<AdjustedTravelTime "_travelTime" 4 true `-$abyssKnow - $riverVisit`>>
-	<<set setup.startPassingTime(passage(), _travelTime)>>
-<</if>>
-
-<<PassTimeWithEvents>>
-
-<</nobr>>\
+<<PassTimeWithEvents>>\
 <<if !setup.passingTime()>>\
 [img[setup.ImagePath+'Foraging/undergroundrivers.png']]
 <<if $atWaterSource>>
@@ -1130,16 +1099,7 @@ Please enter a new eye color:
 <</nobr>>
 
 :: Layer3 Exit2 [layer3]
-<<nobr>>
-
-<<if !setup.passingTime()>>
-	<<AdjustedTravelTime "_travelTime" 6>>
-	<<set setup.startPassingTime(passage(), _travelTime)>>
-<</if>>
-
-<<PassTimeWithEvents>>
-
-<</nobr>>\
+<<PassTimeWithEvents>>\
 <<if !setup.passingTime()>>
 	You continue through the dark winding caverns for days on end. After a long and monotonous journey, broken up only by evading threats that may have interrupted you, you notice that the caves are opening up. But rather than the wet forest from above, you feel the air getting colder, and occasionally notice frost on the walls of the caves.
 

--- a/src/layer3.twee
+++ b/src/layer3.twee
@@ -113,9 +113,7 @@ The Abyss has various bioluminescent moss, mushrooms, and so on scattered about,
 
 
 :: Layer3 Forage [image layer3]
-<<if setup.passingTime()>>
-	<<include "Layer3 Travel Events">>
-<</if>>\
+<<PassTimeWithEvents>>\
 <<if !setup.passingTime()>>\
 <<checkTime>>
 [img[setup.ImagePath+'Clipped-Fin/Abyss Diver Page 4-foraging.png']]
@@ -224,15 +222,9 @@ You have already used the scales on your journey. You may not use them again.<br
 	You must have companions if you would like to use the Skewed Shrine.<br><br>
 <<elseif $skewedForced < 4>>
 	Would you like to use the Skewed Shrine to give a Curse to one of your willing companions at the cost of <<print ($skewedUsed * 5)>> dubloons?<br>
-	<<link "Yes, use the Skewed Shrine to transfer a Curse" "Layer3 Skewed1a">>
-		<<AdjustedTravelTime "_travelTime" 3>>
-		<<set setup.startPassingTime('Layer3 Skewed1a', _travelTime)>>
-	<</link>><br><br>
+	<<TravelToPassage 'Yes, use the Skewed Shrine to transfer a Curse' 'Layer3 Skewed1a' 3>><br><br>
 	Would you like to use the Skewed Shrine to force a Curse upon one of your unwilling companions at the cost of <<print ($skewedUsed * 5)>> dubloons?<br>
-	<<link "Yes, use the Skewed Shrine to force a Curse" "Layer3 Skewed 2a">>
-		<<AdjustedTravelTime "_travelTime" 3>>
-		<<set setup.startPassingTime('Layer3 Skewed 2a', _travelTime)>>
-	<</link>><br><br>
+	<<TravelToPassage 'Yes, use the Skewed Shrine to force a Curse' 'Layer3 Skewed 2a' 3>><br><br>
 <<else>>
 	None of your companions trust you at this shrine anymore. None will get close enough for you to use the shrine with them. They watch you with eyes full of fear and anger, as if they could bolt at any moment and leave you alone in the Abyss.<br><br>
 <</if>>
@@ -313,7 +305,7 @@ In the deeper parts of the layer, a cold breeze occasionally blows through the c
 	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
-<<include "Layer3 Travel Events">>
+<<PassTimeWithEvents>>
 
 <</nobr>>\
 <<if !setup.passingTime()>>
@@ -338,7 +330,7 @@ In the deeper parts of the layer, a cold breeze occasionally blows through the c
 	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
-<<include "Layer3 Travel Events">>
+<<PassTimeWithEvents>>
 
 <</nobr>>\
 <<if !setup.passingTime()>>\
@@ -365,7 +357,7 @@ Once you pick them up, the luster of the scales fades, indicating that they will
 	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
-<<include "Layer3 Travel Events">>
+<<PassTimeWithEvents>>
 
 <</nobr>>\
 <<if !setup.passingTime()>>\
@@ -387,11 +379,7 @@ As you pick up the dubloons from the scales, you notice that the luster of the s
 
 
 :: Layer3 Skewed1a [layer3]
-<<nobr>>
-
-<<include "Layer3 Travel Events">>
-
-<</nobr>>\
+<<PassTimeWithEvents>>\
 <<if !setup.passingTime()>>\
 [img[setup.ImagePath+'Wonders/slantedshrine.png']]
 
@@ -455,11 +443,7 @@ Which Curse would you like to transfer to your willing companion? It can't be to
 
 
 :: Layer3 Skewed 2a [layer3]
-<<nobr>>
-
-<<include "Layer3 Travel Events">>
-
-<</nobr>>\
+<<PassTimeWithEvents>>\
 <<if !setup.passingTime()>>\
 [img[setup.ImagePath+'Wonders/slantedshrine.png']]
 
@@ -890,7 +874,7 @@ On the other hand, the idea of each encounter feeling like your first time holds
 	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
-<<include "Layer3 Travel Events">>
+<<PassTimeWithEvents>>
 
 <</nobr>>\
 <<if !setup.passingTime()>>\
@@ -1153,7 +1137,7 @@ Please enter a new eye color:
 	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
-<<include "Layer3 Travel Events">>
+<<PassTimeWithEvents>>
 
 <</nobr>>\
 <<if !setup.passingTime()>>

--- a/src/layer3.twee
+++ b/src/layer3.twee
@@ -143,9 +143,7 @@ If you decide to start foraging for food or water, it means that you will not co
 	You can also wait at the underground river if you'd like to pass the time while waiting for something.<br>
 	How many days would you like to wait at the underground river?<br>
 	<<textbox "_waitTime" "0">>
-	<<link "Wait" `passage()`>>
-		<<set setup.startPassingTime(passage(), Math.max(parseInt(_waitTime, 10) || 0, 0))>>
-	<</link>><br><br>
+	<<WaitAtPassage 'Wait' `passage()` `Math.max(parseInt(_waitTime, 10) || 0, 0)`>><br><br>
 <</if>>
 <</nobr>>\
 [[Return to exploring the rest of the layer|Layer3 Hub]]

--- a/src/layer4.twee
+++ b/src/layer4.twee
@@ -248,7 +248,7 @@ The Brave Vector Relic you can find here is a perfect example of something you m
 
 <<if !$purityUsed>>
 	Would you like to travel to the Purity Tree?<br>
-	[[Yes, choose what you want to do with the tree|Layer4 Purity 1]]<br><br>
+	<<TravelToPassage 'Yes, choose what you want to do with the tree' 'Layer4 Purity 1' 5>><br><br>
 	<<else>>
 	You can only use the rare species of purity tree one time.<br><br>
 <</if>>
@@ -292,7 +292,7 @@ Between this layer and the next is a kilometers-long sheer drop with a near-feat
 The air seems to get drier as you proceed further down. You might want to stockpile plenty of water before continuing on, probably around 2 weeks worth at a minimum.
 
 [[Turn back and continue your business on the fourth layer|Layer4 Hub]]
-[[Continue your descent to the fifth layer|Layer4 Exit2]]
+<<TravelToPassage 'Continue your descent to the fifth layer' 'Layer4 Exit2' `setup.haveRope ? 8 : 19`>>
 
 
 :: Take on Libido Reinforcement C [layer4]
@@ -812,16 +812,7 @@ Which Curse would you like to forcibly copy onto your unwilling companion?
 
 
 :: Layer4 Purity 1 [layer4]
-<<nobr>>
-
-<<if !setup.passingTime()>>
-	<<AdjustedTravelTime "_travelTime" 5>>
-	<<set setup.startPassingTime(passage(), _travelTime)>>
-<</if>>
-
-<<PassTimeWithEvents>>
-
-<</nobr>>\
+<<PassTimeWithEvents>>\
 <<if !setup.passingTime()>>\
 [img[setup.ImagePath+'Wonders/puritytree.png']]
 
@@ -1238,19 +1229,15 @@ Your hands reach a small crevasse, offering a much-needed respite from the climb
 
 :: Layer4 Ascend2 [layer4]
 <<nobr>>
-
 <<if !setup.passingTime()>>
 	<<set _multiplier = 1>>
 	<<if $DaedalusFly>>
 		<<include "Companions Stranded">>
 		<<set _multiplier = 1/2>>
 	<</if>>
-	<<AdjustedTravelTime "_travelTime" 7 false 0 _multiplier>>
-	<<set setup.startPassingTime(passage(), _travelTime)>>
+	<<StartTraveling 7 0 _multiplier>>
 <</if>>
-
 <<PassTimeWithEvents>>
-
 <</nobr>>\
 <<if !setup.passingTime()>>
 	<<nobr>>
@@ -1267,16 +1254,7 @@ Your hands reach a small crevasse, offering a much-needed respite from the climb
 
 
 :: Layer4 Exit2 [layer4]
-<<nobr>>
-
-<<if !setup.passingTime()>>
-	<<AdjustedTravelTime "_travelTime" `setup.haveRope ? 8 : 19`>>
-	<<set setup.startPassingTime(passage(), _travelTime)>>
-<</if>>
-
-<<PassTimeWithEvents>>
-
-<</nobr>>\
+<<PassTimeWithEvents>>\
 <<if !setup.passingTime()>>
 	You continue your hike and try to keep somewhat warm despite the bone-chilling cold and your treacherous journey along the pit of sheer ice. As you get closer to the bottom, the temperature rises and the air starts to dry out.
 

--- a/src/layer4.twee
+++ b/src/layer4.twee
@@ -239,15 +239,9 @@ The Brave Vector Relic you can find here is a perfect example of something you m
 	You must have companions if you would like to use the Steady Shrine.<br><br>
 <<elseif $steadyForced < 4>>
 	Would you like to use the Steady Shrine to copy a Curse to one of your willing companions at the cost of <<print ($skewedUsed * 5)>> dubloons?<br>
-	<<link "Yes, use the Steady Shrine to copy a Curse" "Layer4 Steady1a">>
-		<<AdjustedTravelTime "_travelTime" 3>>
-		<<set setup.startPassingTime('Layer4 Steady1a', _travelTime)>>
-	<</link>><br><br>
+	<<TravelToPassage 'Yes, use the Steady Shrine to copy a Curse' 'Layer4 Steady1a' 3>><br><br>
 	Would you like to use the Steady Shrine to forcibly copy a Curse onto one of your unwilling companions at the cost of <<print ($skewedUsed * 5)>> dubloons?<br>
-	<<link "Yes, use the Steady Shrine to forcibly copy a Curse" "Layer4 Steady 2a">>
-		<<AdjustedTravelTime "_travelTime" 3>>
-		<<set setup.startPassingTime('Layer4 Steady 2a', _travelTime)>>
-	<</link>><br><br>
+	<<TravelToPassage 'Yes, use the Steady Shrine to forcibly copy a Curse' 'Layer4 Steady 2a' 3>><br><br>
 <<else>>
 	None of your companions trust you at this shrine anymore. None will get close enough for you to use the shrine with them. They watch you with eyes full of fear and anger, as if they could bolt at any moment and leave you alone in the Abyss.<br><br>
 <</if>>
@@ -718,11 +712,7 @@ Using your knowledge of the Abyss, you specifically look to make sure you can ge
 
 
 :: Layer4 Steady1a [layer4]
-<<nobr>>
-
-<<include "Layer4 Travel Events">>
-
-<</nobr>>\
+<<PassTimeWithEvents>>\
 <<if !setup.passingTime()>>\
 [img[setup.ImagePath+'Wonders/steadyshrine.png']]
 
@@ -787,11 +777,7 @@ Which Curse would you like to transfer to your willing companion? It can't be to
 
 
 :: Layer4 Steady 2a [layer4]
-<<nobr>>
-
-<<include "Layer4 Travel Events">>
-
-<</nobr>>\
+<<PassTimeWithEvents>>\
 <<if !setup.passingTime()>>\
 [img[setup.ImagePath+'Wonders/steadyshrine.png']]
 
@@ -833,7 +819,7 @@ Which Curse would you like to forcibly copy onto your unwilling companion?
 	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
-<<include "Layer4 Travel Events">>
+<<PassTimeWithEvents>>
 
 <</nobr>>\
 <<if !setup.passingTime()>>\
@@ -1263,7 +1249,7 @@ Your hands reach a small crevasse, offering a much-needed respite from the climb
 	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
-<<include "Layer4 Travel Events">>
+<<PassTimeWithEvents>>
 
 <</nobr>>\
 <<if !setup.passingTime()>>
@@ -1288,7 +1274,7 @@ Your hands reach a small crevasse, offering a much-needed respite from the climb
 	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
-<<include "Layer4 Travel Events">>
+<<PassTimeWithEvents>>
 
 <</nobr>>\
 <<if !setup.passingTime()>>

--- a/src/layer5.twee
+++ b/src/layer5.twee
@@ -260,9 +260,7 @@ If you decide to start foraging for food or water, it means that you will not co
 	You can also wait at the oasis if you'd like to pass the time while waiting for something.<br>
 	How many days would you like to wait at the oasis?<br>
 	<<textbox "_waitTime" "0">>
-	<<link "Wait" `passage()`>>
-		<<set setup.startPassingTime(passage(), Math.max(parseInt(_waitTime, 10) || 0, 0))>>
-	<</link>><br><br>
+	<<WaitAtPassage 'Wait' `passage()` `Math.max(parseInt(_waitTime, 10) || 0, 0)`>><br><br>
 <</if>>
 <</nobr>>\
 [[Return to exploring the rest of the layer|Layer5 Hub]]
@@ -1405,9 +1403,7 @@ Testing your Pocket Hoard, you stick a hand into the pink rucksack, but find you
 
 	You can wait here for a while if you'd like to check when the door is open. If you'd like to wait, enter the number of days you'd like to wait and choose to wait.
 	<<textbox "_waitTime" "0">>
-	<<link "Wait" `passage()`>>
-		<<set setup.startPassingTime(passage(), Math.max(parseInt(_waitTime, 10) || 0, 0))>>
-	<</link>>
+	<<WaitAtPassage 'Wait' `passage()` `Math.max(parseInt(_waitTime, 10) || 0, 0)`>>
 
 	The door remains locked. You must wait until the timer is between 0 and -5 for it to open and reveal the treasures within.
 <<elseif -5 <= $vaultTimer - $time && $vaultTimer - $time <= 0>>

--- a/src/layer5.twee
+++ b/src/layer5.twee
@@ -245,15 +245,15 @@ If you decide to start foraging for food or water, it means that you will not co
 <</if>>
 <<if $items[2].count > 0>>
 	<<if $atWaterSource>>
-		[[Fill your empty flasks with water from the oasis|Layer5 Flasks]]<br><br>
+		<<link 'Fill your empty flasks with water from the oasis' 'Layer5 Flasks'>><</link>><br><br>
 	<<else>>
-		[[Fill your empty flasks with water from an oasis|Layer5 Flasks]]<br><br>
+		<<TravelToPassage 'Fill your empty flasks with water from an oasis' 'Layer5 Flasks' 7 `-($abyssKnow + 2 * $oasisVisit)`>><br><br>
 	<</if>>
 <<else>>
 	<<if $atWaterSource>>
 		You need empty flasks to fill them with water from the oasis.<br><br>
 	<<else>>
-		[[Find an oasis to avoid using your water|Layer5 Flasks]]<br><br>
+		<<TravelToPassage 'Find an oasis to avoid using your water' 'Layer5 Flasks' 7 `-($abyssKnow + 2 * $oasisVisit)`>><br><br>
 	<</if>>
 <</if>>
 <<if $atWaterSource>>
@@ -302,7 +302,7 @@ You do not have a medkit to cure your status condition.<br>
 <<set _name = _layerRelics[_i]>>
 <<set _relic = $relics.find(r => r.name === _name)>>
 <<set _corr = Math.max(_relic.corr - $corRed + ($currentLayer != 6 ? 5 * Math.trunc($hexflame / 10) : 0), 0)>>
-<<silently>><<AdjustedTravelTime "_time" _relic.time true `-$SibylBuff`>><</silently>>
+<<PreviewTravelTime '_time' _relic.time `-$SibylBuff` 1>>
 <<set _corrStyle = _corr > _relic.corr ? "@@color:red;" : _corr < _relic.corr ? "@@color:green;" : "">>
 <<set _timeStyle = _time > _relic.time ? "@@color:red;" : _time < _relic.time ? "@@color:green;" : "">>
 [img[setup.ImagePath + _relic.pic]]
@@ -384,13 +384,13 @@ Already taken
 
 Do you want to walk through the One-sided Tunnel and send your items back up to the surface?
 
-[[Walk through the tunnel|Layer5 Tunnel]]
+<<TravelToPassage 'Walk through the tunnel' 'Layer5 Tunnel' 2>>
 <<set _totalRelics = $ownedRelics.concat($soldRelics)>>
 <<if _totalRelics.some(e => e.name === "Superpositional Skewer") && $items[7].count > 0>>
 
 	You can also utilize your Superpositional Skewer to sync with your commerce balloon, then swap it with a rock or something after you leave the Tunnel, which would allow you to instantly retrieve your items if you wish to. 
 
-	[[Use the Superpositional Skewer to save 1 commerce balloon, then enter the Tunnel|Layer5 Tunnel][$tunnelSkewer = 1]]
+	<<TravelToPassage 'Use the Superpositional Skewer to save 1 commerce balloon, then enter the Tunnel' 'Layer5 Tunnel' 2 0 1 '$tunnelSkewer = 1'>>
 <</if>>
 <<if $vaultTimer == 0>>
 Do you want to walk to the Mirage Vault to activate it for the first time?
@@ -398,10 +398,7 @@ Do you want to walk to the Mirage Vault to activate it for the first time?
 Do you want to check on the Mirage Vault and see if it's open?
 <</if>>
 
-<<link "Walk to the Mirage Vault door" "Layer5 Vault">>
-	<<AdjustedTravelTime "_travelTime" 3>>
-	<<set setup.startPassingTime('Layer5 Vault', _travelTime)>>
-<</link>>
+<<TravelToPassage 'Walk to the Mirage Vault door' 'Layer5 Vault' 3>>
 
 <<back>>
 
@@ -441,20 +438,11 @@ Either way, it will also cost 50 corruption.
 Layer 5 is the last layer that anyone on the surface currently has any reliable knowledge of. Reports of what lies further below often contain vague strange, and contradictory information, and few emerging from dives that venture lower are in a state to be reporting information to begin with. This means that sources like the Encyclopedia Abyssia are unlikely to be helpful from here on. If you understand this, and still wish to descend further to depths beyond humanity's current understanding, the trip will take 13 days.
 
 [[Turn back and continue your business on the fifth layer|Layer5 Hub]]
-[[Continue your descent to the sixth layer|Layer5 Exit2]]
+<<TravelToPassage 'Continue your descent to the sixth layer' 'Layer5 Exit2' 13>>
 
 
 :: Layer5 Flasks [layer5]
-<<nobr>>
-
-<<if !setup.passingTime() && !$atWaterSource>>
-	<<AdjustedTravelTime "_travelTime" 7 true `-$abyssKnow - 2 * $oasisVisit`>>
-	<<set setup.startPassingTime(passage(), _travelTime)>>
-<</if>>
-
-<<PassTimeWithEvents>>
-
-<</nobr>>\
+<<PassTimeWithEvents>>\
 <<if !setup.passingTime()>>\
 [img[setup.ImagePath+'Foraging/oasis.png']]
 <<if $atWaterSource>>
@@ -1350,16 +1338,7 @@ Please enter your new exoskeleton color:
 
 
 :: Layer5 Tunnel [layer5]
-<<nobr>>
-
-<<if !setup.passingTime()>>
-	<<AdjustedTravelTime "_travelTime" 2>>
-	<<set setup.startPassingTime(passage(), _travelTime)>>
-<</if>>
-
-<<PassTimeWithEvents>>
-
-<</nobr>>\
+<<PassTimeWithEvents>>\
 <<if !setup.passingTime()>>\
 [img[setup.ImagePath+'Wonders/one-sidedtunnel.png']]
 
@@ -1476,19 +1455,15 @@ Testing your Pocket Hoard, you stick a hand into the pink rucksack, but find you
 
 :: Layer5 Ascend2 [layer5]
 <<nobr>>
-
 <<if !setup.passingTime()>>
 	<<set _multiplier = 1>>
 	<<if $DaedalusFly>>
 		<<include "Companions Stranded">>
 		<<set _multiplier = 1/2>>
 	<</if>>
-	<<AdjustedTravelTime "_travelTime" `setup.haveRope ? 11 : 24` false 0 _multiplier>>
-	<<set setup.startPassingTime(passage(), _travelTime)>>
+	<<StartTraveling `setup.haveRope ? 11 : 24` 0 _multiplier>>
 <</if>>
-
 <<PassTimeWithEvents>>
-
 <</nobr>>
 <<if !setup.passingTime()>>
 	<<nobr>>
@@ -1510,29 +1485,16 @@ Testing your Pocket Hoard, you stick a hand into the pink rucksack, but find you
 
 When you wake up in the morning, you hear an enormous amount of buzzing in the air, luckily you managed to stay out of the swarm when you woke up. They scarlet bugs produce a potent aphrodisiac venom, so if you choose to go out into the swarm, and succumb to the venom to participate in a day of sexual debauchery. On the other hand, you can stay in one of the ruins for the day and avoid the swarms altogether. Either choice will cost you one day.
 
-<<link "Walk out into the swarm and enjoy the sexual festivities" "Layer5 Mayfly Scuttler Sexual Activities">>
-	<<PassTime 1>>
-<</link>>
+<<link "Walk out into the swarm and enjoy the sexual festivities" "Layer5 Mayfly Scuttler Sexual Activities">><<PassTime 1>><</link>>
 
-<<link "Hide out in the ruins for the day" `$returnPassage`>>
-	<<PassTime 1>>
-<</link>>
+<<link "Hide out in the ruins for the day" `$returnPassage`>><<PassTime 1>><</link>>
 
 Use the following option only if you have specifically considered your inventory and made a plan of how to use what you have to rid of or avoid these pests.
 [[Use a combination of Relics not mentioned above you believe would be able to get rid of the swarm|$returnPassage]]
 
 
 :: Layer5 Exit2 [layer5]
-<<nobr>>
-
-<<if !setup.passingTime()>>
-	<<AdjustedTravelTime "_travelTime" 13>>
-	<<set setup.startPassingTime(passage(), _travelTime)>>
-<</if>>
-
-<<PassTimeWithEvents>>
-
-<</nobr>>\
+<<PassTimeWithEvents>>\
 <<if !setup.passingTime()>>
 	You continue through the scorching desert for days on end, but the heat only seems to get more intense. But the smell is different, you catch a whiff of more exotic, meaty scents than the fragrance of the flowers of the fifth layer. As the ground begins to change from sand to a more organic texture, you know you're approaching the sixth layer.
 

--- a/src/layer5.twee
+++ b/src/layer5.twee
@@ -230,9 +230,7 @@ How would you like to use Cherry's chaotic luck ability?
 
 
 :: Layer5 Forage [image layer5]
-<<if setup.passingTime()>>
-	<<include "Layer5 Travel Events">>
-<</if>>\
+<<PassTimeWithEvents>>\
 <<if !setup.passingTime()>>\
 <<checkTime>>
 [img[setup.ImagePath+'Clipped-Fin/Abyss Diver Page 6-foraging.png']]
@@ -454,7 +452,7 @@ Layer 5 is the last layer that anyone on the surface currently has any reliable 
 	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
-<<include "Layer5 Travel Events">>
+<<PassTimeWithEvents>>
 
 <</nobr>>\
 <<if !setup.passingTime()>>\
@@ -1359,7 +1357,7 @@ Please enter your new exoskeleton color:
 	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
-<<include "Layer5 Travel Events">>
+<<PassTimeWithEvents>>
 
 <</nobr>>\
 <<if !setup.passingTime()>>\
@@ -1414,11 +1412,7 @@ Testing your Pocket Hoard, you stick a hand into the pink rucksack, but find you
 
 
 :: Layer5 Vault [layer5]
-<<nobr>>
-
-<<include "Layer5 Travel Events">>
-
-<</nobr>>\
+<<PassTimeWithEvents>>\
 <<if !setup.passingTime()>>\
 [img[setup.ImagePath+'Wonders/miragevault.png']]
 <<nobr>>
@@ -1493,7 +1487,7 @@ Testing your Pocket Hoard, you stick a hand into the pink rucksack, but find you
 	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
-<<include "Layer5 Travel Events">>
+<<PassTimeWithEvents>>
 
 <</nobr>>
 <<if !setup.passingTime()>>
@@ -1536,7 +1530,7 @@ Use the following option only if you have specifically considered your inventory
 	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
-<<include "Layer5 Travel Events">>
+<<PassTimeWithEvents>>
 
 <</nobr>>\
 <<if !setup.passingTime()>>

--- a/src/layer6.twee
+++ b/src/layer6.twee
@@ -270,11 +270,7 @@ There is a very easily accessible source of water on this layer, the River Dycx,
 
 
 :: Layer6 Maw1 [image layer6]
-<<nobr>>
-
-<<include "Layer6 Travel Events">>
-
-<</nobr>>\
+<<PassTimeWithEvents>>\
 <<if !setup.passingTime()>>\
 [img[setup.ImagePath+'Clipped-Fin/Abyss Diver Page 7-wonders.png']]
 <<if !$mawUse>>
@@ -973,7 +969,7 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
-<<include "Layer6 Travel Events">>
+<<PassTimeWithEvents>>
 
 <</nobr>>\
 <<if !setup.passingTime()>>
@@ -998,7 +994,7 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
-<<include "Layer6 Travel Events">>
+<<PassTimeWithEvents>>
 
 <</nobr>>\
 <<if !setup.passingTime()>>

--- a/src/layer6.twee
+++ b/src/layer6.twee
@@ -193,11 +193,7 @@ If you decide to start foraging for food or water, it means that you will not co
 
 Do you want to approach the Maw of Kimaris to get a copy of a Relic from a higher layer?
 
-<<link "Approach the Maw" "Layer6 Maw1">>
-	<<AdjustedTravelTime "_travelTime" 3>>
-	<<set setup.startPassingTime('Layer6 Maw1', _travelTime)>>
-<</link>>
-
+<<TravelToPassage 'Approach the Maw' 'Layer6 Maw1' 3>>
 
 <<back>>
 
@@ -238,7 +234,7 @@ There is no indication of what you might find beyond layer 6. There are a few hi
 Traversing down and past this hell will take 16 days.
 
 [[Turn back and continue your business on the sixth layer|Layer6 Hub]]
-[[Continue your descent to the seventh layer|Layer6 Exit2]]
+<<TravelToPassage 'Continue your descent to the seventh layer' 'Layer6 Exit2' 16>>
 
 
 :: Layer6 Flasks [layer6]
@@ -958,19 +954,15 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 
 :: Layer6 Ascend2 [layer6]
 <<nobr>>
-
 <<if !setup.passingTime()>>
 	<<set _multiplier = 1>>
 	<<if $DaedalusFly>>
 		<<include "Companions Stranded">>
 		<<set _multiplier = 1/2>>
 	<</if>>
-	<<AdjustedTravelTime "_travelTime" 15 false 0 _multiplier>>
-	<<set setup.startPassingTime(passage(), _travelTime)>>
+	<<StartTraveling 15 0 _multiplier>>
 <</if>>
-
 <<PassTimeWithEvents>>
-
 <</nobr>>\
 <<if !setup.passingTime()>>
 	<<nobr>>
@@ -987,16 +979,7 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 
 
 :: Layer6 Exit2 [layer6]
-<<nobr>>
-
-<<if !setup.passingTime()>>
-	<<AdjustedTravelTime "_travelTime" 16>>
-	<<set setup.startPassingTime(passage(), _travelTime)>>
-<</if>>
-
-<<PassTimeWithEvents>>
-
-<</nobr>>\
+<<PassTimeWithEvents>>\
 <<if !setup.passingTime()>>
 	You continue through the playfully ticklish yet hellishly searing tentacles for a long hike downward. You find some small hints of paved paths that have long since degraded, but no other indication of what is next for you, until suddenly you are faced with a metal barricade, signaling the end of the sixth layer and the start of the seventh.
 

--- a/src/layer7.twee
+++ b/src/layer7.twee
@@ -1511,10 +1511,7 @@ You have worked $temp1 days and brought robots to artificial orgasm $temp2 times
 <<include 'CampCode'>>
 
 :: Layer7 Threat2 [layer7]
-<<nobr>>
-<<set $timeL7T2 -= 6>>
-<<PassTime 1>>
-<</nobr>>
+<<set $timeL7T2 -= 6>><<PassTime 1>>\
 [img[setup.ImagePath+'Threats/securityrobot.png']]
 
 <<if $playerCurses.some(e => e.name === "Hypno Happytime") && $layer7Hypno < 3>><<set $layer7Hypno += 1>>

--- a/src/layer7.twee
+++ b/src/layer7.twee
@@ -1357,7 +1357,7 @@ You have no choice, you gain consciousness a few times to see yourself in a surg
 	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
-<<include "Layer7 Travel Events">>
+<<PassTimeWithEvents>>
 
 <</nobr>>\
 <<if !setup.passingTime()>>
@@ -1384,7 +1384,7 @@ You have no choice, you gain consciousness a few times to see yourself in a surg
 	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
-<<include "Layer7 Travel Events">>
+<<PassTimeWithEvents>>
 
 <</nobr>>\
 <<if !setup.passingTime()>>

--- a/src/layer7.twee
+++ b/src/layer7.twee
@@ -270,7 +270,7 @@ It is reccomended that you get creative with your Relics and think of more effic
 [img[setup.ImagePath+'Clipped-Fin/Abyss Diver Page 8-wonders2.png']]
 
 Do you want to visit the Clockwork Forge to swap Relic abilities?
-[[Approach the Forge|Layer7 Forge1]]
+<<TravelToPassage 'Approach the Forge' 'Layer7 Forge1' 2>>
 
 Do you want to check out the Vend-o-matic 6900 to purchase new items?
 [[Approach the Vend-o-matic|Layer7 Vend]]
@@ -322,7 +322,7 @@ As you head towards the bottom of the city to descend to the next layer, you not
 If you're not dissuaded and choose to continue onward, it will take you 8 days to reach this layer's bottom.
 
 [[Turn back and continue your business on the seventh layer|Layer7 Hub]]
-[[Continue your descent to the eighth layer|Layer7 Exit2]]
+<<TravelToPassage 'Continue your descent to the eighth layer' 'Layer7 Exit2' 8>>
 
 
 :: Pick up the Daedalus Mechanism [layer7]
@@ -485,7 +485,7 @@ If you choose to place 2 Relics in the Clockwork Forge, along with 4 dubloons, y
 
 
 [[Use the Forge to swap the abilities of 2 Relics|Layer7 Forge2]]
-<<back>>
+[[Continue exploring the seventh layer|Layer7 Hub]]
 
 
 :: Layer7 Vend [layer7 cards nobr]
@@ -1285,7 +1285,6 @@ You retrieve your Relics and find that you have successfully switched the abilit
 
 [[Continue your business on the seventh layer|Layer7 Hub]]<br><br>
 
-<<AdjustedTravelTime "$tempTime" 2>><<PassTime $tempTime>>
 <<set $dubloons -= 4>>
 
 <<set $temp = $relicSwap.length>>
@@ -1346,19 +1345,15 @@ You have no choice, you gain consciousness a few times to see yourself in a surg
 
 :: Layer7 Ascend2 [layer7]
 <<nobr>>
-
 <<if !setup.passingTime()>>
 	<<set _multiplier = 1>>
 	<<if $DaedalusFly>>
 		<<include "Companions Stranded">>
 		<<set _multiplier = 1/2>>
 	<</if>>
-	<<AdjustedTravelTime "_travelTime" 7 false 0 _multiplier>>
-	<<set setup.startPassingTime(passage(), _travelTime)>>
+	<<StartTraveling 7 0 _multiplier>>
 <</if>>
-
 <<PassTimeWithEvents>>
-
 <</nobr>>\
 <<if !setup.passingTime()>>
 	<<nobr>>
@@ -1377,16 +1372,7 @@ You have no choice, you gain consciousness a few times to see yourself in a surg
 
 
 :: Layer7 Exit2 [layer7]
-<<nobr>>
-
-<<if !setup.passingTime()>>
-	<<AdjustedTravelTime "_travelTime" 8>>
-	<<set setup.startPassingTime(passage(), _travelTime)>>
-<</if>>
-
-<<PassTimeWithEvents>>
-
-<</nobr>>\
+<<PassTimeWithEvents>>\
 <<if !setup.passingTime()>>
 	After days of travel, you reach the bottom of the city. What awaits you is an enormous, circular gate, embedded into the ground at the lowest point of the city, almost like an elaborate manhole cover.
 

--- a/src/layer8.twee
+++ b/src/layer8.twee
@@ -1332,19 +1332,15 @@ Ready? Getting back up out of this terrible prison and back to layer 7 will take
 
 :: Layer8 Ascend2 [layer8]
 <<nobr>>
-
 <<if !setup.passingTime()>>
 	<<set _multiplier = 1>>
 	<<if $DaedalusFly>>
 		<<include "Companions Stranded">>
 		<<set _multiplier = 1/2>>
 	<</if>>
-	<<AdjustedTravelTime "_travelTime" 40 false 0 _multiplier>>
-	<<set setup.startPassingTime(passage(), _travelTime)>>
+	<<StartTraveling 40 0 _multiplier>>
 <</if>>
-
 <<PassTimeWithEvents>>
-
 <</nobr>>\
 <<if !setup.passingTime()>>
 	<<nobr>>
@@ -1368,20 +1364,11 @@ Ready? Getting back up out of this terrible prison and back to layer 7 will take
 If you continue your descent in spite of everything, descending past this layer's mind-boggling architecture and into what lies beyond will take 45 days.
 
 [[Turn back and continue your business on the eighth layer|Layer8 Hub]]
-[[Continue your descent to the ninth layer|Layer8 Exit2]]
+<<TravelToPassage 'Continue your descent to the ninth layer' 'Layer8 Exit2' 45>>
 
 
 :: Layer8 Exit2 [layer8]
-<<nobr>>
-
-<<if !setup.passingTime()>>
-	<<AdjustedTravelTime "_travelTime" 45>>
-	<<set setup.startPassingTime(passage(), _travelTime)>>
-<</if>>
-
-<<PassTimeWithEvents>>
-
-<</nobr>>\
+<<PassTimeWithEvents>>\
 <<if !setup.passingTime()>>
 	At the very bottom of the layer you come across what appears to be a very deep pool of water. There doesn't seem to be any other way through besides this pool, so you'll need some kind of way to breathe underwater to continue forwards. The diving gear from Outset town or the Merfolk Curse could work, or you could use the Pneuma Wisp Relic to bypass the issue entirely. Other than that, you would need to get creative.
 

--- a/src/layer8.twee
+++ b/src/layer8.twee
@@ -1343,7 +1343,7 @@ Ready? Getting back up out of this terrible prison and back to layer 7 will take
 	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
-<<include "Layer8 Travel Events">>
+<<PassTimeWithEvents>>
 
 <</nobr>>\
 <<if !setup.passingTime()>>
@@ -1379,7 +1379,7 @@ If you continue your descent in spite of everything, descending past this layer'
 	<<set setup.startPassingTime(passage(), _travelTime)>>
 <</if>>
 
-<<include "Layer8 Travel Events">>
+<<PassTimeWithEvents>>
 
 <</nobr>>\
 <<if !setup.passingTime()>>

--- a/src/relics.twee
+++ b/src/relics.twee
@@ -1622,7 +1622,7 @@ The one supernatural effect not cancelled is the unbreakability of Eternal Repos
     <div>
     <<set _relic = $relics.find(r => r.name === _name)>>
     <<set _corr = Math.max(_relic.corr - $corRed + ($currentLayer != 6 ? 5 * Math.trunc($hexflame / 10) : 0), 0)>>
-    <<silently>><<AdjustedTravelTime "_time" _relic.time true `-$SibylBuff`>><</silently>>
+    <<PreviewTravelTime '_time' _relic.time `-$SibylBuff` 1>>
     <<set _corrStyle = _corr > _relic.corr ? "@@color:red;" : _corr < _relic.corr ? "@@color:green;" : "">>
     <<set _timeStyle = _time > _relic.time ? "@@color:red;" : _time < _relic.time ? "@@color:green;" : "">>
     [img[setup.ImagePath + _relic.pic]]

--- a/src/widgets.twee
+++ b/src/widgets.twee
@@ -2403,7 +2403,7 @@
 		<<AdjustedTravelTime "_travelTime" _relic.time false `-$SibylBuff`>>
 		<<set setup.startPassingTime(passage(), _travelTime)>>
 	<</if>>
-	<<include `"Layer" + $currentLayer + " Travel Events"`>>
+	<<PassTimeWithEvents>>
 	<<if !setup.passingTime()>>
 		<<set $ownedRelics.push(_relic)>>
 		<<set $corruption -= Math.max(_relic.corr - $corRed + ($currentLayer != 6 ? 5 * Math.trunc($hexflame / 10) : 0), 0)>>

--- a/src/widgets.twee
+++ b/src/widgets.twee
@@ -2400,8 +2400,7 @@
 <<capture _relic _travelTime>>
 	<<set _relic = _args[0]>>
 	<<if !setup.passingTime()>>
-		<<AdjustedTravelTime "_travelTime" _relic.time false `-$SibylBuff`>>
-		<<set setup.startPassingTime(passage(), _travelTime)>>
+		<<StartTraveling _relic.time `-$SibylBuff`>>
 	<</if>>
 	<<PassTimeWithEvents>>
 	<<if !setup.passingTime()>>

--- a/t3lt.twee-config.yml
+++ b/t3lt.twee-config.yml
@@ -169,6 +169,10 @@ sugarcube-2:
       name: Threat1Criterion
       parameters:
         - ""
+    TravelToPassage:
+      name: TravelToPassage
+      parameters:
+        - "var|string &+ var|string &+ var|number |+ var|number |+ var|number"
     UpdateAttributes:
       name: UpdateAttributes
       parameters:

--- a/t3lt.twee-config.yml
+++ b/t3lt.twee-config.yml
@@ -104,6 +104,10 @@ sugarcube-2:
       name: PassTime
       parameters:
         - "var|number"
+    PassTimeWithEvents:
+      name: PassTimeWithEvents
+      parameters:
+        - ""
     PenisLengthText:
       name: PenisLengthText
       parameters:

--- a/t3lt.twee-config.yml
+++ b/t3lt.twee-config.yml
@@ -193,3 +193,7 @@ sugarcube-2:
       name: volume
       parameters:
         - ""
+    WaitAtPassage:
+      name: WaitAtPassage
+      parameters:
+        - "var|string &+ var|string &+ var|number |+ string"

--- a/t3lt.twee-config.yml
+++ b/t3lt.twee-config.yml
@@ -1,9 +1,5 @@
 sugarcube-2:
   macros:
-    AdjustedTravelTime:
-      name: AdjustedTravelTime
-      parameters:
-        - "string &+ var|number |+ bool |+ var|number |+ var|number"
     AffectionChange:
       name: AffectionChange
       parameters:
@@ -140,6 +136,10 @@ sugarcube-2:
       name: PregCheck
       parameters:
         - ""
+    PreviewTravelTime:
+      name: PreviewTravelTime
+      parameters:
+        - "string &+ var|number |+ var|number |+ var|number"
     Pronoun:
       name: Pronoun
       parameters:
@@ -169,6 +169,10 @@ sugarcube-2:
       name: sirmaam
       parameters:
        - ""
+    StartTraveling:
+      name: StartTraveling
+      parameters:
+        - "var|number |+ var|number |+ var|number |+ string |+ 'preview'"
     Threat1Criterion:
       name: Threat1Criterion
       parameters:
@@ -176,7 +180,7 @@ sugarcube-2:
     TravelToPassage:
       name: TravelToPassage
       parameters:
-        - "var|string &+ var|string &+ var|number |+ var|number |+ var|number"
+        - "var|string &+ var|string &+ var|number |+ var|number |+ var|number |+ string"
     UpdateAttributes:
       name: UpdateAttributes
       parameters:


### PR DESCRIPTION
I'm pretty happy with this. After these changes:
* Everything except going *up* a layer uses the new widget `<<TravelToPassage>>`. This replaces a bunch of `[[ ]]` style links with something closer to a `<<link>>`.
* `<<AdjustedTravelTime>>` is now `<<StartTraveling>>`, and for the couple of cases where we just want to know how much time it's expected to take there's now `<<PreviewTravelTime>>`.
* This also adds `<<WaitAtPassage>>` for the few places where we really just want to wait in a passage.
* This gets rid of all calls to `setup.startPassingTime()` outside of the relevant widgets in `global.twee`.

There are still a few `<<PassTime>>` calls left; these are all for edge cases like giving birth, working on layer 7, or after getting tentacle.. loved.

I'm not sure what to do about those - time still passes, so the layer timers get incremented, but would it make more sense to suspend them? Especially on layer 7, where you're literally working your ass off to make ends meet :P