### PR TITLE
Inanis Ego and other time-based event fixes

### DIFF
--- a/src/companionConversations.twee
+++ b/src/companionConversations.twee
@@ -50,7 +50,7 @@
 <<if $ownedRelics.some(e => e.name === "Smitten Mitt") && $convo.maruSmitten == 0>>
 	<<set _numConvos += 1>>[[Maru is looking over at the Creator's Bolt|Maru Smitten Ask]]<br>
 <</if>>
-<<if $ownedRelics.some(e => e.name === "Pangea Shaker") && $convo.maruSmitten == 0>>
+<<if $ownedRelics.some(e => e.name === "Pangea Shaker") && $convo.maruPangea == 0>>
 	<<set _numConvos += 1>>[[Maru is looking over at the Pangea Shaker|Maru Pangea Ask]]<br>
 <</if>>
 <<if $ownedRelics.some(e => e.name === "Firmament Pigment") && $convo.maruFirmament == 0 && $companionMaru.affec > 10 && $mc.penisCor > 0>>
@@ -1172,7 +1172,7 @@ She lets out a small giggle as she strokes your $mc.hair hair softly as you cont
 	<<set _numConvos += 1>>[[Khemia seems to be looking at your Aegis Coffin curiously|Khemia Aegis 1]]<br>
 <</if>>
 <<if $convo.khemiaL6 == 0 && $currentLayer == 6>>
-	<<set _numConvos += 1>>[[Khemia seems to be looking arouond at your surroundings intensely|Khemia Aegis 1]]<br>
+	<<set _numConvos += 1>>[[Khemia seems to be looking around at your surroundings intensely|Khemia Layer6 Convo]]<br>
 <</if>>
 
 :: Khemia Convo0
@@ -2596,7 +2596,7 @@ He relinquishes his hold on your breasts, delivers a playful slap to your buttoc
 	<<set _numConvos += 1>>[[Saeko seems to be looking at you|Saeko Colossal-able]]<br>
 <</if>>
 <<if $currentLayer == 4 && $convo.saekoL4 == 0>>
-	<<set _numConvos += 1>>[[Saeko seems to be looking around at the snowy landscape|Saeko Colossal-able]]<br>
+	<<set _numConvos += 1>>[[Saeko seems to be looking around at the snowy landscape|Saeko Layer4 Convo]]<br>
 <</if>>
 <<if $convo.saekoInhuman1 == 0 && $mc.inhuman > 4 && $companionSaeko.affec > 6>>
 	<<set _numConvos += 1>>[[Saeko seems to be looking at you|Saeko Inhuman Affection]]<br>
@@ -4785,10 +4785,8 @@ You gulp.
 			<<set $items[2].count += 1>>
 			<<set $flaskMatrix[$flaskPref] -= 1>>
 		<</if>>
-	<<else>>
-		<<set $items[0].count -= 1 >>
 	<</if>>
-	<<set $temptime+=1>>
+	<<set _state.expectedDays += 1>>
 	<<set $Wetting=true>>
 <</if>>
 
@@ -4844,7 +4842,7 @@ After reading from the book, Cherry seems to somberly ponder what she read for a
 
 :: Forbidden Grimoire Cloud
 After reading from the book, Cloud lines up his finger with a rock in the distance, mime's a gunshot, then turns to you and smiles. <q>I've got to test out some of the stuff I saw in there, it's crazy stuff.</q> You now have to spend 4 less bullets for any task instead of 2 less.\
-<<set $bullRed += 10>><<set $grimoireCloud = 1>>
+<<set $bullRed += 2>><<set $grimoireCloud = 1>>
 
 :: Forbidden Grimoire Saeko
 After reading from the book, Saeko's looks a bit sad as she turns the last page, as if hoping there was more to learn. After that, she is able to use innovative techniques you've never seen before to minimzie your exposure to the miasma whenever possible. You now subtract 10 from all corruption costs in the Abyss, rather than 5.\
@@ -7039,26 +7037,10 @@ Khemia's face lights up instantly, his grin widening as relief washes over him. 
 <<say $companionKhemia>>Thank you, truly. I'll use this chance wisely, I promise.<</say>>
 As Khemia steps into the Aegis Coffin, you can't help but feel a sense of unease. But you have trust in your friend and hope for a successful transformation.
 
-The next morning, Khemia emerges from the Aegis Coffin. His body feels different, stronger. His old skeleton, made of mere bone, lies neatly beside him, a memorial of what he once was.
-
-<<say $companionKhemia>>Well, this is certainly a strange souvenir...<</say>>
-He holds his old skeleton with a fascinated expression, marveling at the thought that these fragile bones once held him together. With his newly transformed orichalcum skeleton, Khemia is ready to face the deeper abyss, stronger and more determined than ever.
-
-<<say $mc>>It's definitely an unusual keepsake. But you're stronger now, Khemia. We're one step closer to reaching the bottom of the Abyss.<</say>>
-The strengthened adventurer nods, his smile unwavering.
-
 [[The next morning you check on Khemia|Khemia Aegis Yes 2]]
 
 
 :: Khemia Aegis Yes 2
-
-You look at Khemia, then at the Aegis Coffin, contemplating his request. After a moment, you offer him a reassuring smile.
-<<say $mc>>If it means you'll be able to protect yourself better and we can continue this journey, then yes. You can use the Aegis Coffin.<</say>>
-
-Khemia's face lights up instantly, his grin widening as relief washes over him. He quickly reaches out, clasping your hand in gratitude.
-
-<<say $companionKhemia>>Thank you, truly. I'll use this chance wisely, I promise.<</say>>
-As Khemia steps into the Aegis Coffin, you can't help but feel a sense of unease. But you have trust in your friend and hope for a successful transformation.
 
 The next morning, Khemia emerges from the Aegis Coffin. His body feels different, stronger. His old skeleton, made of mere bone, lies neatly beside him, a memorial of what he once was.
 

--- a/src/global.twee
+++ b/src/global.twee
@@ -2165,14 +2165,18 @@ How many dubloons would you like to pay back?
 	/* dehydration, but that's okay - we'll try again during the next trip. */
 	<<set _state.unweightedDayIndex += 1, _state.weightedDayIndex += _timeWeight>>
 	/* Check whether we need to be foraging for food to avoid dying of starvation. */
-	<<if !$forageFood && $starving > 4 && $currentLayer != 7 && $items[1].count + $items[24].count < _consumptionPerDay>>
-		@@.alert2; In order to avoid death by starvation, you are currently foraging for food on this layer, no matter the consequences.<br>
-		<<set $forageFood = 1>>
+	<<if !$forageFood && $starving > 4 && $items[1].count + $items[24].count < _consumptionPerDay>>
+		<<if $currentLayer != 7 && passage() != 'Layer3 Threat2'>>
+			@@.alert2; In order to avoid death by starvation, you are currently foraging for food on this layer, no matter the consequences.<br>
+			<<set $forageFood = 1>>
+		<</if>>
 	<</if>>
 	/* Check whether we need to be foraging for water to avoid dying of dehydration. */
-	<<if !$forageWater && $dehydrated > 1 && $currentLayer != 3 && $currentLayer != 5 && $items[0].count + $items[3].count + $items[25].count < _consumptionPerDay>>
-		@@.alert2; In order to avoid death by dehydration, you are currently foraging for water on this layer, no matter the consequences.<br>
-		<<set $forageWater = 1>>
+	<<if !$forageWater && $dehydrated > 1 && $items[0].count + $items[3].count + $items[25].count < _consumptionPerDay>>
+		<<if $currentLayer != 3 && $currentLayer != 5 && passage() != 'Layer3 Threat2'>>
+			@@.alert2; In order to avoid death by dehydration, you are currently foraging for water on this layer, no matter the consequences.<br>
+			<<set $forageWater = 1>>
+		<</if>>
 	<</if>>
 	/* Starvation and dehydration go up by 1 every day. If the player is starving */
 	/* or dehydrated, assume that they will stop to forage until they are sated. */
@@ -2238,13 +2242,9 @@ How many dubloons would you like to pay back?
 					<</if>>
 				<<case 8>>
 					<<set $timeL8 += 1>>
+					<<set $timeL8T1 += 1>>
 					<<set $timeL8T2a += 1>>
 					<<set $timeL8T2b += 1>>
-					/* Trigger an Inanis Ego event (once per event trigger). */
-					<<if !$L8loopLim>>
-						<<include "Layer 8 Threat 1a">>
-						<<set $L8loopLim = true>>
-					<</if>>
 			<</switch>>
 		<</if>>
 		/* Try to eat. */

--- a/src/init.twee
+++ b/src/init.twee
@@ -40,6 +40,7 @@ document.documentElement.setAttribute("lang", "en");
 <<set $timeL7 = 0>>
 <<set $timeL7T2 = 0>>
 <<set $timeL8 = 0>>
+<<set $timeL8T1 = 0>>
 <<set $timeL8T2a = 0>>
 <<set $timeL8T2b = 0>>
 <<set $timeL9 = 0>>

--- a/src/layer3.twee
+++ b/src/layer3.twee
@@ -1600,16 +1600,15 @@ But even as you gather yourself and prepare to move forward, you can't help but 
 
 :: Layer3 Threat2 [layer3]
 <<nobr>>
-<<set $tempTime = 2>>
 <<set $timeL3T2 -= 5>>
-<<if $playerCurses.some(e => e.name === "Gooey")>>
-	<<set $tempTime = 1>>
-<</if>>
-<<set $items[0].count -= $tempTime>>
-<<set $items[1].count -= $tempTime>>
-<<set $time += $tempTime>>
-<<set $timeL3 += $tempTime>>
-<<set $variation = random(0,1)>>
+/* Disable foraging while held. */
+<<set _forageFood = $forageFood, _forageWater = $forageWater>>
+<<set _forageFood = 0, _forageWater = 0>>
+/* Pass time until no longer held. */
+<<set _waitTime = $playerCurses.some(e => e.name === "Gooey") ? 1 : 2>>
+<<silently>><<PassTime _waitTime>><</silently>>
+/* Restore foraging settings. */
+<<set $forageFood = _forageFood, $forageWater = _forageWater>>
 <</nobr>>
 [img[setup.ImagePath+'Threats/slackslime.png']]
 <<if $playerCurses.some(e => e.name === "Gooey")>>

--- a/src/layer5.twee
+++ b/src/layer5.twee
@@ -1593,7 +1593,7 @@ How will you deal with the monstrous worm approaching you?
 <<nobr>>
 <<if $ownedRelics.some(e => e.name === "Sunbeam") && $hiredCompanions.some(e => e.name === "Khemia")>>
 	With Khemia's exceptional swordsmanship and the power of the Sunbeam Relic, he can fend off the beast. However, the struggle will leave him injured, requiring a day to recuperate.<br>
-	[[Have Khemia fight it off with Sunbeam|$returnPassage][$time += 1]]<br><br>
+	<<link 'Have Khemia fight it off with Sunbeam' `$returnPassage`>><<PassTime 1>><</link>><br><br>
 <</if>>
 <<if $joyousSword && $hiredCompanions.some(e => e.name === "Khemia")>>
 	Wielding the formidable Joyous Sunder, an expert swordsman like Khemia can effortlessly vanquish the creature without sustaining any injuries.<br>

--- a/src/layer8.twee
+++ b/src/layer8.twee
@@ -91,7 +91,14 @@ Threats:
 <<CarryAdjust>><<checkTime>>
 <<set $L8loopLim = false>>
 <<set $temp1 = random(0,20)>>
-<<if ($timeL8T2a > 6 && !$hiredCompanions.some(e => e.name === "Maru")) || ($timeL8T2a > 7)>>
+<<if $timeL8T2b >= ($hiredCompanions.some(e => e.name === "Maru") ? 24 : 21)>>
+	[img[setup.ImagePath+'Threats/dementialaberrations.png']]<br>
+
+	You can feel the deepest fears of your party manifesting into reality once again. 
+	However, this time, they are not mere visions, but physical manifestations of your fears.<br>
+
+	[[Deal with the Demential Aberrations|Layer 8 Threat 2b]]
+<<elseif $timeL8T2a >= ($hiredCompanions.some(e => e.name === "Maru") ? 8 : 7)>>
 	[img[setup.ImagePath+'Threats/dementialaberrations.png']]<br>
 
 	Behind every corner there seems to be a hint of something strange and wrong. The combination of the stress and the inherent wrongness of this layer is calling your
@@ -99,14 +106,6 @@ Threats:
 	it doesn't mean you aren't stopped in your tracks for a day while you reckon with the horrific visions.<br>
 
 	[[Deal with the Demential Aberrations|Layer 8 Threat 2a][$returnPassage = "Layer8 Hub"]]
-
-<<elseif ($timeL8T2b > 20 && !$hiredCompanions.some(e => e.name === "Maru")) || $timeL8T2b > 23>>
-	[img[setup.ImagePath+'Threats/dementialaberrations.png']]<br>
-
-	You can feel the deepest fears of your party manifesting into reality once again. 
-	However, this time, they are not mere visions, but physical manifestations of your fears.<br>
-
-	[[Deal with the Demential Aberrations|Layer 8 Threat 2b]]
 <<else>>
 
 	<<if $visitL8 == 0>>
@@ -378,19 +377,18 @@ You can consider your equipment, allies, and general health to take into account
 
 :: Layer8 Relics [layer8 cards nobr]
 <p><<CarryAdjust>><<checkTime>></p>
-<<if ($timeL8T2a > 6 && !$hiredCompanions.some(e => e.name === "Maru")) || ($timeL8T2a > 7)>>
-	<p>[img[setup.ImagePath+'Threats/dementialaberrations.png']]</p>
-
-	<p>Behind every corner there seems to be a hint of something strange and wrong. The combination of the stress and the inherent wrongness of this layer is calling your<<if $hiredCompanions.length > 0>> party's<</if>> sanity into question. And even if you know that these things aren't real, it doesn't mean you aren't stopped in your tracks for a day while you reckon with the horrific visions.<br></p>
-
-	<p>[[Deal with the Demential Aberrations|Layer 8 Threat 2a][$returnPassage = "Layer8 Hub"]]</p>
-
-<<elseif ($timeL8T2b > 20 && !$hiredCompanions.some(e => e.name === "Maru")) || $timeL8T2b > 23>>
+<<if $timeL8T2b >= ($hiredCompanions.some(e => e.name === "Maru") ? 24 : 21)>>
 	<p>[img[setup.ImagePath+'Threats/dementialaberrations.png']]</p>
 
 	<p>You can feel the deepest fears of your party manifesting into reality once again. However, this time, they are not mere visions, but physical manifestations of your fears.</p>
 
 	<p>[[Deal with the Demential Aberrations|Layer 8 Threat 2b]]</p>
+<<elseif $timeL8T2a >= ($hiredCompanions.some(e => e.name === "Maru") ? 8 : 7)>>
+	<p>[img[setup.ImagePath+'Threats/dementialaberrations.png']]</p>
+
+	<p>Behind every corner there seems to be a hint of something strange and wrong. The combination of the stress and the inherent wrongness of this layer is calling your<<if $hiredCompanions.length > 0>> party's<</if>> sanity into question. And even if you know that these things aren't real, it doesn't mean you aren't stopped in your tracks for a day while you reckon with the horrific visions.<br></p>
+
+	<p>[[Deal with the Demential Aberrations|Layer 8 Threat 2a][$returnPassage = "Layer8 Hub"]]</p>
 <<else>>
 <p>[[Continue exploring the eighth layer|Layer8 Hub]]</p>
 <<RelicGrid `setup.relicsOnLayer[8]`>>
@@ -1308,25 +1306,34 @@ Ready? Getting back up out of this terrible prison and back to layer 7 will take
 
 :: Layer8 Travel Events [layer8 nobr]
 <<set _triggers = {
-	dementialAberrations2a: () => ($timeL8T2a > 6 && !$hiredCompanions.some(e => e.name === "Maru")) || ($timeL8T2a > 7),
-	dementialAberrations2b: () => ($timeL8T2b > 20 && !$hiredCompanions.some(e => e.name === "Maru")) || $timeL8T2b > 23,
+	inanisEgo: () => {
+		const state = setup.passingTime();
+		if ($L8loopLim || !state) return false;
+		return $timeL8T2a == 4 || state.unweightedDayIndex === Math.floor(state.expectedDays / 2);
+	},
+	dementialAberrations2a: () => $timeL8T2a >= ($hiredCompanions.some(e => e.name === "Maru") ?  8 :  7),
+	dementialAberrations2b: () => $timeL8T2b >= ($hiredCompanions.some(e => e.name === "Maru") ? 24 : 21),
 }>>
 
 <<PassTime _triggers>>
 
-<<if _triggers.dementialAberrations2a()>>
-	[img[setup.ImagePath+'Threats/dementialaberrations.png']]<br>
-
-	Behind every corner there seems to be a hint of something strange and wrong. The combination of the stress and the inherent wrongness of this layer is calling your
-	<<if $hiredCompanions.length > 0>> party's<</if>> sanity into question. And even if you know that these things aren't real, 
-	it doesn't mean you aren't stopped in your tracks for a day while you reckon with the horrific visions.<br>
-	[[Deal with the Demential Aberrations|Layer 8 Threat 2a][$returnPassage = passage(), $L8loopLim = false]]
+<<if _triggers.inanisEgo()>>
+	<<set $L8loopLim = true>>
+	<<set $returnPassage = passage()>>
+	<<include "Layer 8 Threat 1a">>
 <<elseif _triggers.dementialAberrations2b()>>
 	[img[setup.ImagePath+'Threats/dementialaberrations.png']]<br>
 
 	You can feel the deepest fears of your party manifesting into reality once again. 
 	However, this time, they are not mere visions, but physical manifestations of your fears.<br>
 	[[Deal with the Demential Aberrations|Layer 8 Threat 2b][$returnPassage = passage(), $L8loopLim = false]]
+<<elseif _triggers.dementialAberrations2a()>>
+	[img[setup.ImagePath+'Threats/dementialaberrations.png']]<br>
+
+	Behind every corner there seems to be a hint of something strange and wrong. The combination of the stress and the inherent wrongness of this layer is calling your
+	<<if $hiredCompanions.length > 0>> party's<</if>> sanity into question. And even if you know that these things aren't real, 
+	it doesn't mean you aren't stopped in your tracks for a day while you reckon with the horrific visions.<br>
+	[[Deal with the Demential Aberrations|Layer 8 Threat 2a][$returnPassage = passage(), $L8loopLim = false]]
 <</if>>
 
 
@@ -1386,176 +1393,130 @@ If you continue your descent in spite of everything, descending past this layer'
 <</if>>
 
 
-:: Layer8 Inanis Check
-
-<<nobr>>
+:: Layer8 Inanis Check [layer8 nobr]
 <<set _relicBonus = 0>>
-	<<set _curseBonus = 0>>
-	<<set _companionBonus = 0>>
-	<<set _equipmentBonus = 0>>
-
 <<if $ownedRelics.some(e => e.name === "Lightning Rook")>>
-		Holding the Lightning Rook seems to slow the world down for you, evading your opponents and landing meaningful blows is much easier when you have so much time to react.<br>
-		<<set _relicBonus += 10>>
-	<</if>>
+	Holding the Lightning Rook seems to slow the world down for you, evading your opponents and landing meaningful blows is much easier when you have so much time to react.<br>
+	<<set _relicBonus += 10>>
+<</if>>
+<<if $slingshot>>
+	Your Brave Vector slingshot is proving to be a valuable ranged weapon against the empty dolls.<br>
+	<<set _relicBonus += 20>>
+<</if>>
+<<if $joyousSword>>
+	The sword you made from the Joyous Sunder slices through any resistance as if it were nothing more than air, giving you a great advantage in melee fights.<br>
+	<<set _relicBonus += 10>>
+<</if>>
+<<if $DaedalusEquip>>
+	Having wings on your back allows you to stay out of reach of the mimics. Except for the ones that have ranged weapons, of course, but you can certainly dodge those, right?<br>
+	<<set _relicBonus += 7>>
+<</if>>
+<<if $ownedRelics.some(e => e.name === "Toral Wave") && $ownedRelics.some(e => e.name === "Empath Coil") >>
+	The combination of the Toral Wave and Empath Coil allows you to electrocute the mimics easily, it's very useful as long as you get a chance to use it on them.<br>
+	<<set _relicBonus += 10>>
+<</if>>
+<<if $ownedRelics.some(e => e.name === "Creepy Doll") && $mc.appAge < 18>>
+	The eyes of the creepy doll seem to follow young versions of yourself, then those mimics wander off in random directions. Very strange coincidence...<br>
+	<<set _relicBonus += 3>>
+<</if>>
 
-	<<if $slingshot>>
-		Your Brave Vector slingshot is proving to be a valuable ranged weapon against the empty dolls.<br>
-		<<set _relicBonus += 20>>
-	<</if>>
+<<set _curseBonus =  ($mc.heightCor - $mc.oheight) / $mc.oheight * 100>>
+<<if _curseBonus > 0 >>
+	The fact that you have become much larger during your travels means you have a size advantage over most of the mimics.<br>
+<<elseif _curseBonus < 0 >>
+	The fact that you have shrunk significantly during your travels means you are at a size disadvantage over most of the mimics.<br>
+<</if>>
+<<if $mc.skinType == "sticky, slimy">>
+	Your slimy skin makes it harder for the mimics to grab on to you, letting you get out of sticky situations!<br>
+	<<set _curseBonus += 3>>
+<</if>>
+<<if $playerCurses.some(e => e.name === "Massacre Manicure")>>
+	Your claw-like nails help you somewhat if you get into hand-to-hand combat.<br>
+	<<set _curseBonus += 2>>
+<</if>>
 
-	<<if $joyousSword>>
-		The sword you made from the Joyous Sunder slices through any resistance as if it were nothing more than air, giving you a great advantage in melee fights.<br>
-		<<set _relicBonus += 10>>
-	<</if>>
+<<set _companionBonus = 0>>
+<<set _equipmentBonus = 0>>
 
-	<<if $DaedalusEquip>>
-		Having wings on your back allows you to stay out of reach of the mimics. Except for the ones that have ranged weapons, of course, but you can certainly dodge those, right?<br>
-		<<set _relicBonus += 7>>
-	<</if>>
-
-	<<if $ownedRelics.some(e => e.name === "Toral Wave") && $ownedRelics.some(e => e.name === "Empath Coil") >>
-		The combination of the Toral Wave and Empath Coil allows you to electrocute the mimics easily, it's very useful as long as you get a chance to use it on them.<br>
-		<<set _relicBonus += 10>>
-	<</if>>
-
-	<<if $ownedRelics.some(e => e.name === "Creepy Doll") && $mc.appAge<18>>
-		The eyes of the creepy doll seem to follow young versions of yourself, then those mimics wander off in random directions. Very strange coincidence... <br>
-		<<set _relicBonus += 3>>
-	<</if>>
-
-	<<set _curseBonus +=  ($mc.heightCor - $mc.oheight)/$mc.oheight*100>>
-	<<if ($mc.heightCor - $mc.oheight)/$mc.oheight*100 > 0 >>
-		The fact that you have become much larger during your travels means you have a size advantage over most of the mimics.<br>
-	<<elseif ($mc.heightCor - $mc.oheight)/$mc.oheight*100 < 0 >>
-		The fact that you have shrunk significantly during your travels means you are at a size disadvantage over most of the mimics.<br>
-	<</if>>
-
-	<<if $mc.skinType == "sticky, slimy">>
-		Your slimy skin makes it harder for the mimics to grab on to you, letting you get out of sticky situations!<br>
-		<<set _curseBonus += 3>>
-	<</if>>
-
-	<<if $playerCurses.some(e => e.name === "Massacre Manicure")>>
-		Your claw-like nails help you somewhat if you get into hand-to-hand combat. <br>
-		<<set _curseBonus += 2>>
-	<</if>>
-
-	<<if $hiredCompanions.some(e => e.name === "Maru")>>
-		Maru seems scared, but he is still willing to do what he can in a fight.<br>
-		<<set _companionBonus += 2 * (1+$companionMaru.HandicapThreat/10)>>
-	<</if>>
-
-	<<if $hiredCompanions.some(e => e.name === "Lily")>>
-		Lily puffs her chest, lets out something of a battle cry, and charges headfirst into the puppets as she beats them left and right.<br>
-		<<set _companionBonus += 8 * (1+$companionLily.HandicapThreat/10)>>
-	<</if>>
-
-	<<if $hiredCompanions.some(e => e.name === "Khemia")>>
-		Khemia assumes a fighting stance, dispatching any mimics that finds itself near him. 
-		<<set _companionBonus += 15 * (1+$companionKhemia.HandicapThreat/10)>>
-		<<if setup.haveCuttingTool>>
-			His sword slashes through them almost as fast as you can blink.
-			<<set _companionBonus += 8 * (1+$companionKhemia.HandicapThreat/10)>>
-			<<if $ownedRelics.some(e => e.name === "Sunbeam") || $joyousSword>>
-			<<set _companionBonus += 5 * (1+$companionKhemia.HandicapThreat/10)>>
-			<</if>>
-		<</if>>
-		<br>
-	<</if>>
-
-	<<if $hiredCompanions.some(e => e.name === "Cherry")>>
-		Cherry seems frozen in fear, it's as if she can't bring herself to move against your foes. She does provide a distraction for them, at least.<br>
-		<<set _companionBonus += 1 * (1+$companionCherry.HandicapThreat/10)>>
-	<</if>>
-
-	<<if $hiredCompanions.some(e => e.name === "Cloud")>>
-		Cloud steels his resolve before the fight. When you glance over to him, you can feel the amount of experience he has in battle.
-		<<set _companionBonus += 10 * (1+$companionCloud.HandicapThreat/10)>>
-		<<if $slingshot && $cloudStrat==0>>
-			The modified Brave Vector moves quickly and gracefully in Cloud's hand, then becomes perfectly still the moment he fires a shot. He doesn't miss his mark.
-			<<set _companionBonus += 5 * (1+$companionCloud.HandicapThreat/10)>>
-		<<elseif $items[20].count>0 && $items[13].count>0 && ($ammoStrat>0 || ($slingshot && $cloudStrat>0 ))>>
-			The gun moves quickly and gracefully in Cloud's hand, then becomes perfectly still the moment he fires a shot. He doesn't miss his mark.
-			<<set _companionBonus += 5 * (1+$companionCloud.HandicapThreat/10)>>
-			<<set _ammo = Math.max($ammoStrat,$cloudStrat)>>
-			<<set _equipmentBonus += _ammo*5>>
-			<<set _bulletsUsed = Math.ceil(($timeL8-$tempTime+$i)/(8*_ammo - $bullRed)) >>
-			<<if $items[20].count <= _bulletsUsed>>
-				Cloud has used the last of your bullets...
-				<<set $items[20].count = 0 >>
-				<<set $ammoStrat = 0>>
-				<<set $cloudStrat = 0>>
-			<<else>>
-				Cloud used _bulletsUsed bullets fighting off the enemy.
-				<<set $items[20].count -= _bulletsUsed>>
-			<</if>>
-		<</if>>
-		<br>
-	<</if>>
-
-	<<if $hiredCompanions.some(e => e.name === "Saeko")>>
-		Saeko sticks close to you. It's obvious she's scared, but she tries to hide it while she gives you as many strategic tips as she can.<br>
-		<<set _companionBonus += 5  * (1+$companionSaeko.HandicapThreat/10)>>
-	<</if>>
-
-	<<if $hiredCompanions.some(e => e.name === "Golem")>>
-		Your loyal golem will defend you without question, fighting off enemies without the physical limitation of a normal human.<br>
-		<<set _companionBonus += 10 * (1+$companionGolem.HandicapThreat/10)>>
-	<</if>>
-
-	<<if $hiredCompanions.some(e => e.name === $curse111.variation1)>>
-		<<set _twinBonus = 5 * (1+$companionTwin.HandicapThreat/10)+_curseBonus>>
-		<<if _twinBonus > 7 >>
-			Your twin fights off the doll-like copies of you with relative ease. It's a strange sight to see a copy of you fight other copies, but next to your twin, the mimics seem like cheap immitations.
-		<<elseif _twinBonus > 5>>
-			Much like yourself, your twin is not the most experienced fighter. But the fact that they are able to keep a few of them busy is a pretty big help.
-		<<elseif _twinBonus > 0>>
-			You're not the fighting type, so neither is your twin. The antics of your twin seems to be drawing some attention away from you, which is helpful, but they are not taking many of them down.
-		<<else>>
-			Previously it was only you who was so inept when handling threats, but now it's both you and your twin...
-		<</if>>
-		<<set _companionBonus += _twinBonus>>
-		<br>
-
-	<</if>>
-
+<<if $hiredCompanions.some(e => e.name === "Maru")>>
+	Maru seems scared, but he is still willing to do what he can in a fight.<br>
+	<<set _companionBonus += 2 * (1 + $companionMaru.HandicapThreat / 10)>>
+<</if>>
+<<if $hiredCompanions.some(e => e.name === "Lily")>>
+	Lily puffs her chest, lets out something of a battle cry, and charges headfirst into the puppets as she beats them left and right.<br>
+	<<set _companionBonus += 8 * (1 + $companionLily.HandicapThreat / 10)>>
+<</if>>
+<<if $hiredCompanions.some(e => e.name === "Khemia")>>
+	Khemia assumes a fighting stance, dispatching any mimics that finds itself near him. 
+	<<set _companionBonus += 15 * (1 + $companionKhemia.HandicapThreat / 10)>>
 	<<if setup.haveCuttingTool>>
-		You're glad you brought along a sword to defend yourself.<br>
-		<<set _equipmentBonus += 7>>
-	<</if>>
-
-		<<if $items[20].count>0 && $items[13].count>0 && !$hiredCompanions.some(e => e.name === "Cloud") && !$slingshot>>
-			<<set _equipmentBonus += 5*$ammoStrat>>
-			<<set _bulletsUsed = Math.ceil(($timeL8-$tempTime+$i)/8)*$ammoStrat*(3-$bullRed) >>
-			<<if $items[20].count <= _bulletsUsed>>
-				You has used the last of your bullets...<br>
-				<<set $items[20].count = 0 >>
-				<<set $ammoStrat = 0>>
-			<<else>>
-				You used _bulletsUsed bullets fighting off the enemy.<br>
-				<<set $items[20].count -= _bulletsUsed>>
-			<</if>>
+		His sword slashes through them almost as fast as you can blink.
+		<<set _companionBonus += 8 * (1 + $companionKhemia.HandicapThreat / 10)>>
+		<<if $ownedRelics.some(e => e.name === "Sunbeam") || $joyousSword>>
+			<<set _companionBonus += 5 * (1 + $companionKhemia.HandicapThreat / 10)>>
 		<</if>>
-
-	<<if $items[20].count>0 && $items[13].count>0 && !$hiredCompanions.some(e => e.name === "Cloud") && !$slingshot>>
-		Your gun is an important asset if you want to survive this horde.<br>
 	<</if>>
+	<br>
+<</if>>
+<<if $hiredCompanions.some(e => e.name === "Cherry")>>
+	Cherry seems frozen in fear, it's as if she can't bring herself to move against your foes. She does provide a distraction for them, at least.<br>
+	<<set _companionBonus += 1 * (1 + $companionCherry.HandicapThreat / 10)>>
+<</if>>
+<<if $hiredCompanions.some(e => e.name === "Cloud")>>
+	Cloud steels his resolve before the fight. When you glance over to him, you can feel the amount of experience he has in battle.
+	<<set _companionBonus += 10 * (1 + $companionCloud.HandicapThreat / 10)>>
+	<<if $slingshot && $cloudStrat == 0>>
+		The modified Brave Vector moves quickly and gracefully in Cloud's hand, then becomes perfectly still the moment he fires a shot. He doesn't miss his mark.
+		<<set _companionBonus += 5 * (1 + $companionCloud.HandicapThreat / 10)>>
+	<<elseif $items[20].count > 0 && $items[13].count > 0 && ($ammoStrat > 0 || ($slingshot && $cloudStrat > 0))>>
+		The gun moves quickly and gracefully in Cloud's hand, then becomes perfectly still the moment he fires a shot. He doesn't miss his mark.
+		<<set _companionBonus += 5 * (1 + $companionCloud.HandicapThreat / 10)>>
+		<<set _equipmentBonus += 5 * Math.max($ammoStrat, $cloudStrat)>>
+	<</if>>
+	<br>
+<</if>>
+<<if $hiredCompanions.some(e => e.name === "Saeko")>>
+	Saeko sticks close to you. It's obvious she's scared, but she tries to hide it while she gives you as many strategic tips as she can.<br>
+	<<set _companionBonus += 5 * (1 + $companionSaeko.HandicapThreat / 10)>>
+<</if>>
+<<if $hiredCompanions.some(e => e.name === "Golem")>>
+	Your loyal golem will defend you without question, fighting off enemies without the physical limitation of a normal human.<br>
+	<<set _companionBonus += 10 * (1 + $companionGolem.HandicapThreat / 10)>>
+<</if>>
+<<if $hiredCompanions.some(e => e.name === $curse111.variation1)>>
+	<<set _twinBonus = 5 * (1 + $companionTwin.HandicapThreat / 10) + _curseBonus>>
+	<<if _twinBonus > 7>>
+		Your twin fights off the doll-like copies of you with relative ease. It's a strange sight to see a copy of you fight other copies, but next to your twin, the mimics seem like cheap immitations.
+	<<elseif _twinBonus > 5>>
+		Much like yourself, your twin is not the most experienced fighter. But the fact that they are able to keep a few of them busy is a pretty big help.
+	<<elseif _twinBonus > 0>>
+		You're not the fighting type, so neither is your twin. The antics of your twin seems to be drawing some attention away from you, which is helpful, but they are not taking many of them down.
+	<<else>>
+		Previously it was only you who was so inept when handling threats, but now it's both you and your twin...
+	<</if>>
+	<<set _companionBonus += _twinBonus>>
+	<br>
+<</if>>
 
-	<<set _L8T1_threshold = ($L8T1_difficulty + ($timeL8-$tempTime+$i)/100)*($timeL8-$tempTime+$i)>>
-	<<set _L8T1_threshold2 = _L8T1_threshold*1.25>>
-	<<set _L8T1_threshold3 = _L8T1_threshold*1.5>>
+<<if setup.haveCuttingTool>>
+	You're glad you brought along a sword to defend yourself.<br>
+	<<set _equipmentBonus += 7>>
+<</if>>
+<<if $items[20].count > 0 && $items[13].count > 0 && !$hiredCompanions.some(e => e.name === "Cloud") && !$slingshot>>
+	Your gun is an important asset if you want to survive this horde.<br>
+	<<set _equipmentBonus += 5 * $ammoStrat>>
+<</if>>
 
-	<<set _temp =  3*(_relicBonus + _curseBonus + _companionBonus + _equipmentBonus + $mc.HandicapThreat*10)>>
+<<set _L8T1_threshold = (($L8T1_difficulty + $timeL8T1 / 100) * $timeL8T1).toRounded(1)>>
+
+<<set _temp = (3 * (_relicBonus + _curseBonus + _companionBonus + _equipmentBonus + $mc.HandicapThreat * 10)).toRounded(1)>>
 
 <br>Your relative strength bonus due to these factors against the Inanis Ego is _temp, though in a real fight you would also get a bonus between 1 and 100 based on random factors such as terrain and luck. And based on your experience. If you encountered them today, they would have a strength of _L8T1_threshold, which you would need to overcome.<br>
 
 <br>[[Continue exploring the eighth layer|Layer8 Hub]]
-<</nobr>>
 
 
-:: Layer 8 Threat 1a
-<<nobr>>
+:: Layer 8 Threat 1a [layer8 nobr]
 <<Handicap>>
 <<set _random = random(0,1)>>
 <<if _random == 0>>
@@ -1564,7 +1525,7 @@ If you continue your descent in spite of everything, descending past this layer'
 	[img[setup.ImagePath+'Threats/inanisego2.png']]<br>
 <</if>>
 <<set _temp1=1>>
-<<if $timeL8 >= $L8T1_milestones[$L8T1_counter]>>
+<<if $timeL8T1 >= $L8T1_milestones[$L8T1_counter]>>
 	<<if $L8T1_counter==0>>
 		You spot a distant figure slowly limping in your direction.<br><br>
 
@@ -1609,10 +1570,10 @@ If you continue your descent in spite of everything, descending past this layer'
 		<<set $L8T1_difficulty += 0.4>>
 	<</if>>
 <<else>>
-	<<if $timeL8 < 10 >>
-		About $timeL8 of these eerie, clockwork dolls swarm you. You don't know exactly what they are planning, but you're certain it isn't good.<br>
+	<<if $timeL8T1 < 10 >>
+		About $timeL8T1 of these eerie, clockwork dolls swarm you. You don't know exactly what they are planning, but you're certain it isn't good.<br>
 	<<else>>
-		About $timeL8 of these eerie, porcelain versions of yourself swarm you. You don't know exactly what they are planning, but you're certain it isn't good.<br>
+		About $timeL8T1 of these eerie, porcelain versions of yourself swarm you. You don't know exactly what they are planning, but you're certain it isn't good.<br>
 	<</if>>
 <</if>>
 <<if _temp1==1>>
@@ -1687,9 +1648,9 @@ If you continue your descent in spite of everything, descending past this layer'
 			<<set _companionBonus += 5* (1+ $companionCloud.HandicapThreat/10)>>
 		<<elseif $items[20].count>0 && $items[13].count>0 && ($ammoStrat>0 || ($slingshot && $cloudStrat>0 ))>>
 			<<set _companionBonus += 5* (1+ $companionCloud.HandicapThreat/10)>>
-			<<set _ammo = Math.max($ammoStrat,$cloudStrat)>>
+			<<set _ammo = Math.max($ammoStrat, $cloudStrat)>>
 			<<set _equipmentBonus += _ammo*5>>
-			<<set _bulletsUsed = Math.ceil(($timeL8-$tempTime+$i)/(8*_ammo - $bullRed)) >>
+			<<set _bulletsUsed = Math.max(Math.ceil($timeL8T1 / 8) * _ammo - $bullRed, 1)>>
 			<<if $items[20].count <= _bulletsUsed>>
 				Cloud has used the last of your bullets...
 				<<set $items[20].count = 0 >>
@@ -1727,7 +1688,7 @@ If you continue your descent in spite of everything, descending past this layer'
 
 		<<if $items[20].count>0 && $items[13].count>0 && !$hiredCompanions.some(e => e.name === "Cloud") && !$slingshot>>
 			<<set _equipmentBonus += 5*$ammoStrat>>
-			<<set _bulletsUsed = Math.ceil(($timeL8-$tempTime+$i)/8)*$ammoStrat*(3-$bullRed) >>
+			<<set _bulletsUsed = Math.max(Math.ceil($timeL8T1 / 8) * _ammo * 3 - $bullRed, 1)>>
 			<<if $items[20].count <= _bulletsUsed>>
 				You have used the last of your bullets...<br>
 				<<set $items[20].count = 0 >>
@@ -1741,11 +1702,11 @@ If you continue your descent in spite of everything, descending past this layer'
 	<<if $items[20].count>0 && $items[13].count>0 && !$hiredCompanions.some(e => e.name === "Cloud") && !$slingshot>>
 	<</if>>
 
-	<<set _L8T1_threshold = ($L8T1_difficulty + ($timeL8-$tempTime+$i)/100)*($timeL8-$tempTime+$i)>>
-	<<set _L8T1_threshold2 = _L8T1_threshold*1.25>>
-	<<set _L8T1_threshold3 = _L8T1_threshold*1.5>>
+	<<set _L8T1_threshold = ($L8T1_difficulty + $timeL8T1 / 100) * $timeL8T1>>
+	<<set _L8T1_threshold2 = _L8T1_threshold * 1.25>>
+	<<set _L8T1_threshold3 = _L8T1_threshold * 1.5>>
 
-	<<set _temp = random(0,100) + 3*_relicBonus + 3*_curseBonus + 3*_companionBonus + 3*_equipmentBonus + 3*$mc.HandicapThreat*10>>
+	<<set _temp = random(1, 100) + 3 * (_relicBonus + _curseBonus + _companionBonus + _equipmentBonus + $mc.HandicapThreat * 10)>>
 
 <br>
 	<<if _temp >  _L8T1_threshold3>>
@@ -1756,7 +1717,6 @@ If you continue your descent in spite of everything, descending past this layer'
 		<br>You had some close calls, a few felt a little too close for comfort. You barely avoided getting caught by the dolls, despite your best efforts. Were you simply unlucky this time or should you consider leaving this place before it's too late?<br>
 	<<elseif _temp <= (_L8T1_threshold - 100) && $easymode==false>>
 			<<set $gameOver = true>>
-			<<set $i=$tempTime>>
 			<br>You fight as hard as you can, but eventually the lifeless dolls overwhelm you. As one of them grabs hold of your face, it closes in for a gentle kiss. 
 			The moment your lips touch, you feel your life flashing before your eyes, and you know you have to escape as quickly as possible. 
 			But you have been so overwhelmed that you are unable to get away, so after a full 5 seconds you feel their hands leaving your face.<br>
@@ -1765,7 +1725,6 @@ If you continue your descent in spite of everything, descending past this layer'
 	<<elseif _temp <= _L8T1_threshold>>
 		<<if $status.duration > 0>>
 			<<set $gameOver = true>>
-			<<set $i=$tempTime>>
 			<br>You fight as hard as you can, but eventually the lifeless dolls overwhelm you. As one of them grabs hold of your face, it closes in for a gentle kiss. 
 			The moment your lips touch, you feel your life flashing before your eyes, and you know you have to escape as quickly as possible. 
 			But your previous injuries have made you too weak to get away, so after a full 5 seconds you feel their hands leaving your face.<br>
@@ -1779,16 +1738,12 @@ If you continue your descent in spite of everything, descending past this layer'
 	<</if>>
 <</if>>
 <br>
-<</nobr>>
+[[Continue exploring the eighth layer|$returnPassage]]
 
 :: Layer 8 Threat 2a
 
 <<nobr>>
-<<if $hiredCompanions.some(e => e.name === "Maru")>>
-	<<set $timeL8T2a -= 6>>
-<<else>>
-	<<set $timeL8T2a -= 7>>
-<</if>>
+<<set $timeL8T2a -= $hiredCompanions.some(e => e.name === "Maru") ?  8 :  7>>
 <<set $totalFears = []>>
 <<set $totalFears.push($fear)>>
 <<for _companion range $hiredCompanions>>
@@ -2033,13 +1988,8 @@ You're not sure. Still, that sound in the dark... some part of you can't complet
 :: Layer 8 Threat 2b
 
 <<nobr>>
-<<if $hiredCompanions.some(e => e.name === "Maru")>>
-	<<set $timeL8T2a -= 6>>
-	<<set $timeL8T2b -= 18>>
-<<else>>
-	<<set $timeL8T2a -= 7>>
-	<<set $timeL8T2b -= 21>>
-<</if>>
+<<set $timeL8T2a -= $hiredCompanions.some(e => e.name === "Maru") ?  8 :  7>>
+<<set $timeL8T2b -= $hiredCompanions.some(e => e.name === "Maru") ? 24 : 21>>
 <<set $totalFears = []>>
 <<set $totalFears.push($fear)>>
 <<for _companion range $hiredCompanions>>

--- a/src/relics.twee
+++ b/src/relics.twee
@@ -1149,7 +1149,7 @@ A small, golden bell. When rung, all sound in a 100 meter (330 ft) radius from t
 
 
 :: Lightning Rook Description
-A transparent, glassy chess piece in the shape of a rook. When held in a hand, it slows down the user's perception of time based on how long they've continuously held it, starting at 1/2 normal perception and slowly going down to 1/200 the normal perception over the course of 24 hours of continuously holding it. the effect cannot be toggled except by letting go of the rook and esetting the timer. Allows more time to make decisions, but doesn't make the holder physically move faster. Requires a great deal of patience to make full use of.
+A transparent, glassy chess piece in the shape of a rook. When held in a hand, it slows down the user's perception of time based on how long they've continuously held it, starting at 1/2 normal perception and slowly going down to 1/200 the normal perception over the course of 24 hours of continuously holding it. The effect cannot be toggled except by letting go of the rook and resetting the timer. Allows more time to make decisions, but doesn't make the holder physically move faster. Requires a great deal of patience to make full use of.
 
 
 :: Acrobatic Accord Description
@@ -1457,7 +1457,7 @@ This has an interesting additional effect when used on other Relics - while Reli
 
 
 :: Aeonglass Description
-A handheld hourglass containing a shimmering liquid. When turned upside-down and allowed to flow, it causes time in a 5 meter (16ft) radius arouond the hourglass to move at double speed relative to the outside radius for 10 minutes. Those inside the radius will see events outside it moving at half their typical speed, while those outside will see events inside moving at twice the normal speed, but neither will likely notice anything especially strange on their own side for the duration - sped-up brains inside the radius will process the sped-up events, and they will appear at normal speed.
+A handheld hourglass containing a shimmering liquid. When turned upside-down and allowed to flow, it causes time in a 5 meter (16ft) radius around the hourglass to move at double speed relative to the outside radius for 10 minutes. Those inside the radius will see events outside it moving at half their typical speed, while those outside will see events inside moving at twice the normal speed, but neither will likely notice anything especially strange on their own side for the duration - sped-up brains inside the radius will process the sped-up events, and they will appear at normal speed.
 
 After it has begun to flow to one side, it can only be turned again for another 5-minute time acceleration once the liquid has completely flowed into the other end. If it is kept completely vertical the entire time, this will take about 3 hours.
 

--- a/src/script.js
+++ b/src/script.js
@@ -530,6 +530,9 @@ Object.defineProperties(setup, {
 				if (vars.currentLayer == 5 && !['Layer5 Camp', 'Layer5 Forage'].includes(passage)) vars.atWaterSource = false;
 			}
 
+			// If we're on layer 8, allow an Inanis Ego event to trigger every time we wait or travel somewhere.
+			if (vars.currentLayer == 8) vars.L8loopLim = false;
+
 			const state = {
 				expectedDays: days, /* The number of days of time to pass, modulo the time weight. */
 				unweightedDayIndex: 0,


### PR DESCRIPTION
This started out as a bunch of miscellaneous time-related fixes but mostly turned into fixing up the Inanis Ego stuff.

I moved it out of `<<PassTime>>` and made it a regular event trigger: It triggers halfway through the journey or when the threat 2a counter hits 4, whichever happens first (both demential aberrations reset the flag so it can happen again). That way we can just use the actual current time instead of having to worry about adding or subtracting temporary state.

I also tried to fix up the bullets used logic - I'm not entirely sure I succeeded but it makes more sense to me like this. Should be easier to tweak now, regardless.

While testing I found some companion conversation triggers that didn't work right - fixed those up too.