### PR TITLE
Remove additional checks for time-based threats from hubs and relic screens

### DIFF
--- a/src/layer2.twee
+++ b/src/layer2.twee
@@ -30,92 +30,81 @@ This layer is filled with a very dense growth of vines, bushes, and other plant 
 	<<audio "layer2" volume 0.2 play loop>>
 <</if>>
 <<CarryAdjust>><<checkTime>>
-
-<</nobr>>\
-<<if $timeL2T1 < 4 || $hiredCompanions.length > 3>><<nobr>>
-	<<if $visitL2 == 0>>
-		<<set $visitL2 = 1>>
-		<<set $layerTemp = 8>>
-	<<elseif $secondVisitL2 == 0>>
-		<<set $secondVisitL2 = 1>>
-		<<set $layerTemp = 18>>
-	<<else>>
-		<<set $layerTemp = random(0,20)>>
-	<</if>>
-	<<if $layerTemp == 1>>
-		Above you, a blood-curdling screech fills the air. Freezing in fear, a bird seems to fly from the canopy above you, paying no mind to you on the ground. Strangely, it looks almost like a hawk, but as if its mouth were turned sideways and it's wings were a bit too sharp-edged to match any bird you've seen before. However, you don't get a chance to get a good look at it before it flaps it's wings and and leaves you once again with only the sound of the dripping rain. <br><br>
-	<<elseif $layerTemp == 2>>
-		At one point along your path, you spot a tangle of vines that seem to rustle slightly, but upon further inspection there is nothing inside them. After spending a minute watching them, you realize the sound comes from the speed at which the vines are growing, which seems to be a few centimeters a minute. You also hear a crunch, which seems to originate from the long-deadbskeleton of a small mammal being crushed by the vines. Wisely, you decide to move on and conclude this would not be a good place to make camp. <br><br>
-	<<elseif $layerTemp == 3 && $hiredCompanions.some(e => e.name === "Saeko") && $hiredCompanions.some(e => e.name === "Lily")>>
-		You hear a loud hissing sound in one of the bushes nearby, and suddenly Saeko stops your group from moving forward.
-		<br><br>
-		<<say $companionSaeko>>Wait, we have to go around here. I'm not sure what would make a sound like that here, but I suspect it's not a good idea to find out.<</say>><br>
-		Lily almost walks forward on her own.
-		<br><br>
-		<<say $companionLily>>I don't know either! I really want to find out though! It can't be that bad if it's only on the second layer, right?<</say>><br>
-		Saeko grabs her collar and sighs.
-		<br><br>
-		<<say $companionSaeko>>I believe I heard of a certain diver who thought similarly, but he was lost a few years ago. Better not to fall prey to some unkown venomous creature here.<</say>><br>
-		Lily hesitates, but eventually agrees and your group ends up going around the potential threat.<br><br>
-	<<elseif $layerTemp == 4 && $hiredCompanions.some(e => e.name === "Cherry")>>
-		A small feline-looking creature approaches you and gives a little mewling sound. As you hesitate with how to react, Cherry bends down and rubs it behind one of its furry ears. Her expression is blank and she sighs as the feline mews, whispering under her breath.
-		
-		<<say $companionCherry>>I remember this being fun. Why isn't this fun anymore?<</say>>
-		She stands up and steps back, giving you a chance to touch the feline, feeling that it feels much softer than you'd expect, as if it were a sack of blubber rather than a cat. But after a few minutes, it gets tired of your touches and tightens up as it scampers away. Cherry is staring at the sky, letting the rain run down her face with no resistance. <<if $hiredCompanions.includes("Maru")>>Maru walks over to her and gives her a big, warm hug, but despite reaching her arms around him, her expression never changes.<</if>><br><br>
-	<<elseif $layerTemp == 5>>
-		You stumble upon a tranquil, crystal-clear pond, with bioluminescent plants casting a soft, otherworldly glow upon its surface. The gentle hum of insects creates a soothing melody, accompanied by the occasional splash of leaping fish as they break the water's surface. As you draw closer, you notice that the fish are adorned with vivid, iridescent scales, shimmering like living gemstones under the luminescent light. You are momentarily entranced by this serene oasis, a welcome reprieve from the dangers you've faced thus far. However, you remind yourself to remain vigilant and continue on your journey, with the memory of the pond's enchanting beauty etched in your mind. <br><br>
-	<<elseif $layerTemp == 6 && $playerCurses.some(e => e.name === "Hijinks Ensue")>>
-		<<include "Hijinks Ensue Scenes">>
-	<<elseif $layerTemp >= 18 - (1+$hiredCompanions.length) && $layerTemp < 19 && ($hiredCompanions.length > 0  || $ownedRelics.some(e => e.name === "Creepy Doll") )>>
-		<<include "Companion Layer Interaction">>
-	<<elseif $layerTemp >= 19>>
-		<<include "Curse Descriptions">><br><br>
-	<<else>>
-		The dew continually drips down around you, creating the illusion of a rainstorm without clouds. The atmosphere is heavy, partially with humdity, but mainly with the ever-present, creeping corruption of the miasma.
-
-		This layer is filled with a vey dense growth of vines, bushes, and other plant life that impedes you and makes movement very time-consuming. Having a way to clear them out of your way would make navigation much easier. Subtract 1 day from every time on this layer (including the cost of going up or down layers) if you have a sword with you to cut through the flora.
-	<</if>>
-<br><br>
-	<<if $forageWater == 1>>
-		<<print "You are currently foraging for your daily water on this layer">><br>
-		<<else>>
-		<<print "You are not currently foraging for your daily water on this layer">><br>
-	<</if>>
-	<<if $forageFood == 1 && $mudHunt == 1>>
-		<<print "You are currently foraging for your daily food on this layer by spending 1 bullet each day to hunt mudgrazers">><br>
-		<<elseif $forageFood == 1>>
-		<<print "You are currently foraging for your daily food on this layer by finding flanberries to eat.">><br>
-		<<else>>
-		<<print "You are not currently foraging for your daily food on this layer">><br>
-	<</if>>
-	<<if !isPlaying("layer2")>>
-		<<masteraudio stop>><<audio "layer2" volume 0.2 play loop>>
-	<</if>>
-
-	<br>What do you want to do while you're here?<br><br>
-	[[Use Items and Relics]]<br>
-	<<if $hiredCompanions.length > 0>>
-		[[Interact with your party|Party overview]] <<CheckParty>><br>
-	<</if>>
-	<</nobr>>
-	[[Learn about the threats on this layer|Layer2 Threats]]
-	[[Check for food and water you can forage for|Layer2 Forage]]
-	[[Search for Relics|Layer2 Relics]]
-	[[Take on Curses to purge your corruption|Layer2 Curses]]
-	[[Look for any wonders you can take advantage of|Layer2 Wonders]]
-	[[Set up camp and rest here|Layer2 Camp]]
-	[[View the Layer 2 habitation option|Layer2 Habitation]]
-
-	[[Look up towards the surface|Layer2 Ascend 1]]
-	[[Look down at the next layer|Layer2 Exit1]]
-
+<<if $visitL2 == 0>>
+	<<set $visitL2 = 1>>
+	<<set $layerTemp = 8>>
+<<elseif $secondVisitL2 == 0>>
+	<<set $secondVisitL2 = 1>>
+	<<set $layerTemp = 18>>
 <<else>>
-
-	Suddenly, you hear a deep, guttural growl that echoes through the layer. A shiver runs down your spine as you recognize it as the ominous call of the Baying Gourmet. The very ground beneath you seems to tremble with anticipation, and a sense of dread washes over you. You clutch your belongings closer, acutely aware of the abundance of food rations you carry.
-
-	[[Deal with the Baying Gourmet|Layer2 Threat1][$returnPassage="Layer2 Hub"]]
-
+	<<set $layerTemp = random(0,20)>>
 <</if>>
+<<if $layerTemp == 1>>
+	Above you, a blood-curdling screech fills the air. Freezing in fear, a bird seems to fly from the canopy above you, paying no mind to you on the ground. Strangely, it looks almost like a hawk, but as if its mouth were turned sideways and it's wings were a bit too sharp-edged to match any bird you've seen before. However, you don't get a chance to get a good look at it before it flaps it's wings and and leaves you once again with only the sound of the dripping rain. <br><br>
+<<elseif $layerTemp == 2>>
+	At one point along your path, you spot a tangle of vines that seem to rustle slightly, but upon further inspection there is nothing inside them. After spending a minute watching them, you realize the sound comes from the speed at which the vines are growing, which seems to be a few centimeters a minute. You also hear a crunch, which seems to originate from the long-deadbskeleton of a small mammal being crushed by the vines. Wisely, you decide to move on and conclude this would not be a good place to make camp. <br><br>
+<<elseif $layerTemp == 3 && $hiredCompanions.some(e => e.name === "Saeko") && $hiredCompanions.some(e => e.name === "Lily")>>
+	You hear a loud hissing sound in one of the bushes nearby, and suddenly Saeko stops your group from moving forward.
+	<br><br>
+	<<say $companionSaeko>>Wait, we have to go around here. I'm not sure what would make a sound like that here, but I suspect it's not a good idea to find out.<</say>><br>
+	Lily almost walks forward on her own.
+	<br><br>
+	<<say $companionLily>>I don't know either! I really want to find out though! It can't be that bad if it's only on the second layer, right?<</say>><br>
+	Saeko grabs her collar and sighs.
+	<br><br>
+	<<say $companionSaeko>>I believe I heard of a certain diver who thought similarly, but he was lost a few years ago. Better not to fall prey to some unkown venomous creature here.<</say>><br>
+	Lily hesitates, but eventually agrees and your group ends up going around the potential threat.<br><br>
+<<elseif $layerTemp == 4 && $hiredCompanions.some(e => e.name === "Cherry")>>
+	A small feline-looking creature approaches you and gives a little mewling sound. As you hesitate with how to react, Cherry bends down and rubs it behind one of its furry ears. Her expression is blank and she sighs as the feline mews, whispering under her breath.
+	
+	<<say $companionCherry>>I remember this being fun. Why isn't this fun anymore?<</say>>
+	She stands up and steps back, giving you a chance to touch the feline, feeling that it feels much softer than you'd expect, as if it were a sack of blubber rather than a cat. But after a few minutes, it gets tired of your touches and tightens up as it scampers away. Cherry is staring at the sky, letting the rain run down her face with no resistance. <<if $hiredCompanions.includes("Maru")>>Maru walks over to her and gives her a big, warm hug, but despite reaching her arms around him, her expression never changes.<</if>><br><br>
+<<elseif $layerTemp == 5>>
+	You stumble upon a tranquil, crystal-clear pond, with bioluminescent plants casting a soft, otherworldly glow upon its surface. The gentle hum of insects creates a soothing melody, accompanied by the occasional splash of leaping fish as they break the water's surface. As you draw closer, you notice that the fish are adorned with vivid, iridescent scales, shimmering like living gemstones under the luminescent light. You are momentarily entranced by this serene oasis, a welcome reprieve from the dangers you've faced thus far. However, you remind yourself to remain vigilant and continue on your journey, with the memory of the pond's enchanting beauty etched in your mind. <br><br>
+<<elseif $layerTemp == 6 && $playerCurses.some(e => e.name === "Hijinks Ensue")>>
+	<<include "Hijinks Ensue Scenes">>
+<<elseif $layerTemp >= 18 - (1+$hiredCompanions.length) && $layerTemp < 19 && ($hiredCompanions.length > 0  || $ownedRelics.some(e => e.name === "Creepy Doll") )>>
+	<<include "Companion Layer Interaction">>
+<<elseif $layerTemp >= 19>>
+	<<include "Curse Descriptions">><br><br>
+<<else>>
+	The dew continually drips down around you, creating the illusion of a rainstorm without clouds. The atmosphere is heavy, partially with humdity, but mainly with the ever-present, creeping corruption of the miasma.
+
+	This layer is filled with a vey dense growth of vines, bushes, and other plant life that impedes you and makes movement very time-consuming. Having a way to clear them out of your way would make navigation much easier. Subtract 1 day from every time on this layer (including the cost of going up or down layers) if you have a sword with you to cut through the flora.
+<</if>>
+<br><br>
+<<if $forageWater == 1>>
+	<<print "You are currently foraging for your daily water on this layer">><br>
+	<<else>>
+	<<print "You are not currently foraging for your daily water on this layer">><br>
+<</if>>
+<<if $forageFood == 1 && $mudHunt == 1>>
+	<<print "You are currently foraging for your daily food on this layer by spending 1 bullet each day to hunt mudgrazers">><br>
+	<<elseif $forageFood == 1>>
+	<<print "You are currently foraging for your daily food on this layer by finding flanberries to eat.">><br>
+	<<else>>
+	<<print "You are not currently foraging for your daily food on this layer">><br>
+<</if>>
+<<if !isPlaying("layer2")>>
+	<<masteraudio stop>><<audio "layer2" volume 0.2 play loop>>
+<</if>>
+
+<br>What do you want to do while you're here?<br><br>
+[[Use Items and Relics]]<br>
+<<if $hiredCompanions.length > 0>>
+	[[Interact with your party|Party overview]] <<CheckParty>><br>
+<</if>>
+<</nobr>>
+[[Learn about the threats on this layer|Layer2 Threats]]
+[[Check for food and water you can forage for|Layer2 Forage]]
+[[Search for Relics|Layer2 Relics]]
+[[Take on Curses to purge your corruption|Layer2 Curses]]
+[[Look for any wonders you can take advantage of|Layer2 Wonders]]
+[[Set up camp and rest here|Layer2 Camp]]
+[[View the Layer 2 habitation option|Layer2 Habitation]]
+
+[[Look up towards the surface|Layer2 Ascend 1]]
+[[Look down at the next layer|Layer2 Exit1]]
 
 
 :: Layer2 Cherry [layer2]
@@ -219,8 +208,6 @@ After collecting enough berries, you head back to camp with Maru. He mashes the 
 
 :: Layer2 Relics [layer2 cards nobr]
 <p><<CarryAdjust>><<checkTime>></p>
-<<if $timeL2T1 < 4 || $hiredCompanions.length > 3>>
-
 <h1>Relics</h1>
 
 <p>
@@ -236,14 +223,6 @@ By default, your companions' reward for coming down here with you is the dubloon
 <<RelicGrid `setup.relicsOnLayer[2]`>>
 
 <p>[[Continue exploring the second layer|Layer2 Hub]]</p>
-
-<<else>>
-
-<p>Suddenly, you hear a deep, guttural growl that echoes through the layer. A shiver runs down your spine as you recognize it as the ominous call of the Baying Gourmet. The very ground beneath you seems to tremble with anticipation, and a sense of dread washes over you. You clutch your belongings closer, acutely aware of the abundance of food rations you carry.</p>
-
-<p>[[Deal with the Baying Gourmet|Layer2 Threat1][$returnPassage = "Layer2 Relics"]]</p>
-
-<</if>>
 
 
 :: Layer2 Curses [layer2 cards nobr]
@@ -1415,7 +1394,7 @@ A few tests and you can confirm you have pure water to fill your flasks with! No
 
 :: Layer2 Travel Events [layer2 nobr]
 <<set _triggers = {
-	bayingGourmet: () => $timeL2T1 > 3 && $hiredCompanions.length < 4,
+	bayingGourmet: () => $timeL2T1 >= 4 && $hiredCompanions.length < 4,
 }>>
 
 <<PassTime _triggers>>

--- a/src/layer3.twee
+++ b/src/layer3.twee
@@ -32,8 +32,6 @@ The Abyss has various bioluminescent moss, mushrooms, and so on scattered about,
 <</if>>
 <<CarryAdjust>><<checkTime>>
 <<set $forageWater = 0>>
-<</nobr>>\
-<<if $timeL3T1 < 6 && $timeL3T2 < 5>><<nobr>>
 <<if $visitL3 == 0>>
 	<<set $visitL3 = 1>>
 	<<set $layerTemp = 8>>
@@ -97,13 +95,7 @@ The Abyss has various bioluminescent moss, mushrooms, and so on scattered about,
 [[View the Layer 3 habitation option|Layer3 Habitation]]
 
 [[Look up towards the surface|Layer3 Ascend 1]]
-[[Look down at the next layer|Layer3 Exit1]]<<elseif $timeL3T2 < 5>>
-<<include "Layer3 Tentacle Encounter">>
-
-[[Deal with the lesser tentacle beast|Layer3 Threat1][$returnPassage = passage()]]<<else>>
-<<include "Layer3 Slackslime Encounter">>
-
-[[Deal with the slackslime|Layer3 Threat2][$returnPassage = passage()]]<</if>>
+[[Look down at the next layer|Layer3 Exit1]]
 
 
 :: Layer3 Threats [image layer3]
@@ -152,8 +144,6 @@ If you decide to start foraging for food or water, it means that you will not co
 
 :: Layer3 Relics [layer3 cards nobr]
 <p><<CarryAdjust>><<checkTime>></p>
-<<if $timeL3T1 < 6 && $timeL3T2 < 5>>
-
 <h1>Relics</h1>
 
 <p>
@@ -167,20 +157,6 @@ The Abyss is a huge place. The Relics listed in these sections are only a small 
 <<RelicGrid `setup.relicsOnLayer[3]`>>
 
 <p>[[Continue exploring the third layer|Layer3 Hub]]</p>
-
-<<elseif $timeL3T2 < 5>>
-
-<p><<include "Layer3 Tentacle Encounter">></p>
-
-<p>[[Deal with the lesser tentacle beast|Layer3 Threat1][$returnPassage="Layer3 Hub"]]</p>
-
-<<else>>
-
-<p><<include "Layer3 Slackslime Encounter">></p>
-
-<p>[[Deal with the slackslime|Layer3 Threat2][$returnPassage="Layer3 Hub"]]</p>
-
-<</if>>
 
 
 :: Layer3 Curses [layer3 cards nobr]
@@ -275,8 +251,8 @@ In the deeper parts of the layer, a cold breeze occasionally blows through the c
 
 :: Layer3 Travel Events [layer3 nobr]
 <<set _triggers = {
-	lesserTentacleBeast: () => $timeL3T1 > 5,
-	slackslime: () => $timeL3T2 > 4,
+	lesserTentacleBeast: () => $timeL3T1 >= 6,
+	slackslime: () => $timeL3T2 >= 5,
 }>>
 
 <<PassTime _triggers>>

--- a/src/layer4.twee
+++ b/src/layer4.twee
@@ -45,10 +45,8 @@ She stands at the edge of your peripheral vision, immaterial and seemingly harml
 	<<audio "layer4" volume 0.2 play loop>>
 <</if>>
 <<CarryAdjust>><<checkTime>>
-<<if $visitL4 == 0>><<set $endSpectre = $time>><</if>>
-<</nobr>>\
-<<if $timeL4T1 < 7>><<nobr>>
 <<if $visitL4 == 0>>
+	<<set $endSpectre = $time>>
 	<<set $visitL4 = 1>>
 	<<set $layerTemp = 8>>
 <<elseif $secondVisitL4 == 0>>
@@ -133,13 +131,7 @@ She stands at the edge of your peripheral vision, immaterial and seemingly harml
 [[View the Layer 4 habitation option|Layer4 Habitation]]
 
 [[Look up towards the surface|Layer4 Ascend 1]]
-[[Look down at the next layer|Layer4 Exit1]]<<else>>
-
-A great hissing sound, as if a blimp were leaking its helium, fills your ears as a dark form descends on you from above. A monstrous beast floats above your head and unveils its tentacles in preparation of its attempt to shovel you into its enormous maw.
-
-[[Deal with the Drifting Swallower|Layer4 Threat1][$returnPassage = passage()]]
-
-<</if>>
+[[Look down at the next layer|Layer4 Exit1]]
 
 
 :: Layer4 Cherry [layer4]
@@ -190,8 +182,6 @@ Would you like to increase or decrease your height due to eating flairabou meat?
 
 :: Layer4 Relics [layer4 cards nobr]
 <p><<CarryAdjust>><<checkTime>></p>
-<<if $timeL4T1 < 7>>
-
 <p>
 @@.floatr;[img[setup.ImagePath+'icon.png']]@@
 
@@ -203,14 +193,6 @@ The Brave Vector Relic you can find here is a perfect example of something you m
 <<RelicGrid `setup.relicsOnLayer[4]`>>
 
 <p>[[Continue exploring the fourth layer|Layer4 Hub]]</p>
-
-<<else>>
-
-<p>A great hissing sound, as if a blimp were leaking its helium, fills your ears as a dark form descends on you from above. A monstrous beast floats above your head and unveils its tentacles in preparation of its attempt to shovel you into its enormous maw.</p>
-
-<p>[[Deal with the Drifting Swallower|Layer4 Threat1][$returnPassage = passage()]]</p>
-
-<</if>>
 
 
 :: Layer4 Curses [layer4 cards nobr]
@@ -1215,7 +1197,7 @@ Your hands reach a small crevasse, offering a much-needed respite from the climb
 
 :: Layer4 Travel Events [layer4 nobr]
 <<set _triggers = {
-	driftingSwallower: () => $timeL4T1 > 6,
+	driftingSwallower: () => $timeL4T1 >= 7,
 }>>
 
 <<PassTime _triggers>>

--- a/src/layer5.twee
+++ b/src/layer5.twee
@@ -29,9 +29,6 @@ For an area that otherwise bears such a strong resemblance to a surface desert, 
 	<<audio "layer5" volume 0.2 play loop>>
 <</if>>
 <<CarryAdjust>><<checkTime>>
-
-<</nobr>>\
-<<if $timeL5T1 < 8 && $timeL5T2 < 11>><<nobr>>
 <<if $visitL5 == 0>>
 	<<set $visitL5 = 1>>
 	<<set $layerTemp = 8>>
@@ -101,19 +98,7 @@ For an area that otherwise bears such a strong resemblance to a surface desert, 
 [[View the Layer 5 habitation option|Layer5 Habitation]]
 
 [[Look up towards the surface|Layer5 Ascend 1]]
-[[Look down at the next layer|Layer5 Exit1]]<<elseif $timeL5T1 < 8>>
-<<include "Layer5 Borer Encounter">>
-
-[[Deal with the Dune Devouring Borer|Layer5 Threat2][$returnPassage = passage()]]
-<<else>>
-When you wake up in the morning, you hear an enormous amount of buzzing in the air, luckily you managed to stay out of the swarm when you woke up, but you'll need to decide what to do with the swarm today.
-
-[[Deal with the Mayfly Scuttler|Layer5 Threat1][$returnPassage = passage()]]<<if $ownedRelics.some(e => e.name === "Breathless Exhale")>>
-
-The radiant sun empowers your Breathless Exhale Relic, its energy pulsating within your grasp. You can sense the potential of the Relic, trembling with anticipation, ready to alter the wind's course and drive the insects away from you.
-[[Summon a powerful gust to drive the swarm away from you|Layer5 Hub][$timeL5T1 -= 8]]
-<</if>>
-<</if>>
+[[Look down at the next layer|Layer5 Exit1]]
 
 
 :: Layer5 Cherry [layer5]
@@ -269,8 +254,6 @@ If you decide to start foraging for food or water, it means that you will not co
 
 :: Layer5 Relics [layer5 cards nobr]
 <p><<CarryAdjust>><<checkTime>></p>
-<<if $timeL5T1 < 8 && $timeL5T2 < 11>>
-
 <p>
 @@.floatr;[img[setup.ImagePath+'icon.png']]@@
 
@@ -337,25 +320,6 @@ Already taken
 </div>
 
 <p>[[Continue exploring the fifth layer|Layer5 Hub]]</p>
-
-<<elseif $timeL5T1 < 8>>
-
-<p><<include "Layer5 Borer Encounter">></p>
-
-<p>[[Deal with the Dune Devouring Borer|Layer5 Threat2][$returnPassage = "Layer5 Hub"]]</p>
-
-<<else>>
-
-<p>When you wake up in the morning, you hear an enormous amount of buzzing in the air, luckily you managed to stay out of the swarm when you woke up, but you'll need to decide what to do with the swarm today.</p>
-
-<p>[[Deal with the Mayfly Scuttler|Layer5 Threat1][$returnPassage = "Layer5 Hub"]]</p><<if $ownedRelics.some(e => e.name === "Breathless Exhale")>>
-
-<p>The radiant sun empowers your Breathless Exhale Relic, its energy pulsating within your grasp. You can sense the potential of the Relic, trembling with anticipation, ready to alter the wind's course and drive the insects away from you.</p>
-
-<p>[[Summon a powerful gust to drive the swarm away from you|Layer5 Hub][$timeL5T1 -= 8]]</p>
-<</if>>
-
-<</if>>
 
 
 :: Layer5 Curses [layer5 cards nobr]
@@ -1429,8 +1393,8 @@ Testing your Pocket Hoard, you stick a hand into the pink rucksack, but find you
 
 :: Layer5 Travel Events [layer5 nobr]
 <<set _triggers = {
-	duneDevouringBorer: () => $timeL5T2 > 8,
-	mayflyScuttler: () => $timeL5T1 > 7,
+	duneDevouringBorer: () => $timeL5T2 >= 9,
+	mayflyScuttler: () => $timeL5T1 >= 8,
 }>>
 
 <<PassTime _triggers>>

--- a/src/layer6.twee
+++ b/src/layer6.twee
@@ -20,16 +20,13 @@ They grow taller as you proceed, until you're wading through a thicket or navel-
 <</if>><</nobr>>
 
 
-:: Layer6 Hub [layer6]
-<<nobr>>
+:: Layer6 Hub [layer6 nobr]
 <<set $currentLayer = 6>>
 <<if !isPlaying("layer6")>>
 	<<masteraudio stop>>
 	<<audio "layer6" volume 0.2 play loop>>
 <</if>>
 <<CarryAdjust>><<checkTime>>
-
-<<if $timeL6T1 < 15 && ($timeL6T2 < 8 || $dragonKill > 4)>>
 <<if $visitL6 == 0>>
 	<<set $layerTemp = 8>>
 	<<set $visitL6 = 1>>
@@ -96,15 +93,6 @@ They grow taller as you proceed, until you're wading through a thicket or navel-
 [[Look up towards the surface|Layer6 Ascend 1]]<br>
 [[Look down at the next layer|Layer6 Exit1]]
 
-<<elseif $timeL6T2 > 7 && $dragonKill < 5>>
-<<include "Layer6 Dragon Encounter">><br><br>
-[[Deal with the Fell Dragon|Layer6 Threat2][$returnPassage = passage()]]
-<<else>>
-<<include "Layer6 Tentacle Encounter">><br><br>
-
-[[Deal with the Greater Tentacle Beast|Layer6 Threat1 1][$returnPassage = passage()]]
-<</if>><</nobr>>
-
 
 :: Layer6 Cherry [layer6]
 [img[setup.ImagePath+'Surface/cherry.png']]
@@ -148,26 +136,11 @@ If you decide to start foraging for food or water, it means that you will not co
 
 :: Layer6 Relics [layer6 cards nobr]
 <p><<CarryAdjust>><<checkTime>></p>
-<<if $timeL6T1 < 7>>
-
 <p>[[Continue exploring the sixth layer|Layer6 Hub]]</p>
 
 <<RelicGrid `setup.relicsOnLayer[6]`>>
 
 <p>[[Continue exploring the sixth layer|Layer6 Hub]]</p>
-
-<<elseif $timeL6T2 > 7 && $dragonKill < 5>>
-
-<p><<include "Layer6 Dragon Encounter">><p>
-
-<p>[[Deal with the Fell Dragon|Layer6 Threat2][$returnPassage = "Layer6 Hub"]]<p>
-
-<<else>>
-
-<p><<include "Layer6 Tentacle Encounter">></p>
-
-<p>[[Deal with the Greater Tentacle Beast|Layer6 Threat1 1][$returnPassage = "Layer6 Hub"]]</p>
-<</if>>
 
 
 :: Layer6 Curses [layer6 cards nobr]
@@ -937,8 +910,8 @@ With Cherry's Chaotic Luck you have found the Relic $relics[$temp1].name for a c
 
 :: Layer6 Travel Events [layer6 nobr]
 <<set _triggers = {
-	fellDragon: () => $timeL6T2 > 7 && $dragonKill < 5,
-	greaterTentacleBeast: () => $timeL6T1 > 14,
+	fellDragon: () => $timeL6T2 >= 8 && $dragonKill < 5,
+	greaterTentacleBeast: () => $timeL6T1 >= 15,
 }>>
 
 <<PassTime _triggers>>

--- a/src/layer7.twee
+++ b/src/layer7.twee
@@ -79,39 +79,6 @@ Threats:
 	<<audio "layer7" volume 0.2 play loop>>
 <</if>>
 <<CarryAdjust>><<checkTime>>
-
-<</nobr>>\
-<<if $dubloons < 0 && $easymode==false>>[img[setup.ImagePath+'Threats/taxdrone.png']]
-
-A quiet humming sound descends upon you as you see the Taxdrone floating towards you from over a nearby building. You reach into your pack to get your typical dubloon payment, but then you realize something is wrong, you can't find any dubloons! Perhaps you didn't keep track of them properly? But it's too late to get any now, the taxes are already due.
-
-The Taxdrone patiently requests that you submit your taxes as it displays a slot for you to deposit the dubloons into, but soon it realizes you will not be paying and the typically soft blue lights on the drone change to glaring red and an alarm sounds.
-
-Within a moment you are restrained by nets made of light and you feel a prick on your neck. You notice the drone has stabbed you with a syringe, but at this point it's too late to resist and your consciousness begins to fade, leaving you to succumb to your fate.
-
-You are now forced to become a permanent resident of Layer 7.
-
-[[Awaken to your new life|Layer7 Tax End]]
-<<elseif  $dubloons < 0 && $easymode==true>>
-
-<br>[img[setup.ImagePath+'Threats/taxdrone.png']]<br><br>
-
-<br>A quiet humming sound descends upon you as you see the Taxdrone floating towards you from over a nearby building. You reach into your pack to get your typical dubloon payment, but then you realize something is wrong, you can't find any dubloons! Perhaps you didn't keep track of them properly? But it's too late to get any now, the taxes are already due.<br><br>
-
-The Taxdrone patiently requests that you submit your taxes as it displays a slot for you to deposit the dubloons into, but soon it realizes you will not be paying and the typically soft blue lights on the drone change to glaring red and an alarm sounds.<br><br>
-
-Within a moment you are restrained by nets made of light and you feel a prick on your neck. You notice the drone has stabbed you with a syringe, but at this point it's too late to resist and your consciousness begins to fade, leaving you to succumb to your fate.<br><br>
-
-As you awaken later that day you feel your entire body still aching. However, the Taxdrone is nowhere to be found and you feel like you escaped a terrible fate.<br><br>
-<<set $status.penalty += 2>>
-<<set $status.duration += 1>><br><br>
-<<set $dubloons = 3>>
-
-[[Continue your journey|Layer7 Hub]]
-
-<<elseif $timeL7T2 < 6>>\
-<<nobr>>
-
 <<if $visitL7 == 0>>
 	<<set $layerTemp = 8>>
 	<<set $visitL7 = 1>>
@@ -168,15 +135,6 @@ What do you want to do while you're here?<br><br>
 
 [[Look up towards the surface|Layer7 Ascend 1]]
 [[Look down at the next layer|Layer7 Exit1]]
-<<else>>
-A an enormous rumbling catches your attention as you walk through the seventh layer. A brief glance around reveals the source, an enormous, building-sized machine that is now rapidly approaching you. You consider running, but the Security Robot is moving at an incredible speed, leaving you no chance to get away.
-
-"ACCEPT REHABILITATION" a synthetic voice calls out, with the huge robot nearly upon you.
-
-And suddenly, it's here, reaching down to grab you with shining metallic arms and pulling you into its shell.
-
-[[Get rehabilitated|Layer7 Threat2][$returnPassage = "Layer7 Hub"]]
-<</if>>
 
 
 :: Layer7 Cherry [layer7]
@@ -213,39 +171,11 @@ It is reccomended that you get creative with your Relics and think of more effic
 
 :: Layer7 Relics [layer7 cards nobr]
 <p><<CarryAdjust>><<checkTime>></p>
-<<if $dubloons < 0>>
-
-<p>[img[setup.ImagePath+'Threats/taxdrone.png']]</p>
-
-<p>A quiet humming sound descends upon you as you see the Taxdrone floating towards you from over a nearby building. You reach into your pack to get your typical dubloon payment, but then you realize something is wrong, you can't find any dubloons! Perhaps you didn't keep track of them properly? But it's too late to get any now, the taxes are already due.</p>
-
-<p>The Taxdrone patiently requests that you submit your taxes as it displays a slot for you to deposit the dubloons into, but soon it realizes you will not be paying and the typically soft blue lights on the drone change to glaring red and an alarm sounds.</p>
-
-<p>Within a moment you are restrained by nets made of light and you feel a prick on your neck. You notice the drone has stabbed you with a syringe, but at this point it's too late to resist and your consciousness begins to fade, leaving you to succumb to your fate.</p>
-
-<p>You are now forced to become a permanent resident of Layer 7.</p>
-
-<p>[[Awaken to your new life|Layer7 Tax End]]</p>
-
-<<elseif $timeL7T2 < 6>>
-
 <p>[[Continue exploring the seventh layer|Layer7 Hub]]</p>
 
 <<RelicGrid `setup.relicsOnLayer[7]`>>
 
 <p>[[Continue exploring the seventh layer|Layer7 Hub]]</p>
-
-<<else>>
-
-<p>A an enormous rumbling catches your attention as you walk through the seventh layer. A brief glance around reveals the source, an enormous, building-sized machine that is now rapidly approaching you. You consider running, but the Security Robot is moving at an incredible speed, leaving you no chance to get away.</p>
-
-<p>"ACCEPT REHABILITATION" a synthetic voice calls out, with the huge robot nearly upon you.</p>
-
-<p>And suddenly, it's here, reaching down to grab you with shining metallic arms and pulling you into its shell.</p>
-
-<p>[[Get rehabilitated|Layer7 Threat2][$returnPassage = "Layer7 Hub"]]</p>
-
-<</if>>
 
 
 :: Layer7 Curses [layer7 cards nobr]
@@ -1306,7 +1236,7 @@ You have no choice, you gain consciousness a few times to see yourself in a surg
 :: Layer7 Travel Events [layer7 nobr]
 <<set _triggers = {
 	inDebt: () => $dubloons < 0,
-	rehabilitated: () => $timeL7T2 > 5,
+	rehabilitated: () => $timeL7T2 >= 6,
 }>>
 
 <<PassTime _triggers>>

--- a/src/layer8.twee
+++ b/src/layer8.twee
@@ -89,90 +89,72 @@ Threats:
 	<<audio "layer8" volume 0.2 play loop>>
 <</if>>
 <<CarryAdjust>><<checkTime>>
-<<set $L8loopLim = false>>
-<<set $temp1 = random(0,20)>>
-<<if $timeL8T2b >= ($hiredCompanions.some(e => e.name === "Maru") ? 24 : 21)>>
-	[img[setup.ImagePath+'Threats/dementialaberrations.png']]<br>
-
-	You can feel the deepest fears of your party manifesting into reality once again. 
-	However, this time, they are not mere visions, but physical manifestations of your fears.<br>
-
-	[[Deal with the Demential Aberrations|Layer 8 Threat 2b]]
-<<elseif $timeL8T2a >= ($hiredCompanions.some(e => e.name === "Maru") ? 8 : 7)>>
-	[img[setup.ImagePath+'Threats/dementialaberrations.png']]<br>
-
-	Behind every corner there seems to be a hint of something strange and wrong. The combination of the stress and the inherent wrongness of this layer is calling your
-	<<if $hiredCompanions.length > 0>> party's<</if>> sanity into question. And even if you know that these things aren't real, 
-	it doesn't mean you aren't stopped in your tracks for a day while you reckon with the horrific visions.<br>
-
-	[[Deal with the Demential Aberrations|Layer 8 Threat 2a][$returnPassage = "Layer8 Hub"]]
+<<if $visitL8 == 0>>
+	<<set $layerTemp = 8>>
+	<<set $visitL8 = 1>>
+	<<set $L8T1_milestones = [0,10,30,70,100] >>
+	<<set $L8T1_counter = 0>>
+	<<set $L8T1_difficulty = -0.1>>
+<<elseif $secondVisitL8 == 0>>
+	<<set $secondVisitL8 = 1>>
+	<<set $layerTemp = 18>>
 <<else>>
-
-	<<if $visitL8 == 0>>
-		<<set $layerTemp = 8>>
-		<<set $visitL8 = 1>>
-		<<set $L8T1_milestones = [0,10,30,70,100] >>
-		<<set $L8T1_counter = 0>>
-		<<set $L8T1_difficulty = -0.1>>
-	<<elseif $secondVisitL8 == 0>>
-		<<set $secondVisitL8 = 1>>
-		<<set $layerTemp = 18>>
-	<<else>>
-		<<set $layerTemp = random(0,20)>>
-	<</if>>
-
-	<<if $layerTemp == 1>>
-		After walking down a hallway that seems to twist and turn in impossible ways, you find yourself in a large chamber filled with floating, white orbs of various sizes. The orbs emit a gentle humming sound that is both soothing and eerie. As you reach out to touch one of the orbs, it changes shape, taking on the form of a familiar face from your past. It speaks words of comfort, but the voice is distorted and unnatural. You quickly withdraw your hand, and the face dissipates back into an orb. You can't shake the feeling that this place is trying to manipulate your emotions, making it harder to distinguish between reality and illusion.<br><br>
-	<<elseif $layerTemp == 2>>
-		You find yourself in a room where the walls, floor, and ceiling are covered with intricate, interlocking patterns that shift and change before your eyes. The longer you stare, the more mesmerized you become by the hypnotic movements. Just as you feel yourself becoming lost in the patterns, a sudden jolt brings you back to your senses. You realize that the room itself is rotating, and that you must focus on maintaining your balance to avoid being thrown off your feet. You quickly exit the room and continue your journey through the labyrinthine halls of the layer. <br><br>
-	<<elseif $layerTemp == 3>>
-		You enter a hallway that seems to stretch on forever in both directions. The walls are lined with countless doors, each one identical to the next. As you walk, you notice that the doors seem to be whispering in a multitude of voices, each one offering advice, secrets, or warnings. Curiosity gets the better of you, and you open one of the doors, only to find that it leads to another identical hallway, with the whispers becoming louder and more urgent. Realizing the danger of becoming trapped in this maze of voices, you quickly retrace your steps and manage to find your way back to the original hallway, vowing to ignore the whispers for the rest of your journey. <br><br>
-	<<elseif $layerTemp == 4>>
-		You turn a corner and find yourself confronted by a large, shimmering mirror. The surface of the mirror is ever-changing, and you see distorted reflections of yourself and your companions, as well as glimpses of past and future events. Some of the reflections are unsettling, showing versions of yourself twisted by darkness or despair. The mirror seems to be a nexus of possibilities, and you feel an unnerving pull to touch its surface. With great effort, you resist the temptation and move on, haunted by the images you've seen. <br><br>
-	<<elseif $layerTemp == 5>>
-		The hallway you enter is shrouded in a thick, unnatural fog that seems to cling to your skin and makes it difficult to breathe. You hear footsteps behind you and catch glimpses of shadowy figures in the mist, but when you turn to face them, they vanish as if they were never there. Your sense of unease grows with each step, as you feel unseen eyes watching your every move. You press on, eager to leave this suffocating atmosphere behind and praying that the figures lurking in the mist are only figments of your imagination. <br><br>
-	<<elseif $layerTemp == 7>>
-		You find yourself in a long hallway that appears to be filled with a dense fog. As you move through the fog, you begin to see faint outlines of figures on either side of the hallway, reaching out to you with desperate, grasping hands. You can hear their whispers, pleading for help and salvation, but you can't determine whether they're real or just a cruel illusion. Despite your compassion, you know that stopping to help could mean your own doom, so you press on, the haunting whispers and outstretched hands fading into the fog behind you. <br><br>
-	<<elseif $layerTemp == 6 && $playerCurses.some(e => e.name === "Hijinks Ensue")>>
-		<<include "Hijinks Ensue Scenes">>
-	<<elseif $layerTemp >= 18 - (1+$hiredCompanions.length) && $layerTemp < 19 && ($hiredCompanions.length > 0  || $ownedRelics.some(e => e.name === "Creepy Doll") )>>
-		<<include "Companion Layer Interaction">>
-	<<elseif $layerTemp >= 19>>
-		<<include "Curse Descriptions">><br><br>
-	<<else>>
-		You walk through an unending maze of halls and rooms. Every step you take seems to be a guess, as it can be hard to tell up from down and north from south, even assuming things stay in the same place when you look away. Normal laws of navigation mean little here, but somehow you're still able to make some semblance of progress at the cost of a lot of time.<br><br>
-	<</if>>
-
-	<<if $forageWater == 1>>
-		<<print "You are currently foraging for your daily water on this layer">><br>
-		<<else>>
-		<<print "You are not currently foraging for your daily water on this layer">><br>
-	<</if>>
-	<<if $forageFood == 1>>
-		<<print "You are currently foraging for your daily food on this layer">><br>
-		<<else>>
-		<<print "You are not currently foraging for your daily food on this layer">><br><</if>>
-	<<if !isPlaying("layer8")>>
-		<<masteraudio stop>><<audio "layer8" volume 0.2 play loop>>
-	<</if>>
-	<br>
-	What do you want to do while you're here?<br><br>
-	[[Use Items and Relics]]<br>
-	<<if $hiredCompanions.length > 0>>
-		[[Interact with your party|Party overview]] <<CheckParty>><br>
-	<</if>>
-	<br>
-	[[Learn about the threats on this layer|Layer8 Threats]]<br>
-	[[Check for food and water you can forage for|Layer8 Forage]]<br>
-	[[Search for Relics|Layer8 Relics]]<br>
-	[[Take on Curses to purge your corruption|Layer8 Curses]]<br>
-	[[Look for any wonders you can take advantage of|Layer8 Wonders]]<br>
-	[[Set up camp and rest here|Layer8 Camp]]<br>
-	[[View the Layer 8 habitation option|Layer8 Habitation]]<br><br>
-
-	[[Look up towards the surface|Layer8 Ascend 1]]<br>
-	[[Look down at the next layer|Layer8 Exit1]]<br>
+	<<set $layerTemp = random(0,20)>>
 <</if>>
+
+<<if $layerTemp == 1>>
+	After walking down a hallway that seems to twist and turn in impossible ways, you find yourself in a large chamber filled with floating, white orbs of various sizes. The orbs emit a gentle humming sound that is both soothing and eerie. As you reach out to touch one of the orbs, it changes shape, taking on the form of a familiar face from your past. It speaks words of comfort, but the voice is distorted and unnatural. You quickly withdraw your hand, and the face dissipates back into an orb. You can't shake the feeling that this place is trying to manipulate your emotions, making it harder to distinguish between reality and illusion.<br><br>
+<<elseif $layerTemp == 2>>
+	You find yourself in a room where the walls, floor, and ceiling are covered with intricate, interlocking patterns that shift and change before your eyes. The longer you stare, the more mesmerized you become by the hypnotic movements. Just as you feel yourself becoming lost in the patterns, a sudden jolt brings you back to your senses. You realize that the room itself is rotating, and that you must focus on maintaining your balance to avoid being thrown off your feet. You quickly exit the room and continue your journey through the labyrinthine halls of the layer. <br><br>
+<<elseif $layerTemp == 3>>
+	You enter a hallway that seems to stretch on forever in both directions. The walls are lined with countless doors, each one identical to the next. As you walk, you notice that the doors seem to be whispering in a multitude of voices, each one offering advice, secrets, or warnings. Curiosity gets the better of you, and you open one of the doors, only to find that it leads to another identical hallway, with the whispers becoming louder and more urgent. Realizing the danger of becoming trapped in this maze of voices, you quickly retrace your steps and manage to find your way back to the original hallway, vowing to ignore the whispers for the rest of your journey. <br><br>
+<<elseif $layerTemp == 4>>
+	You turn a corner and find yourself confronted by a large, shimmering mirror. The surface of the mirror is ever-changing, and you see distorted reflections of yourself and your companions, as well as glimpses of past and future events. Some of the reflections are unsettling, showing versions of yourself twisted by darkness or despair. The mirror seems to be a nexus of possibilities, and you feel an unnerving pull to touch its surface. With great effort, you resist the temptation and move on, haunted by the images you've seen. <br><br>
+<<elseif $layerTemp == 5>>
+	The hallway you enter is shrouded in a thick, unnatural fog that seems to cling to your skin and makes it difficult to breathe. You hear footsteps behind you and catch glimpses of shadowy figures in the mist, but when you turn to face them, they vanish as if they were never there. Your sense of unease grows with each step, as you feel unseen eyes watching your every move. You press on, eager to leave this suffocating atmosphere behind and praying that the figures lurking in the mist are only figments of your imagination. <br><br>
+<<elseif $layerTemp == 7>>
+	You find yourself in a long hallway that appears to be filled with a dense fog. As you move through the fog, you begin to see faint outlines of figures on either side of the hallway, reaching out to you with desperate, grasping hands. You can hear their whispers, pleading for help and salvation, but you can't determine whether they're real or just a cruel illusion. Despite your compassion, you know that stopping to help could mean your own doom, so you press on, the haunting whispers and outstretched hands fading into the fog behind you. <br><br>
+<<elseif $layerTemp == 6 && $playerCurses.some(e => e.name === "Hijinks Ensue")>>
+	<<include "Hijinks Ensue Scenes">>
+<<elseif $layerTemp >= 18 - (1+$hiredCompanions.length) && $layerTemp < 19 && ($hiredCompanions.length > 0  || $ownedRelics.some(e => e.name === "Creepy Doll") )>>
+	<<include "Companion Layer Interaction">>
+<<elseif $layerTemp >= 19>>
+	<<include "Curse Descriptions">><br><br>
+<<else>>
+	You walk through an unending maze of halls and rooms. Every step you take seems to be a guess, as it can be hard to tell up from down and north from south, even assuming things stay in the same place when you look away. Normal laws of navigation mean little here, but somehow you're still able to make some semblance of progress at the cost of a lot of time.<br><br>
+<</if>>
+
+<<if $forageWater == 1>>
+	<<print "You are currently foraging for your daily water on this layer">><br>
+	<<else>>
+	<<print "You are not currently foraging for your daily water on this layer">><br>
+<</if>>
+<<if $forageFood == 1>>
+	<<print "You are currently foraging for your daily food on this layer">><br>
+	<<else>>
+	<<print "You are not currently foraging for your daily food on this layer">><br><</if>>
+<<if !isPlaying("layer8")>>
+	<<masteraudio stop>><<audio "layer8" volume 0.2 play loop>>
+<</if>>
+<br>
+What do you want to do while you're here?<br><br>
+[[Use Items and Relics]]<br>
+<<if $hiredCompanions.length > 0>>
+	[[Interact with your party|Party overview]] <<CheckParty>><br>
+<</if>>
+<br>
+[[Learn about the threats on this layer|Layer8 Threats]]<br>
+[[Check for food and water you can forage for|Layer8 Forage]]<br>
+[[Search for Relics|Layer8 Relics]]<br>
+[[Take on Curses to purge your corruption|Layer8 Curses]]<br>
+[[Look for any wonders you can take advantage of|Layer8 Wonders]]<br>
+[[Set up camp and rest here|Layer8 Camp]]<br>
+[[View the Layer 8 habitation option|Layer8 Habitation]]<br><br>
+
+[[Look up towards the surface|Layer8 Ascend 1]]<br>
+[[Look down at the next layer|Layer8 Exit1]]
+
+
 :: Layer8 Wonders [image layer8]
 [img[setup.ImagePath+'Clipped-Fin/Abyss Diver Page 9-wonders.png']]
 
@@ -377,23 +359,9 @@ You can consider your equipment, allies, and general health to take into account
 
 :: Layer8 Relics [layer8 cards nobr]
 <p><<CarryAdjust>><<checkTime>></p>
-<<if $timeL8T2b >= ($hiredCompanions.some(e => e.name === "Maru") ? 24 : 21)>>
-	<p>[img[setup.ImagePath+'Threats/dementialaberrations.png']]</p>
-
-	<p>You can feel the deepest fears of your party manifesting into reality once again. However, this time, they are not mere visions, but physical manifestations of your fears.</p>
-
-	<p>[[Deal with the Demential Aberrations|Layer 8 Threat 2b]]</p>
-<<elseif $timeL8T2a >= ($hiredCompanions.some(e => e.name === "Maru") ? 8 : 7)>>
-	<p>[img[setup.ImagePath+'Threats/dementialaberrations.png']]</p>
-
-	<p>Behind every corner there seems to be a hint of something strange and wrong. The combination of the stress and the inherent wrongness of this layer is calling your<<if $hiredCompanions.length > 0>> party's<</if>> sanity into question. And even if you know that these things aren't real, it doesn't mean you aren't stopped in your tracks for a day while you reckon with the horrific visions.<br></p>
-
-	<p>[[Deal with the Demential Aberrations|Layer 8 Threat 2a][$returnPassage = "Layer8 Hub"]]</p>
-<<else>>
 <p>[[Continue exploring the eighth layer|Layer8 Hub]]</p>
 <<RelicGrid `setup.relicsOnLayer[8]`>>
 <p>[[Continue exploring the eighth layer|Layer8 Hub]]</p>
-<</if>>
 
 :: Pick up the Voila Viola [layer8]
 <<CollectRelic $relic85>>\

--- a/src/relics.twee
+++ b/src/relics.twee
@@ -1733,33 +1733,33 @@ If you have no cutting tools, you could still get some benefit by burning the wh
 
 :: Init Wonders
 
-<<set setup.iconOfMercy{
+<<set setup.iconOfMercy = {
     name: "Icon of Mercy",
     time: 3,
-    destinationPassage: "Layer1 Icon"
+    destinationPassage: "Layer1 Icon",
 }>>
 
-<<set setup.emptyHandedBroker{
+<<set setup.emptyHandedBroker = {
     name: "Empty-handed broker",
     time: 2,
-    destinationPassage: "Layer2 Broker"
+    destinationPassage: "Layer2 Broker",
 }>>
 
-<<set setup.fateCrossingStar{
+<<set setup.fateCrossingStar = {
     name: "Fate-crossing Star",
     time: 3,
-    destinationPassage: "Layer2 Star 1"
+    destinationPassage: "Layer2 Star 1",
 }>>
 
-<<set setup.gossameryScales{
+<<set setup.gossameryScales = {
     name: "Gossamery Scales",
     time: 2,
-    destinationPassage: "Layer3 Scales 1"
+    destinationPassage: "Layer3 Scales 1",
 }>>
 
-<<set setup.skewedShrine{
+<<set setup.skewedShrine = {
     name: "Skewed Shrine",
     time: 3,
-    destinationPassage: "Layer3 Skewed 1a"
-    destinationPassage2: "Layer3 Skewed 2a"
+    destinationPassage: "Layer3 Skewed 1a",
+    destinationPassage2: "Layer3 Skewed 2a",
 }>>


### PR DESCRIPTION
This finally removes the other hardcoded checks for time-based threats in hubs and on relics screens, reducing code duplication and hopefully making these passages easier to read.

These checks should no longer be necessary: We now perform them whenever we wait or travel anywhere. There are a few minor exceptions, like time that passes *during* threats or after giving birth, but that shouldn't really matter - we'll still check the triggers the next time you do anything substantial.

The 2nd commit fixes up the wonders initialization that was added recently - I couldn't start the game to test my changes without doing that ;)