### PR TITLE
Add reduced/increased travel time preview to `<<WonderGrid>>`

### DIFF
--- a/src/wonders.twee
+++ b/src/wonders.twee
@@ -100,15 +100,22 @@
 :: WonderGrid [widget nobr]
 <<widget "WonderGrid">>
 <div class="cards-grid cards-wide">
-  <<for _wonder range _args>>
-    <div>
-      [img[ setup.ImagePath + _wonder.pic ]]
-      <h2>_wonder.name</h2>
-      <p class="cost">Travel Time: <<print _wonder.time>> days</p>
-      <p><<TravelToPassage `'Travel to ' + _wonder.name` `_wonder.name + " Site"` _wonder.time>></p>
-      <p><<include `_wonder.name + " Description"`>></p>
-    </div>
-  <</for>>
+    <<for _wonder range _args>>
+        <div>
+            [img[setup.ImagePath + _wonder.pic]]
+            <h2>_wonder.name</h2>
+            <<PreviewTravelTime '_time' _wonder.time>>
+            <<set _timeStyle = _time > _wonder.time ? "@@color:red;" : _time < _wonder.time ? "@@color:green;" : "">>
+            <p class="cost">
+                <<if _time != _wonder.time>><s>
+                    Travel Time: <<print _wonder.time + (_wonder.time == 1 ? " day" : " days")>>
+                </s><br><</if>>
+                Travel Time: <<print _timeStyle + _time + (_time == 1 ? " day" : " days") + (_timeStyle ? "@@" : "")>>
+            </p>
+            <p><<TravelToPassage `'Travel to ' + _wonder.name` `_wonder.name + " Site"` _time>></p>
+            <p><<include `_wonder.name + " Description"`>></p>
+        </div>
+    <</for>>
 </div>
 <</widget>>
 

--- a/t3lt.twee-config.yml
+++ b/t3lt.twee-config.yml
@@ -197,3 +197,7 @@ sugarcube-2:
       name: WaitAtPassage
       parameters:
         - "var|string &+ var|string &+ var|number |+ string"
+    WonderGrid:
+      name: WonderGrid
+      parameters:
+        - "var |+ ...var"


### PR DESCRIPTION
Basically matched what I did for the relic grid, but without the exception for 0 days because calling it "free" felt weird.

Preview:
![image](https://github.com/FloricSpacer/AbyssDiver/assets/133602907/084064e7-ba4a-4d04-a8cb-c6a43cf682b5)

Also added `<<WonderGrid>>` to the twee config and made its indentation consistent with the file (I think it would be nice to convert the file from spaces to tabs to match the rest of the project, but currently the indentation is 4 spaces per level).