### PR TITLE
Fix <<WaitAtPassage>> by avoiding eager evaluation for the entered wait time

### DIFF
--- a/src/global.twee
+++ b/src/global.twee
@@ -1755,13 +1755,14 @@ How many dubloons would you like to pay back?
 :: Widgets for traveling and the passage of time [widget nobr]
 <<widget "WaitAtPassage">>
 /*
-	_args[0]: var|string = As linkText in <<link>>. The text of the link. May contain markup.
-	_args[1]: var|string = As passageName in <<link>>. The name of the passage to go to.
-	_args[2]: var|number = The number of days to wait.
-	_args[3]: [string]   = Set expression to execute (optional).
+	_args[0]: var|string    = As linkText in <<link>>. The text of the link. May contain markup.
+	_args[1]: var|string    = As passageName in <<link>>. The name of the passage to go to.
+	_args[2]: number|string = The number of days to wait. Expressions should be passed as a regular string.
+	_args[3]: [string]      = Set expression to execute (optional).
 */
 <<link _args[0] _args[1]>>
-	<<if _args[2] > 0>><<set setup.startPassingTime(_args[1], _args[2])>><</if>>
+	<<print `<<set _waitTime = ${_args[2]}>>`>>
+	<<if _waitTime > 0>><<set setup.startPassingTime(_args[1], _waitTime)>><</if>>
 	<<if _args[3]>><<print `<<set ${_args[3]}>>`>><</if>>
 <</link>>
 <</widget>>
@@ -2494,7 +2495,7 @@ You will first drink:<br>
 
 	How many days would you like to rest here?<br>
 	<<textbox "_campTime" "0">><br>
-	<<WaitAtPassage 'Set up camp and wait' `passage()` `Math.max(parseInt(_campTime, 10) || 0, 0)`>><br><br>
+	<<WaitAtPassage 'Set up camp and wait' `passage()` 'Math.max(parseInt(_campTime, 10) || 0, 0)'>><br><br>
 
 	<<link "Return to exploring the layer without waiting" `"Layer" + $currentLayer + " Hub"`>><</link>>
 <</if>>

--- a/src/layer3.twee
+++ b/src/layer3.twee
@@ -135,7 +135,7 @@ If you decide to start foraging for food or water, it means that you will not co
 	You can also wait at the underground river if you'd like to pass the time while waiting for something.<br>
 	How many days would you like to wait at the underground river?<br>
 	<<textbox "_waitTime" "0">>
-	<<WaitAtPassage 'Wait' `passage()` `Math.max(parseInt(_waitTime, 10) || 0, 0)`>><br><br>
+	<<WaitAtPassage 'Wait' `passage()` 'Math.max(parseInt(_waitTime, 10) || 0, 0)'>><br><br>
 <</if>>
 <</nobr>>\
 [[Return to exploring the rest of the layer|Layer3 Hub]]

--- a/src/layer5.twee
+++ b/src/layer5.twee
@@ -245,7 +245,7 @@ If you decide to start foraging for food or water, it means that you will not co
 	You can also wait at the oasis if you'd like to pass the time while waiting for something.<br>
 	How many days would you like to wait at the oasis?<br>
 	<<textbox "_waitTime" "0">>
-	<<WaitAtPassage 'Wait' `passage()` `Math.max(parseInt(_waitTime, 10) || 0, 0)`>><br><br>
+	<<WaitAtPassage 'Wait' `passage()` 'Math.max(parseInt(_waitTime, 10) || 0, 0)'>><br><br>
 <</if>>
 <</nobr>>\
 [[Return to exploring the rest of the layer|Layer5 Hub]]
@@ -1359,7 +1359,7 @@ Testing your Pocket Hoard, you stick a hand into the pink rucksack, but find you
 
 	You can wait here for a while if you'd like to check when the door is open. If you'd like to wait, enter the number of days you'd like to wait and choose to wait.
 	<<textbox "_waitTime" "0">>
-	<<WaitAtPassage 'Wait' `passage()` `Math.max(parseInt(_waitTime, 10) || 0, 0)`>>
+	<<WaitAtPassage 'Wait' `passage()` 'Math.max(parseInt(_waitTime, 10) || 0, 0)'>>
 
 	The door remains locked. You must wait until the timer is between 0 and -5 for it to open and reveal the treasures within.
 <<elseif -5 <= $vaultTimer - $time && $vaultTimer - $time <= 0>>

--- a/t3lt.twee-config.yml
+++ b/t3lt.twee-config.yml
@@ -196,7 +196,7 @@ sugarcube-2:
     WaitAtPassage:
       name: WaitAtPassage
       parameters:
-        - "var|string &+ var|string &+ var|number |+ string"
+        - "var|string &+ var|string &+ number|string |+ string"
     WonderGrid:
       name: WonderGrid
       parameters:


### PR DESCRIPTION
Didn't test this properly: The entered wait time was getting evaluated too early, making it always 0.