### PR TITLE
Fix pulse bloom asked return if companion decides against it

### DIFF
--- a/src/companionConversations.twee
+++ b/src/companionConversations.twee
@@ -3759,11 +3759,10 @@ You produce the unusual flower, the crimson hue glimmering in the light.
 	<<say $mc>> Okay fair enough.<</say>>
 	The words escape your lips, a quiet acceptance of your companion's wishes.
 
-	[[Return to your adventure| _string]]
+	<<link 'Return to your adventure' `"Layer" + $currentLayer + " Hub"`>><</link>>
 <</if>>
 
 :: Pulse Bloom Transformation[nobr]
-<<set _string = "Layer" + $currentLayer + " Hub">>
 You tenderly clutch the Pulse Bloom, drawing it closer to your face, as you take a deep breath, inhaling its crimson vapors. Your nostrils flare, savoring the intoxicatingly sweet and pungent scent. Yet, oddly, nothing seems to occur immediately. Exhaling, you proceed to draw in more of these ruby-hued emissions, until the Pulse Bloom has no more to offer. You stand there in quiet anticipation, but nothing appears to be taking place.<br>
 Minutes trickle by, only for you to suddenly sense your heartbeat accelerating, each pulse resonating through your veins, making your blood buzz. You're seized by an alarming dizziness, and your body flushes with a heat that is almost too much to bear. Disoriented, you stagger, attempting to regain your balance when you feel the transformation seeping into you like ink in water.<br><br>
 
@@ -3802,7 +3801,7 @@ Minutes trickle by, only for you to suddenly sense your heartbeat accelerating, 
 <</if>>
 
 <<say $mc>>It worked, I guess.<</say>><br>
-[[Continue on your journey with a temporary new body|_string]]
+<<link 'Continue on your journey with a temporary new body' `"Layer" + $currentLayer + " Hub"`>><</link>>
 
 :: Companion Mistreatment Reaction [nobr]
 /* Arguments:


### PR DESCRIPTION
Turned it into a `<<link>>` (which should be slightly better than using `_string` due to sugarcube's automatic passage generation).