### PR TITLE
Avoid floating point errors in age calculation, display years and months

### DIFF
--- a/src/companionSetup.twee
+++ b/src/companionSetup.twee
@@ -700,7 +700,7 @@ The rest of the world just sees you as a pair of twins who did everything togeth
 <<nobr>>
 <<if _companion.name=="Golem">>The golem, which is controlled by your summoned specter,<<else>>_companion.name<</if>> is a _companion.sex <<PerceivedRace _companion>>.
 <<if _companion.sex=="male">>He<<else>>She<</if>> is <<set _meters = (_companion.heightCor > 100)>><<print (Math.round(_companion.heightCor)*(_meters ? 0.01 : 1)).toFixed(_meters ? 2 : 1) + (_meters ? " meters" : " cm")>> tall 
-and _companion.realAge years old<<if _companion.realAge != _companion.appAge>>, but <<if _companion.sex=="male">>he<<else>>she<</if>> appears to be _companion.appAge years old<</if>>.
+and <<ShowAge _companion.realAge>> old<<if Math.round(12 * _companion.realAge) != Math.round(12 * _companion.appAge)>>, but <<if _companion.sex=="male">>he<<else>>she<</if>> appears to be <<ShowAge _companion.appAge>> old<</if>>.
 
 <br><br>
 <<if _companion.sex=="male">>His<<else>>Her<</if>> hair color is _companion.hair.<br>

--- a/src/global.twee
+++ b/src/global.twee
@@ -475,7 +475,7 @@ You have $mc.skinColor colored $mc.skinType skin.<<if $mc.skinType.includes("fur
 <br>
 You are <<BodyHeightText>> tall.<br>
 You have $mc.ears ears.<br>
-You are $mc.realAge years old<<if $mc.realAge != $mc.appAge>>, but you appear to be $mc.appAge years old<</if>><<if $eternalYouth < 9999>> and you will never appear to be any older due to your biological immortality granted by the Fountain of Youth<</if>>.
+You are <<ShowAge $mc.realAge>> old<<if Math.round(12 * $mc.realAge) != Math.round(12 * $mc.appAge)>>, but you appear to be <<ShowAge $mc.appAge>> old<</if>><<if $eternalYouth < 9999>> and you will never appear to be any older due to your biological immortality granted by the Fountain of Youth<</if>>.
 <br><br>
 <<if $DaedalusEquip==true>> You appear to have two $relic73.variation wings sprouting from your back. However, in reality, this is the Daedalus Mechanism.<br><br><</if>>
 <<if $companionSwitched == 'Twin'>>

--- a/src/widgets.twee
+++ b/src/widgets.twee
@@ -1,9 +1,13 @@
 :: UpdateAttributes [widget nobr]
 <<widget "UpdateAttributes">>
 <<capture
+	_aDay
+	_aMonth
+	_aYear
 	_assetMod
 	_boxShadowColor
 	_boxShadowOpacity
+	_eternalYouthTime
 	_event
 	_eventAge
 	_eventVariation
@@ -27,69 +31,59 @@
 
 		<<print `<<set _log = $Age${_logName}>>`>>
 
+		/* The Gregorian calendar has 97 leap years in every 400 year cycle. Thus the average length of a year is */
+		/* 365 + 97 / 400 = 365.2425 days, and the average length of a month is 365.2425 / 12 = 30.436875 days. By */
+		/* dividing each year into 1600 * 365.2425 = 12 * 48699 = 584388 units, we can avoid floating point errors. */
+		<<set _aDay = 1600, _aMonth = 48699, _aYear = 584388>>
+		<<set _eternalYouthTime = $eternalYouth * _aDay>>
+
 		<<set _oldTime = 0>>
-		<<set _eventAge = _handle.age>>
+		<<set _eventAge = _handle.age * _aYear>>
 		<<for _event range _log>>
 			/* If this is an age event with a recorded time, add the elapsed time to the subject's age. */
 			<<if _event.variation>>
-				<<set _newTime = _event.variation>>
-				/* If we're adjusting the mc with eternal youth, only age them until they drank from the fountain. */
-				<<if _handle === $mc && _newTime > $eternalYouth>>
-					<<set _newTime = $eternalYouth>>
+				<<set _newTime = _event.variation * _aDay>>
+				/* If we're adjusting the mc who has eternal youth, only age them until they drank from the fountain. */
+				<<if _handle === $mc && _newTime > _eternalYouthTime>>
+					<<set _newTime = _eternalYouthTime>>
 				<</if>>
 				<<if _oldTime < _newTime>>
-					<<set _eventAge += (_newTime - _oldTime) / 365.2425>>
+					<<set _eventAge += _newTime - _oldTime>>
 				<</if>>
-				<<set _oldTime = _event.variation>>
+				<<set _oldTime = _event.variation * _aDay>>
 			<</if>>
 			/* Now apply the effect of the age event. */
 			<<switch _event.name>>
 				<<case 'Age Reduction A'>>
-					<<if _eventAge > 22>>
-						<<set _eventAge = 20>>
-					<<else>>
-						<<set _eventAge -= 2>>
-					<</if>>
+					<<set _eventAge = Math.min(20 * _aYear, _eventAge - 2 * _aYear)>>
 				<<case 'Age Reduction B'>>
-					<<if _eventAge > 23>>
-						<<set _eventAge = 20>>
-					<<else>>
-						<<set _eventAge -= 3>>
-					<</if>>
+					<<set _eventAge = Math.min(20 * _aYear, _eventAge - 3 * _aYear)>>
 				<<case 'Age Reduction C'>>
-					<<if _eventAge > 24>>
-						<<set _eventAge = 20>>
-					<<else>>
-						<<set _eventAge -= 4>>
-					<</if>>
+					<<set _eventAge = Math.min(20 * _aYear, _eventAge - 4 * _aYear)>>
 				<<case 'Doll Transformation'>>
-					<<if _eventAge > 19>>
-						<<set _eventAge = 17>>
-					<<else>>
-						<<set _eventAge -= 2>>
-					<</if>>
+					<<set _eventAge = Math.min(17 * _aYear, _eventAge - 2 * _aYear)>>
 				<<case '1 Day Food Forage Minor Impact'>> /* Layer 3 Crystalline Confectionaries with knowledge */
-					<<set _eventAge -= 0.08>>
+					<<set _eventAge -= _aMonth>>
 				<<case '1 Day Food Forage Major Impact'>> /* Layer 3 Crystalline Confectionaries without knowledge */
-					<<set _eventAge -= 1>>
+					<<set _eventAge -= _aYear>>
 			<</switch>>
 		<</for>>
 
 		/* Add any additional elapsed time to the subject's age. */
-		<<set _newTime = $time>>
-		/* If we're adjusting the MC and MC has eternal youth, only age them until they drank from the fountain. */
-		<<if _handle === $mc && _newTime > $eternalYouth>>
-			<<set _newTime = $eternalYouth>>
+		<<set _newTime = $time * _aDay>>
+		/* If we're adjusting the mc who has eternal youth, only age them until they drank from the fountain. */
+		<<if _handle === $mc && _newTime > _eternalYouthTime>>
+			<<set _newTime = _eternalYouthTime>>
 		<</if>>
 		<<if _oldTime < _newTime>>
-			<<set _eventAge += (_newTime - _oldTime) / 365.2425>>
+			<<set _eventAge += _newTime - _oldTime>>
 		<</if>>
 
 		/* Update the subject's apparent age. */
-		<<set _handle.appAge = Math.round(_eventAge)>>
+		<<set _handle.appAge = Math.round(_eventAge / _aYear)>>
 
 		/* Also set the subject's real age depending on the elapsed time. */
-		<<set _handle.realAge = Math.round(_handle.age + _newTime / 365.2425)>>
+		<<set _handle.realAge = Math.round((_handle.age * _aYear + _newTime) / _aYear)>>
 
 		/* ----------------------------------- Compute apparent gender and assets ----------------------------------- */
 

--- a/src/widgets.twee
+++ b/src/widgets.twee
@@ -80,10 +80,10 @@
 		<</if>>
 
 		/* Update the subject's apparent age. */
-		<<set _handle.appAge = Math.round(_eventAge / _aYear)>>
+		<<set _handle.appAge = _eventAge / _aYear>>
 
 		/* Also set the subject's real age depending on the elapsed time. */
-		<<set _handle.realAge = Math.round((_handle.age * _aYear + _newTime) / _aYear)>>
+		<<set _handle.realAge = (_handle.age * _aYear + _newTime) / _aYear>>
 
 		/* ----------------------------------- Compute apparent gender and assets ----------------------------------- */
 
@@ -775,6 +775,18 @@
 	<<else>>\
 		monster\
 	<</if>>\
+<</widget>>
+
+<<widget "ShowAge">>
+<<capture _months _years>>\
+	<<set _years = Math.floor(Math.round(_args[0] * 12) / 12)>>
+	<<set _months = Math.round(_args[0] * 12) % 12>>
+	<<switch _months>>\
+		<<case 0>>_years years\
+		<<case 1>>_years years and 1 month\
+		<<default>>_years years and _months months\
+	<</switch>>\
+<</capture>>\
 <</widget>>
 
 :: Threat1 Criterion [widget nobr]

--- a/t3lt.twee-config.yml
+++ b/t3lt.twee-config.yml
@@ -165,6 +165,10 @@ sugarcube-2:
       name: SemenDemonCalc
       parameters:
         - "var|number"
+    ShowAge:
+      name: ShowAge
+      parameters:
+        - "var|number"
     sirmaam:
       name: sirmaam
       parameters:


### PR DESCRIPTION
The potential for rounding errors in the age calculation irked me, so I added some multipliers to avoid them. Then I removed the internal rounding so age-based asset adjustments can be more granular, and added a widget to display age as years and months. Might be a bit too specific but I think it's kind of nice for tracking the minor foraging event (and the passage of time).