### PR TITLE
Add `$hubReturn`, remove `$layerReturn`, move `predisplay` actions into `:passagestart` event listener

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,7 +24,6 @@
 		"lastVisited": "readonly",
 		"memorize": "readonly",
 		"passage": "readonly",
-		"predisplay": "readonly",
 		"previous": "readonly",
 		"random": "readonly",
 		"randomFloat": "readonly",

--- a/src/Conditional Scenes.twee
+++ b/src/Conditional Scenes.twee
@@ -12,7 +12,7 @@
 
 	Then you recover and find yourself once again in a new place. But this is one that you've been to before.
 
-	<<link 'Open your eyes to find yourself back in the Abyss, your hand clutching a scorched coin, now devoid of its sigil' `"Layer" + $currentLayer + " Hub"`>>
+	<<link 'Open your eyes to find yourself back in the Abyss, your hand clutching a scorched coin, now devoid of its sigil' $hubReturn>>
 		<<set setup.loseRelic('Phoenix Obol')>>
 		<<set $starving = 0>>
 		<<set $dehydrated = 0>>
@@ -50,7 +50,6 @@ If you are over 18, please go back and enter an age above 18 to continue.
 <<back>>
 
 :: Maxim Labor Scene [nobr]
-<<set _string = "Layer" + $currentLayer + " Hub">>
 <<set $MaximCycleT_flag = false>>
 /*xxx */
 Seemingly out of nowhere you feel an immense pain from inside you stomach accompanied by a dull pop.<br><br> 
@@ -164,7 +163,6 @@ Shocked you silence your thoughts. 'You' still continue your adventure, but you 
 @@.layerTitle;GAME OVER@@
 
 :: Labor Scene
-<<set _string = "Layer" + $currentLayer + " Hub">>\
 <<set setup.setNotPregnant($mc)>>\
 <<set $menCycleFlag = true>>\
 <<set $menCycleT = $time+63>>\
@@ -280,7 +278,7 @@ It emits of a bright flash of light that forces you to close your eyes, and you 
 
 :: Labor Scene Companion
 
-<<nobr>><<set _string = "Layer" + $currentLayer + " Hub">>
+<<nobr>>
 <<set _temp = 13*$BabysBirthed + 3567 + $time>>
 <<for _i = 0; _i < $hiredCompanions.length; _i++>>
 <<if $hiredCompanions[_i].name == $companionLabor>>

--- a/src/companionConversations.twee
+++ b/src/companionConversations.twee
@@ -3651,7 +3651,7 @@ You still feel frustrated by the whole ordeal, but you tentatively agree for now
 With a mutual understanding, you and your twin join forces once more, ready to tackle the challenges ahead, together.
 
 :: Pulse Bloom Forced
-<<print "<<set _companion  = $companion"+ $PulseBloomUse +" >>">> 	<<set _string = "Layer" + $currentLayer + " Hub">>
+<<print "<<set _companion  = $companion"+ $PulseBloomUse +" >>">>
 Silently, you approach _companion.name,  moving stealthily to catch them off guard. You aim to coax <<if _companion.sex=="male">>him<<else>>her<</if>> into a subdued state and wrestle <<if _companion.sex=="male">>him<<else>>her<</if>> into submission.
 <<set _appFitCor = $playerCurses.some(e => e.name === "Weakling") ? 0 : $mc.fit>>
 <<set _companionFitCor = _companion.curses.some(e => e.name === "Weakling") ? 0 : _companion.fit>>
@@ -3701,10 +3701,11 @@ You struggle to form a coherent response.
 <<say _companion>>You know what? I don't even want to hear it. Let's just go already.<</say>>
 They dismiss your stuttered apology with a dismissive wave of their hand.
 
+<<link 'Return to your adventure' $hubReturn>><</link>>
 <</if>>
 
 :: Pulse Bloom Asked
-<<print "<<set _companion  = $companion"+ $PulseBloomUse +" >>">><<set _string = "Layer" + $currentLayer + " Hub">>
+<<print "<<set _companion  = $companion"+ $PulseBloomUse +" >>">>
 <<say $mc>> Can I ask you a favor<</say>>
 You broach the subject, trying to measure the reaction of your companion.
 
@@ -3759,7 +3760,7 @@ You produce the unusual flower, the crimson hue glimmering in the light.
 	<<say $mc>> Okay fair enough.<</say>>
 	The words escape your lips, a quiet acceptance of your companion's wishes.
 
-	<<link 'Return to your adventure' `"Layer" + $currentLayer + " Hub"`>><</link>>
+	<<link 'Return to your adventure' $hubReturn>><</link>>
 <</if>>
 
 :: Pulse Bloom Transformation[nobr]
@@ -3801,7 +3802,7 @@ Minutes trickle by, only for you to suddenly sense your heartbeat accelerating, 
 <</if>>
 
 <<say $mc>>It worked, I guess.<</say>><br>
-<<link 'Continue on your journey with a temporary new body' `"Layer" + $currentLayer + " Hub"`>><</link>>
+<<link 'Continue on your journey with a temporary new body' $hubReturn>><</link>>
 
 :: Companion Mistreatment Reaction [nobr]
 /* Arguments:
@@ -4738,7 +4739,7 @@ Who do you want to give the grimoire to improve their skills?
 		<</capture>>
 <</for>>
 <</nobr>>
-[[Put away the grimoire without using it|$layerReturn]]
+[[Put away the grimoire without using it|$hubReturn]]
 
 
 :: Forbidden Grimoire Outcome
@@ -4755,7 +4756,7 @@ You have given the eldritch knowledge contained in the book to $name.
 
 After $name finishes reading, all words fade from the grimoire's pages, leaving it completely blank.
 
-[[Return to exploring|$layerReturn]]
+[[Return to exploring|$hubReturn]]
 
 :: Forbidden Grimoire Maru
 While Maru great appreciates your gift and improves the taste of his cooking, you don't gain any material benefit on your journey from giving it to him.

--- a/src/companionSetup.twee
+++ b/src/companionSetup.twee
@@ -644,7 +644,7 @@ The rest of the world just sees you as a pair of twins who did everything togeth
 	<</if>>
 <</if>>
 
-[[Return|$layerReturn]]
+[[Return|$hubReturn]]
 
 :: Party Sidebar [nobr noreturn]
 <<CarryAdjust>>

--- a/src/global.twee
+++ b/src/global.twee
@@ -858,7 +858,7 @@ Using your balloon, you're able to send up any Relics you want to sell and get b
 [[Buy items|Balloon Store1]]
 
 
-[[Finish using balloon to trade|$layerReturn]]
+[[Finish using balloon to trade|$hubReturn]]
 
 
 :: Balloon Sell1 [balloon nobr]
@@ -1487,7 +1487,7 @@ Helpful people on the surface managed to find your items safely, retrieving all 
 
 <<if $ownedRelics.some(e => e.name === "Gleam Dazer")>>
 <br>You can use the Gleam Dazer one time to view a glimpse of the next layer and see what threats, Relics, and Curses await you further into the Abyss.<br>
-	<<set $previewReturn = $layerReturn>>
+	<<set $previewReturn = $hubReturn>>
 	<<if $currentLayer == 0>>
 		[[Peek at what is waiting for you on the first layer|Layer1 Preview]]<br>
 	<</if>>
@@ -1520,7 +1520,7 @@ Helpful people on the surface managed to find your items safely, retrieving all 
 <</nobr>>
 [[Perform other stat adjustments to correct for errors|Adjustments]]
 
-[[Return|$layerReturn]]
+[[Return|$hubReturn]]
 
 
 :: Ward Water Drink
@@ -1543,7 +1543,7 @@ You just drank $temp bottles of Ward Water.<<if $temp > 3 >> It was quite an eff
 
 You now have <<print $hexflame - 9>> jinxed flame counters and $items[25].count Ward Waters remaining.
 
-[[Continue exploring the layer|$layerReturn]]
+[[Continue exploring the layer|$hubReturn]]
 
 :: Adjust bullets [noreturn]
 <<set $temp = 0>>How many bullets would you like to add? (Use a negative number to subtract)
@@ -1597,7 +1597,7 @@ The current total value of Relics you have copied is $relic38.copiedValue dubloo
 <</if>>
 <</nobr>>
 
-[[Return to exploring|$layerReturn]]
+[[Return to exploring|$hubReturn]]
 
 :: Daedalus Mechanism Select [noreturn]
 
@@ -2470,7 +2470,7 @@ You will first drink:<br>
 	<<textbox "_campTime" "0">><br>
 	<<WaitAtPassage 'Set up camp and wait' `passage()` 'Math.max(parseInt(_campTime, 10) || 0, 0)'>><br><br>
 
-	<<link "Return to exploring the layer without waiting" `"Layer" + $currentLayer + " Hub"`>><</link>>
+	<<link "Return to exploring the layer without waiting" $hubReturn>><</link>>
 <</if>>
 
 
@@ -3074,7 +3074,7 @@ Your team is currently carrying <<print setup.carriedWeight.toRounded(1)>> kg.<b
 
 <br>
 
-[[Return|$layerReturn]]
+[[Return|$hubReturn]]
 
 :: Drop Item Count [nobr noreturn]
 <<set _item = $items[$temp]>>

--- a/src/script.js
+++ b/src/script.js
@@ -127,9 +127,29 @@ Config.navigation.override = function (destPassage) {
 	return destPassage;
 };
 
+// Listen for the :passagestart jQuery event.
 $(document).on(':passagestart', () => {
 	// Get a reference to the active story variables store.
 	const vars = variables();
+
+	// Update $hubReturn.
+	if (vars.currentLayer < 1) {
+		vars.hubReturn = 'Surface Hub';
+	} else {
+		vars.hubReturn = `Layer${vars.currentLayer} Hub`;
+	}
+
+	// Update $menuReturn.
+	if (!tags().includes('noreturn')) vars.menuReturn = passage();
+
+	// Add some CSS classes based on where we are.
+	if (State.variables.comBalloon) {
+		document.body.classList.add('balloon');
+	} else if (vars.currentLayer < 1) {
+		document.body.classList.add('surface');
+	} else {
+		document.body.classList.add(`layer${vars.currentLayer}`);
+	}
 
 	/* ---- Companion object identity ---- */
 
@@ -232,26 +252,6 @@ $(document).on(':passagestart', () => {
 		}
 	}
 });
-
-predisplay["Menu Return"] = function (/* taskName */) {
-	if (! tags().contains("noreturn")) {
-		State.variables.menuReturn = passage();
-	}
-};
-predisplay["Layer Return"] = function (/* taskName */) {
-	if (tags().some(t => t === "surface" || t.startsWith("layer"))) {
-		State.variables.layerReturn = passage();
-	}
-	if (State.variables.comBalloon) {
-		$(document.body).addClass("balloon");
-	} else if (State.variables.layerReturn) {
-		for (var tag of tags(State.variables.layerReturn)) {
-			if (tag === "surface" || tag.startsWith("layer")) {
-				$(document.body).addClass(tag);
-			}
-		}
-	}
-};
 
 // eslint-disable-next-line no-constant-condition -- Change from false to true if running inside Twine.
 if (false) {


### PR DESCRIPTION
This replaces `$layerReturn` with `$hubReturn`. The former was confusing as it was only ever used to return to the hub, but could theoretically return to any passage with a tag starting with `layer`. Every passage that dynamically computed the name of the hub passage now uses `$hubReturn`.

This also moves the `predisplay` actions into the `:passagestart` event listener: `predisplay` actions are deprecated, and `:passagestart` is the replacement.

Finally, I cleaned up the code for adding the body styles: They were looking at the contents of `$layerReturn`, but actually they just want to know what layer we're on (aside from the commerce balloon exception), so I made them use `$currentLayer` directly instead.