### PR TITLE
Managed Misfortune and Skewed/Steady Shrine fixes

### DIFF
--- a/src/global.twee
+++ b/src/global.twee
@@ -1476,8 +1476,6 @@ Helpful people on the surface managed to find your items safely, retrieving all 
 					<<set _text = "Deactivate stored " + _curse.name + " Curse">>
 					<<link _text "Use Items and Relics">>
 						<<RemoveCurse _curse>>
-						<<set _j = $ManagedMisfortuneActive.indexOf(c => c.name === _curse.name)>>
-						<<set $ManagedMisfortuneActive.deleteAt(_j)>>
 					<</link>><br>
 				<</if>>
 			<</capture>>
@@ -1716,6 +1714,12 @@ How many dubloons would you like to pay back?
 			<<if _j >= 0>>
 				<<set State.variables[_logName].deleteAt(_j)>>
 			<</if>>
+		<</if>>
+		<<set _j = $ManagedMisfortuneActive.findLastIndex(curse => curse.name == _targetCurse.name)>>
+		<<if _j != -1>>
+			<<set $ManagedMisfortuneActive.deleteAt(_j)>>
+			<<set _j = $StoredCurse.findLastIndex(curse => curse.name == _targetCurse.name)>>
+			<<set $StoredCurse.deleteAt(_j)>>
 		<</if>>
 		<<set $playerCurses.deleteAt(_i)>>
 		<<break>>

--- a/src/layer3.twee
+++ b/src/layer3.twee
@@ -411,7 +411,9 @@ Which Curse would you like to force upon your unwilling companion?
 	You do not have enough dubloons for an offering.
 <<else>>
 	<<for _i, _curse range $playerCurses>>
-		<<if  _curse.name != 'Double Trouble' && _curse.name != 'Conjoined' && _curse.name != 'The Maxim'>>
+		<<if _curse.name != 'Double Trouble' && _curse.name != 'Conjoined' && _curse.name != 'The Maxim' &&
+			!$hiredCompanions.every(companion => companion === $companionGolem || companion.curses.some(curse => curse.name == _curse.name))
+		>>
 			<<capture _i>>
 				[[_curse.name|Layer3 Skewed2b][$temp = _i]]<br>
 			<</capture>>

--- a/src/layer4.twee
+++ b/src/layer4.twee
@@ -773,9 +773,13 @@ Which Curse would you like to forcibly copy onto your unwilling companion?
 	You do not have enough dubloons for an offering.
 <<else>>
 	<<for _i, _curse range $playerCurses>>
-		<<capture _i>>
-			[[_curse.name|Layer4 Steady2b][$temp = _i]]<br>
-		<</capture>>
+		<<if _curse.name != 'Double Trouble' && _curse.name != 'Conjoined' &&
+			!$hiredCompanions.every(companion => companion === $companionGolem || companion.curses.some(curse => curse.name == _curse.name))
+		>>
+			<<capture _i>>
+				[[_curse.name|Layer4 Steady2b][$temp = _i]]<br>
+			<</capture>>
+		<</if>>
 	<</for>>
 <</if>>
 <</nobr>>


### PR DESCRIPTION
This:
* Extends the `<<RemoveCurse>>` widget to keep Managed Misfortune in mind
* Prevents you from copying Double Trouble or Conjoined (Double Trouble in particular would require companions to be handled differently)
* Prevents you from attempting to forcibly transfer or copy a curse that all party members already have