### PR TITLE
Only allow the purity tree to be used once

### DIFF
--- a/src/wonders.twee
+++ b/src/wonders.twee
@@ -40,6 +40,7 @@
     name: "Purity Tree",
     pic: "Wonders/puritytree.png",
     time: 5,
+    condition: () => !$purityUsed,
 }>>
 
 <<set setup.oneSidedTunnel = {
@@ -101,6 +102,7 @@
 <<widget "WonderGrid">>
 <div class="cards-grid cards-wide">
     <<for _wonder range _args>>
+        <<if _wonder.condition && !_wonder.condition()>><<continue>><</if>>
         <div>
             [img[setup.ImagePath + _wonder.pic]]
             <h2>_wonder.name</h2>


### PR DESCRIPTION
Other ways to do this:
* Wrap call to `<<WonderGrid>>`  in a conditional. Doesn't seem ideal.
* Still show the wonder, but with some text about how you can no longer access it (explanation could be added to the object along with the condition).