### PR TITLE
Fix bandit companion identity in a few places

### DIFF
--- a/src/companionConversations.twee
+++ b/src/companionConversations.twee
@@ -2967,7 +2967,7 @@ Saeko meticulously guides you through a comprehensive timetable, detailing every
 You approach the bandit who is still bound after all this time. She looks at you pissed of, although not with the killer stare she used to had.<br><br>
 <<say $mc>>How about we take this of.<</say>><br>
 <<say $companionBandit>>Hmpf!<</say>><br>
-You untie the makeshift gag. <<set $companionBanit.imageIcon = "Icons/BanditIcon_released.jpg">><br><br>
+You untie the makeshift gag. <<set $companionBandit.imageIcon = "Icons/BanditIcon_released.jpg">><br><br>
 <<say $companionBandit>>What is it? I'm I getting an extra meal or something?<</say>><br>
 <<say $mc>>Nope, I just wanted to talk today.<</say>><br>
 <<say $companionBandit>>I've got nothing to say to you.<</say>><br>
@@ -3001,7 +3001,7 @@ The bandit pauses for a second and looks lost in thought.<br><br>
 <<say $mc>>On second thought, you still seem angry and you're still a flight risk. We better leave those on a little longer.<</say>><br>
 <<say $companionBandit>>Are you fucking kidding me?! Was this all some weird tease? Do you get off on this shit?<</say>><br>
 <<say $mc>>Yeah, I'm sorry we are going to need this as well again.<</say>><br>
-You tie the gag around the head of the thrashing bandit again. <<set $companionBanit.imageIcon = "Icons/BanditIcon.jpg">><br><br>
+You tie the gag around the head of the thrashing bandit again. <<set $companionBandit.imageIcon = "Icons/BanditIcon.jpg">><br><br>
 <<say $companionBandit>>Hmpfh!<</say>><br>
 <<say $mc>>Much better, let's continue!<</say>><br>
 
@@ -3024,15 +3024,12 @@ And with that Vesper continues to walk away.
 [[Conclude your conversation|Party overview]]
 <<set $BanditConvo0_rejoin = $time+5>>
 <<set $companionBandit.name = "Vesper">>
-<<set $companionBanit.image = "Surface/bandit_released.jpg">>
+<<set $companionBandit.image = "Surface/bandit_released.jpg">>
 <<set $companionBandit.subdom -=3>>
 <<set $companionBandit.carry = 25>>
 <<set $BanditConvo0 = true>>
-<<for _i=0; _i<$hiredCompanions.length; _i++>>
-	<<if $hiredCompanions[_i].name == $companionBandit.name>>
-		<<set $hiredCompanions.deleteAt(_i)>>
-	<</if>>
-<</for>>
+<<set _i = $hiredCompanions.findIndex(companion => companion === $companionBandit)>>
+<<if _i != -1>><<set $hiredCompanions.deleteAt(_i)>><</if>>
 
 
 :: Bandit Convo0 Fled Permanent
@@ -3044,13 +3041,10 @@ You start untying here right away. She stands up slowly and stretches her limbs.
 As she walks by you she gives you a shove with her shoulders.
 
 <<say $companionBandit>>Later loser.<</say>><br>
-And with that se starts walking off.
+And with that she starts walking off.
 [[Conclude your conversation|Party overview]]
-<<for _i=0; _i<$hiredCompanions.length; _i++>>
-	<<if $hiredCompanions[_i].name == $companionBandit.name>>
-		<<set $hiredCompanions.deleteAt(_i)>>
-	<</if>>
-<</for>>
+<<set _i = $hiredCompanions.findIndex(companion => companion === $companionBandit)>>
+<<if _i != -1>><<set $hiredCompanions.deleteAt(_i)>><</if>>
 
 :: Bandit Joins
 You suddenly see figure in the distance. As she walks closer it looks like the bandit you released a few days ago, Vesper.<br><br>
@@ -4094,13 +4088,7 @@ Minutes trickle by, only for you to suddenly sense your heartbeat accelerating, 
 			<<else>>
 				<<if $hiredCompanions.length < 2 >>
 					The moment you start flying up you see the bandit hopping in a different direction. She's probably not going to look for you.
-					<<nobr>>
-					<<for _i=0; _i<$hiredCompanions.length; _i++>>
-						<<if $hiredCompanions[_i].name == $companionBandit.name>>
-							<<set $hiredCompanions.deleteAt(_i)>>
-						<</if>>
-					<</for>>
-					<</nobr>>
+					<<set $hiredCompanions.deleteAt(_i)>>
 				<<else>>
 					The moment you start flying up you see the bandit trying to make a break for it. However, she is soon reeled in and dragged along again.
 				<</if>>

--- a/src/companionSetup.twee
+++ b/src/companionSetup.twee
@@ -713,19 +713,13 @@ One can only imagine what she'll do if she manages to break free.
 <<if $ConvoHandicapLarge || $ConvoHandicapSmall>>
 	@@.alert2; Because of your handicaps you are unable to have an effective conversation with your companions.@@ <br>
 	<<for _companion range $hiredCompanions>>
-		<<set _name = _companion !== $companionTwin ? _companion.name : 'Twin'>>
-		<<if _companion.name == $companionBandit.name>>
-			<<set _name = "Bandit">>
-		<</if>>
+		<<set _name = _companion === $companionTwin ? 'Twin' : _companion === $companionBandit ? 'Bandit' : _companion.name>>
 		<<print `[[${_companion.name}|${_name} Overview]]: $companion${_name}.affec`>>
 		<br>
 	<</for>>
 <<else>>
 	<<for _companion range $hiredCompanions>>
-		<<set _name = _companion !== $companionTwin ? _companion.name : 'Twin'>>
-		<<if _companion.name == $companionBandit.name>>
-			<<set _name = "Bandit">>
-		<</if>>
+		<<set _name = _companion === $companionTwin ? 'Twin' : _companion === $companionBandit ? 'Bandit' : _companion.name>>
 		<<print `[[${_companion.name}|${_name} Overview]]: $companion${_name}.affec`>>
 		<<if _companion !== $companionGolem>>
 			<br><<include `_name + ' Conversations'`>>

--- a/src/layer1.twee
+++ b/src/layer1.twee
@@ -1277,11 +1277,8 @@ As you lock eyes with the bandit leader to anticipate her next move you get hit 
 
 		<<say $companionBandit>>This piece of shit is all yours, Boss<</say>>
 		<<nobr>>
-		<<for _i=0; _i<$hiredCompanions.length; _i++>>
-			<<if $hiredCompanions[_i].name == $companionBandit.name>>
-				<<set $hiredCompanions.deleteAt(_i)>>
-			<</if>>
-		<</for>>
+		<<set _i = $hiredCompanions.findIndex(companion => companion === $companionBandit)>>
+		<<if _i != -1>><<set $hiredCompanions.deleteAt(_i)>><</if>>
 		<</nobr>>
 	<</if>>\
 <</if>>\
@@ -1330,11 +1327,8 @@ When you wake up you find that all of your relics are gone<<if $hiredCompanions.
 		<<say $companionBandit>>Of course, Boss!<</say>>
 	<</if>>\
 	<<nobr>>
-	<<for _i=0; _i<$hiredCompanions.length; _i++>>
-		<<if $hiredCompanions[_i].name == $companionBandit.name>>
-			<<set $hiredCompanions.deleteAt(_i)>>
-		<</if>>
-	<</for>>
+		<<set _i = $hiredCompanions.findIndex(companion => companion === $companionBandit)>>
+		<<if _i != -1>><<set $hiredCompanions.deleteAt(_i)>><</if>>
 	<</nobr>>
 <</if>>\
 Nervously, you begin going trough your bag, attempting to decide which Relics to surrender and which to keep.

--- a/src/layer3.twee
+++ b/src/layer3.twee
@@ -366,10 +366,8 @@ Which Curse would you like to transfer to your willing companion? It can't be to
 			<</switch>>
 
 			<<if _flag >>
+				<<if _companion === $companionBandit>><<set _tempName = "Bandit">><</if>>
 				<<capture _companion _curse _tempName>>
-					<<if _companion.name == $companionBandit.name>>
-						<<set _tempName = "Bandit">>
-					<</if>>
 					&nbsp; _curse.name
 					<<link "Choose" "Layer3 Skewed1a">>
 						<<set _companion.curses.push(_curse)>>
@@ -875,10 +873,8 @@ The magic of the shrine wisps through the air menacingly as your victim struggle
 	<</switch>>
 
 	<<if _flag>>
+		<<if _companion === $companionBandit>><<set _tempName = "Bandit">><</if>>
 		<<capture _companion _i _tempName>>
-			<<if _companion.name == $companionBandit.name>>
-				<<set _tempName = "Bandit">>
-			<</if>>
 			<<set _choiceText = "Transfer to " + _tempName>>
 			<<link _choiceText "Layer3 Skewed Apply">>
 				<<set _companion.curses.push(_curse)>>

--- a/src/layer4.twee
+++ b/src/layer4.twee
@@ -723,10 +723,8 @@ Which Curse would you like to transfer to your willing companion? It can't be to
 			<</switch>>
 
 			<<if _flag>>
+				<<if _companion === $companionBandit>><<set _tempName = "Bandit">><</if>>
 				<<capture _companion _curse _tempName>>
-					<<if _companion.name == $companionBandit.name>>
-						<<set _tempName = "Bandit">>
-					<</if>>
 					&nbsp; _curse.name
 					<<link "Choose" "Layer4 Steady1a">>
 						<<set _companion.curses.push(_curse)>>
@@ -844,10 +842,8 @@ The magic of the shrine wisps through the air menacingly as your victim struggle
 	<</switch>>
 
 	<<if _flag>>
+		<<if _companion === $companionBandit>><<set _tempName = "Bandit">><</if>>
 		<<capture _companion _i _tempName>>
-			<<if _companion.name == $companionBandit.name>>
-				<<set _tempName = "Bandit">>
-			<</if>>
 			<<set _choiceText = "Transfer to " + _tempName>>
 			<<link _choiceText "Layer4 Steady Apply">>
 				<<set _companion.curses.push(_curse)>>

--- a/src/script.js
+++ b/src/script.js
@@ -163,13 +163,15 @@ $(document).on(':passagestart', () => {
 
 	/* ---- Companion object identity ---- */
 
-	// Get name of twin so we don't have to look it up each time.
+	// Get names of twin and bandit so we don't have to look them up each time.
 	const twinName = vars.companionTwin.name;
+	const banditName = vars.companionBandit.name;
 
 	// Get all the companion array variables.
 	const companionArrays = [
 		'companions',
 		'hiredCompanions',
+		'DaedalusCompanions',
 		'DesertedCompanions',
 		'SemenDemonVec',
 	].map(varName => vars[varName]);
@@ -177,7 +179,7 @@ $(document).on(':passagestart', () => {
 	// Restore object identity between elements of companion arrays and $companionName variables.
 	for (const companions of companionArrays) {
 		for (const [i, companion] of companions.entries()) {
-			const name = companion.name !== twinName ? companion.name : "Twin";
+			const name = companion.name == twinName ? 'Twin' : companion.name == banditName ? 'Bandit' : companion.name;
 			const companionVar = vars[`companion${name}`];
 			if (companionVar) {
 				companions[i] = companionVar;
@@ -216,7 +218,7 @@ $(document).on(':passagestart', () => {
 	}
 
 	// Restore object identity between curses in curse logs and $curseN variables.
-	const logNameSuffixes = ['', ...vars.companions.map(companion => companion.name)];
+	const logNameSuffixes = ['', ...vars.companions.map(companion => companion.name), 'Bandit'];
 	for (const type of ['Height', 'Gender', 'Age', 'Libido', 'Handicap']) {
 		for (const suffix of logNameSuffixes) {
 			const events = vars[`${type}Log${suffix}`];

--- a/src/widgets.twee
+++ b/src/widgets.twee
@@ -24,10 +24,7 @@
 	_wombEvents
 >>
 	<<for _handle range $hiredCompanions.concat($mc)>>
-		<<set _name = _handle !== $companionTwin ? _handle.name : 'Twin'>>
-		<<if _handle.name == $companionBandit.name>>
-			<<set _name = "Bandit">>
-		<</if>>
+		<<set _name = _handle === $companionTwin ? 'Twin' : _handle === $companionBandit ? 'Bandit' : _handle.name>>
 		<<set _logName = _handle === $mc ? 'Log' : `Log${_name}`>>
 
 		/* ------------------------------------ Compute age (real and apparent) ------------------------------------- */
@@ -627,8 +624,8 @@
 
 	<<if _pulseBloomInUse>>
 		<<print `<<set _handle = $companion${$PulseBloomUse}>>`>>
-		<<if _handle.name== $companionBandit.name>>
-			<<set $mc.imageIcon = "Icons/BanditIcon_released.jpg">> /* Note: Use the *current* image icon. */
+		<<if _handle === $companionBandit>>
+			<<set $mc.imageIcon = "Icons/BanditIcon_released.jpg">>
 		<<else>>
 			<<set $mc.imageIcon = _handle.imageIcon>> /* Note: Use the *current* image icon. */
 		<</if>>


### PR DESCRIPTION
I think the important changes are in `src/script.js` (they're easy to miss because you can't refer to `$companionBandit` directly).

Miscellaneous fixes and changes:
* Fixes some instances of 'Banit' (only affected the image icon).
* Tidies up some identity checks to check for `$companionBandit` directly.
* Fixes (?) skewed and steady shrine to set correct name *before* capturing variable. Not sure this matters.
* Uses `Array.prototype.findIndex` in a few places instead of looping.