### PR TITLE
Add content filters for watersports and amputation

### DIFF
--- a/src/classes/2curse.js
+++ b/src/classes/2curse.js
@@ -119,6 +119,15 @@ class Curse extends CharEvent {
 	get maximum() {
 		return 1;
 	}
+
+	get isWatersports() {
+		// despite the seeming senselessness this comparison is necessary to prevent coercion
+		return this.constructor.iswatersports === true;
+	}
+	get isAmputation() {
+		// despite the seeming senselessness this comparison is necessary to prevent coercion
+		return this.constructor.isamputation === true;
+	}
 }
 
 class LibidoReinforcementA extends Curse {
@@ -1861,6 +1870,7 @@ window.AssetRobustnessE = AssetRobustnessE
 setup.curseArray.push(AssetRobustnessE)
 
 class UrineReamplificationA extends Curse {
+	static iswatersports = true;
 	constructor() {
 		super('Urine Reamplification A', 55, 'Curses/urinereamplificationA.png', 'none',
 			  'Your bladder capacity has been significantly reduced, you need to be careful to make sure you don\'t have any accidents. ');
@@ -2033,6 +2043,7 @@ window.AssetRobustnessF = AssetRobustnessF
 setup.curseArray.push(AssetRobustnessF)
 
 class UrineReamplificationB extends Curse {
+	static iswatersports = true;
 	constructor() {
 		super('Urine Reamplification B', 55, 'Curses/urinereamplificationB.png', 'none');
 	}
@@ -2043,6 +2054,7 @@ window.UrineReamplificationB = UrineReamplificationB
 setup.curseArray.push(UrineReamplificationB)
 
 class EyeOnThePrize extends Curse {
+	static isamputation = true;
 	constructor() {
 		super('Eye on the Prize', 70, 'Curses/eyeontheprize.png', 'handicap');
 	}
@@ -2057,6 +2069,7 @@ window.EyeOnThePrize = EyeOnThePrize
 setup.curseArray.push(EyeOnThePrize)
 
 class DeafeningSilence extends Curse {
+	static isamputation = true;
 	constructor() {
 		super('Deafening Silence', 90, 'Curses/deafeningsilence.png', 'handicap');
 	}
@@ -2073,6 +2086,7 @@ window.DeafeningSilence = DeafeningSilence
 setup.curseArray.push(DeafeningSilence)
 
 class TaciturnTurnaround extends Curse {
+	static isamputation = true;
 	constructor() {
 		super('Taciturn Turnaround', 90, 'Curses/taciturnturnaround.png', 'handicap');
 	}
@@ -2089,6 +2103,7 @@ window.TaciturnTurnaround = TaciturnTurnaround
 setup.curseArray.push(TaciturnTurnaround)
 
 class AmpuQtie extends Curse {
+	static isamputation = true;
 	constructor(arms = 0, legs = 0) {
 		super('Ampu-Q-tie', 45, 'Curses/ampu-Q-tie.png', 'none');
 		if (typeof arms === 'string') {
@@ -2140,6 +2155,7 @@ window.AmpuQtie = AmpuQtie
 setup.curseArray.push(AmpuQtie)
 
 class NoseGoes extends Curse {
+	static isamputation = true;
 	constructor() {
 		super('Nose Goes', 65, 'Curses/nosegoes.png', 'handicap');
 	}

--- a/src/curses.twee
+++ b/src/curses.twee
@@ -646,7 +646,15 @@ You will also have a new name, 'Princess'. Others will find it impossible to cal
 <<for _name range _args[0]>>
 	<div>
 	<<set _curse = setup.findCurseBy(c => c.name === _name)>>
-	[img[ setup.ImagePath + _curse.pic ]]
+	<<set _isfiltered = false>>
+	<<if _curse.isWatersports && settings.WSHidden>><<set _isfiltered = true>><</if>>
+	<<if _curse.isAmputation && settings.amputationHidden>><<set _isfiltered = true>><</if>>
+
+	<<if !_isfiltered>>
+		[img[ setup.ImagePath + _curse.pic ]]
+	<<else>>
+		[img[setup.ImagePath + 'curses/censored.png']]
+	<</if>>
 	<h2>_name</h2>
 	<p class="benefit">
 	+ <<print _curse.corr>> corruption </p>
@@ -683,10 +691,15 @@ You will also have a new name, 'Princess'. Others will find it impossible to cal
 	<</if>>
 	</p>
 	<p>
-	<<if _curse.name.startsWith("Libido Reinforcement ") || _curse.name.startsWith("Gender Reversal ")>>
-		<<LeveledCurseDescription `_curse.name`>>
+	<<if _isfiltered>>
+		This curse has been hidden by your content filters. Note that if you choose to take it anyway, its effects
+	    will not be hidden.
 	<<else>>
-		<<include `_curse.name + " Description"`>>
+		<<if _curse.name.startsWith("Libido Reinforcement ") || _curse.name.startsWith("Gender Reversal ")>>
+			<<LeveledCurseDescription `_curse.name`>>
+		<<else>>
+			<<include `_curse.name + " Description"`>>
+		<</if>>
 	<</if>>
 	</p>
 	</div>
@@ -736,7 +749,8 @@ You will also have a new name, 'Princess'. Others will find it impossible to cal
 <<for _name range _tempCurses>>
 	<<set _curse = setup.findCurseBy(c => c.name === _name)>>
 	<<include "Curse Limits">>
-	<<if !_curseLimitation && (_totalCurses.filter(e => e.name === _name).length + $StoredCurse.filter(e => e.name === _name).length) < _maxCurses>>
+	<<if !_curseLimitation && (_totalCurses.filter(e => e.name === _name).length + $StoredCurse.filter(e => e.name === _name).length) < _maxCurses &&
+	     (!_curse.isWatersports || !settings.WDHidden) && (!curse.isAmputation || !settings.amputationHidden)>>
 		<<set _validNames.push(_name)>>
 	<</if>>
 <</for>>

--- a/src/script.js
+++ b/src/script.js
@@ -281,6 +281,16 @@ Setting.addToggle("MenCycleToggleFilter", {
     default  : true,
 });
 
+Setting.addToggle("WSHidden", {
+    label : "Hide content involving watersports",
+    default  : false,
+});
+
+Setting.addToggle("amputationHidden", {
+    label : "Hide content involving amputation. This includes non-physical crippling such as removing ability to hear or speak",
+    default  : false,
+});
+
 Setting.addRange("appAgeControl", {
     label    : "Minimum age your physical body can regress to (3-18):",
     min      : 3,


### PR DESCRIPTION
When enabled, relevant curses are hidden. Their image is replaced with a "censored" stamp and the description says "This curse has been hidden by your content filters. Note that if you choose to take it anyway, its effects will not be hidden.".
The name is still revealed so that users may make a guess at how upsetting they would find it, giving them the option to temporarily disable the filter or take the curse anyway.
Choosing a random curse also avoids filtered curses, but cherry's luck does not since that one gives a mechanical advantage.