### PR TITLE
Allow taking semen demon multiple times

### DIFF
--- a/src/classes/2curse.js
+++ b/src/classes/2curse.js
@@ -1715,12 +1715,25 @@ class SemenDemon extends Curse {
 	/**
 	 * Creates a new Semen Demon curse.
 	 * @param {'semen' | 'sexual fluids' | 'vaginal fluids'} fluidType The type of fluids the cursed character is required to consume.
-	 * @param {number} amount The number of times this Curse has been taken.
+	 * @param {number} amount Deprecated: Semen Demon is now taken multiple times by actually taking it multiple times.
 	 */
 	constructor(fluidType = 'sexual fluids', amount = 1) {
 		super('Semen Demon', 20, 'Curses/semendemon.png', 'libido');
 		this.fluidType = fluidType;
-		this.amount = amount;
+		if (amount !== 1) console.error('Semen Demon created with invalid amount')
+	}
+
+	get maximum() {
+		return 4;
+	}
+
+	/**
+	 * Returns 1
+	 * @deprecated To take Semen Demon multiple times, use multiple instances.
+	 * @returns {number} The number 1
+	 */
+	get amount() {
+		return 1
 	}
 
 	/**

--- a/src/classes/3character.js
+++ b/src/classes/3character.js
@@ -302,6 +302,8 @@ class Character {
 
 	/**
 	 * Removes a Curse from this character.
+	 * Curses on the main character should always be removed this way to ensure it's removed from the twin too,
+	 * not dropped from events manually.
 	 * @param {Class | string} curse The name or class of the Curse to remove.
 	 * @param {boolean} all Iff all is true, removes all copies of the Curse, not just the last.
 	 */
@@ -313,6 +315,9 @@ class Character {
 			// noinspection JSUnresolvedReference -- findLastIndex exists, I'm not sure why my linter claims it doesn't.
 			let i = this.events.findLastIndex(e => typeof curse === 'string' ? e.name === curse : e instanceof curse);
 			if (i >= 0) this.events.deleteAt(i);
+		}
+		if (this.id === setup.companionIds.mc) {
+			State.variables.companionTwin.removeCurse(curse, all);
 		}
 	}
 
@@ -865,6 +870,8 @@ class Character {
 
 	/**
 	 * Returns a description of this character's ears.
+	 * The description is a string such as would fit into the phrase "this character has ### ears",
+	 * for example "furry cat".
 	 * @returns {string} A description of this character's ears.
 	 */
 	get ears() {
@@ -874,6 +881,9 @@ class Character {
 
 	/**
 	 * Returns the quantity of this character's body hair.
+	 * 1: normal human
+	 * 0: no body hair below the nose (hair removal, scales, exoskeleton...)
+	 * 2: full-body hair coverage (maximum fluff)
 	 * @returns {number} The level of this character's body hair.
 	 */
 	get bodyHair() {
@@ -1010,17 +1020,32 @@ class Character {
 	}
 
 	/**
+	 * Sets the character's original image icon. Has no effect on body-swapped characters.
+	 * @param value
+	 */
+	set imageIcon(value) {
+		this._imageIcon = value;
+	}
+
+	/**
 	 * Returns the path of the image used in icons representing this character.
 	 * @returns {string} The path to the image containing this character's icon.
 	 */
 	get imageIcon() {
 		let transformed = this.events.reduce((v, e) => e.changeImageIcon(v), '');
+		// as a special exception, anybody who swapped with the bandit is released
+		if (transformed === 'Icons/BanditIcon.jpg') transformed = 'Icons/BanditIcon_released.jpg';
 		if (transformed !== '') return transformed;
 
 		if (this.id === setup.companionIds.mc || this.id === setup.companionIds.twin) {
 			let image = this.appGender <= 5 ? 'M' : 'F';
 			return `Player Icons/player${image}.png`;
 		}
+
+		if (this.id === setup.companionIds.bandit && State.variables.BanditConvo0) {
+			return 'Icons/BanditIcon_released.jpg'
+		}
+
 		return this._imageIcon;
 	}
 

--- a/src/curses.twee
+++ b/src/curses.twee
@@ -667,14 +667,13 @@ You will also have a new name, 'Princess'. Others will find it impossible to cal
 		@@.unreachable; This Curse can not be taken in combination with the other Curses you have already taken
 	<<else>>
 		<<print "[[Take on " + _name + "]]">>
-		<<if $ownedRelics.some(e => e.name === "Managed Misfortune")>>\
+		<<if $ownedRelics.some(e => e.name === "Managed Misfortune")>>
 		<br><br>
-			<<if $ManagedMisfortuneActive.length >= $ManagedMisfortuneMax >>\
+			<<if $ManagedMisfortuneActive.length >= $ManagedMisfortuneMax >>
 				@@.unreachable; You can not store a new Curse while you are still affected by all the Curses in Managed Misfortune.       
-			<<else>>\
+			<<else>>
 				<<for _i=0; _i < $ManagedMisfortuneMax && _i <= $StoredCurse.length; _i++ >>
-					<<capture _i>>
-					<<capture _curse>>
+					<<capture _i, _curse>>
 					<<if _i < $StoredCurse.length>>
 						<<if !$ManagedMisfortuneActive.some(e => e.name === $StoredCurse[_i].name)>>
 							<<print "[[Switch out "+ $StoredCurse[_i].name +" for " + _name +" in the Managed Misfortune's marble|Layer"+ $currentLayer +" Curses][$StoredCurse.deleteAt(_i), $StoredCurse.push(_curse)]]">>
@@ -682,7 +681,6 @@ You will also have a new name, 'Princess'. Others will find it impossible to cal
 					<<else>>
 						<<print "[[Store " + _name +" in Managed Misfortune's free marble|Layer"+ $currentLayer +" Curses][$StoredCurse.push(_curse)]]">>
 					<</if>>
-					<</capture>>
 					<</capture>>
 				<br><br>
 				<</for>>

--- a/src/global.twee
+++ b/src/global.twee
@@ -669,12 +669,7 @@ They are a bit sore at the moment.
 			($mc.vagina > 0 && e.fluidType !== 'semen')
 		))
 	>>
-		<<if $mc.hasCurse("Leaky")>>
-			<<set _temp = Math.floor((1+$crumbleFluid/100)*2)>>
-		<<else>>
-			<<set _temp = Math.floor(1+$crumbleFluid/100)>>
-		<</if>>
-		You can supply yourself with <<print _temp*2>> loads a day.
+		You can supply yourself with <<print Math.floor($mc.fluids/100*2)>> loads a day.
 	<</if>>
 	<<if $SemenDemonVec.length > 0>>
 		<<if $SemenDemonVec.length === 1>>
@@ -682,7 +677,7 @@ They are a bit sore at the moment.
 		<<else>>
 			<<print `${$SemenDemonVec.slice(0, -1).map(c => c.name).join(', ')} and ${$SemenDemonVec.at(-1).name}`>>
 		<</if>>
-		<<if $SemenDemonVec.length === 1>>is<<else>>are<</if>> providing you with <<print 2 * $SemenDemonVec.length>> loads a day.
+		<<if $SemenDemonVec.length === 1>>is<<else>>are<</if>> providing you with <<print 2 * $SemenDemonVec.map(c => c.fluids / 100).reduce((a, b) => a + b, 0)>> loads a day.
 	<</if>>
 	<<print " ">>
 <</if>>
@@ -1482,7 +1477,7 @@ Helpful people on the surface managed to find your items safely, retrieving all 
 						Please enter your new exoskeleton color: <<textbox "_curse.skinColor" "shiny black" "Use Items and Relics">><br>
 					<<elseif _curse.name === "Horny" && !$hornVariation>>
 						<<include "Horny Customization">><br>
-					<<elseif _curse instanceof SemenDemon && !_curse.fluidType>>
+					<<elseif _curse instanceof SemenDemon && !$mc.hasCurse(SemenDemon)>>
 						<<include "Semen Demon Customization">><br>
 					<<elseif _curse.name === "Eye on the Prize" && !$eyeRemove>>
 						<<include "Eye on the Prize Customization">><br>
@@ -1509,6 +1504,14 @@ Helpful people on the surface managed to find your items safely, retrieving all 
 					<</if>>
 					<<set _text = "Activate stored " + _curse.name + " Curse">>
 					<<link _text "Use Items and Relics">>
+						<<if _curse instanceof SemenDemon>>
+							<<set _curse = _curse.copy()>>
+							<<set _prevCurse = $mc.getCurse(SemenDemon)>>
+							<<if _prevCurse !== undefined>>
+								<<set _curse.fluidType = _prevCurse.fluidType>>
+							<</if>>
+						<</if>>
+
 						<<set $mc.addCurse(_curse)>>
 						<<set $ManagedMisfortuneActive.push(_curse)>>
 					<</link>><br>

--- a/src/layer6.twee
+++ b/src/layer6.twee
@@ -705,9 +705,14 @@ The answers are far from comforting, leaving you to face a future filled with un
 
 :: Take on Semen Demon [layer6]
 <<set _curse = new SemenDemon()>>\
+<<set _prevCurse = $mc.getCurse(SemenDemon)>>\
 <<set $mc.addCurse(_curse)>>\
 [img[setup.ImagePath + _curse.pic]]
-<<include "Semen Demon Customization">>
+<<if _prevCurse !== undefined>>\
+	<<set _curse.fluidType = _prevCurse.fluidType>>\
+<<else>>\
+	<<include "Semen Demon Customization">>
+<</if>>\
 
 [[Confirm|Take on Semen Demon pt2]]
 
@@ -726,21 +731,22 @@ The answers are far from comforting, leaving you to face a future filled with un
 <<set _curse = $mc.getCurse(SemenDemon)>>\
 What would be your preferred meal type.
 
+@@.alert2; Not having the correct equipment to supply yourself or taking more than one level will mean you have to find additional sources or you will die!@@<br><br>
+
 <<radiobutton "_curse.fluidType" "sexual fluids" checked>> Any sexual fluids
 <<radiobutton "_curse.fluidType" "semen">> Just semen
 <<radiobutton "_curse.fluidType" "vaginal fluids">> Just vaginal fluids
 
-How many levels of the Curse would you like to gain?
-
-@@.alert2; Not having the correct equipment to supply yourself or taking more than one level will mean you have to find additional sources or you will die!@@<br><br>
-
-<<radiobutton "_curse.amount" 1 checked>> One
-<<radiobutton "_curse.amount" 2 >> Two
-<<radiobutton "_curse.amount" 3 >> Three
-<<radiobutton "_curse.amount" 4 >> Four
 
 :: Apply Stored Semen Demon Curse
-<<set $mc.addCurse(new SemenDemon())>>
+<<set _curse = new SemenDemon()>>
+<<set _prevCurse = $mc.getCurse(SemenDemon)>>
+<<set $mc.addCurse(_curse)>>
+<<if _prevCurse !== undefined>>
+	<<set _curse.fluidType = _prevCurse.fluidType>>
+<<else>>
+	<<include "Semen Demon Customization">>
+<</if>>
 <<include "Semen Demon Taken">>
 <<include "Semen Demon Retrieval">>
 
@@ -749,7 +755,7 @@ How many levels of the Curse would you like to gain?
 
 :: Semen Demon Taken [nobr]
 <<set _curse = $mc.getCurse(SemenDemon)>>
-<<set $corruption += _curse.corr * _curse.amount>>
+<<set $corruption += _curse.corr>>
 <<if _curse.fluidType !== "sexual fluids">>
 	<<set $corruption +=15>>
 <</if>>

--- a/src/script.js
+++ b/src/script.js
@@ -244,10 +244,11 @@ Macro.add('say', {
         tags: null,
         handler: function () {
             const person = this.args[0];
+            const imageIcon = this.args[1];
             const output =
                 `<div class="say clearfix" style="${person?.style ?? ''};${person?.style1 ?? ''}">` +
                     `<div class="avatar">` +
-                        `<img src="${setup.ImagePath}${person?.imageIcon ?? ''}" style="width:100px;height:100px">` +
+                        `<img src="${setup.ImagePath}${imageIcon ?? person?.imageIcon ?? ''}" style="width:100px;height:100px">` +
                     `</div>` +
                     `<span class="say-nameB">${person?.name ?? ''}</span>` +
                     `<hr>` +

--- a/src/widgets.twee
+++ b/src/widgets.twee
@@ -31,27 +31,23 @@
 :: Semen Demon Widget [widget nobr]
 <<widget "SemenDemonCalc">>
 <<set _sdcurse = $mc.getCurse(SemenDemon)>>
-<<set _sdTotal = $mc.events.filter(e => e instanceof SemenDemon).reduce((v, e) => v + e.amount)>>
+<<set _sdTotal = $mc.events.filter(e => e instanceof SemenDemon).reduce((v, e) => v + 1)>>
 <<if _sdcurse !== undefined>>
 	<<set _contributions = 0>>
 	<<if
 		($mc.penis > 0 && _sdcurse.fluidType !== 'vaginal fluids') ||
 		($mc.vagina > 0 && _sdcurse.fluidType !== 'semen')
 	>>
-		<<if $mc.hasCurse("Leaky")>>
-			<<set _contributions += Math.floor((1+$crumbleFluid/100)*2)>>
-		<<else>>
-			<<set _contributions += Math.floor(1+$crumbleFluid/100)>>
-		<</if>>
+		<<set _contributions += 1+$mc.fluids/100>>
 	<</if>>
 
 	<<for _i=0; _i<$SemenDemonVec.length; _i++ >>
 		<<if $hiredCompanions.some(e => e.name === $SemenDemonVec[_i].name)>>
-			<<set _contributions +=1>>
+			<<set _contributions += $SemenDemonVec[_i].fluids / 100>>
 		<</if>>
 	<</for>>
 
-	<<set $SemenDemonBalance += (_contributions - _sdTotal) * _args[0]>>/* */
+	<<set $SemenDemonBalance += (Math.floor(_contributions) - _sdTotal) * _args[0]>>/* */
 	<<if $SemenDemonBalance < -14>>
 		<<set $gameOver=true>>
 	<<elseif $SemenDemonBalance > 14>>

--- a/t3lt.twee-config.yml
+++ b/t3lt.twee-config.yml
@@ -160,7 +160,7 @@ sugarcube-2:
       name: say
       container: true
       parameters:
-        - "var"
+        - "var |+ string"
     SemenDemonCalc:
       name: SemenDemonCalc
       parameters:


### PR DESCRIPTION
Semen Demon now behaves like other curses and can be taken multiple times. After the first time, fluid type is forced to always be the same.

Also adds a second parameter to the `say` macro to override the image icon.