### PR TITLE
Fix conversation handicap checks

### DIFF
--- a/src/companionConversations.twee
+++ b/src/companionConversations.twee
@@ -5320,7 +5320,7 @@ Maru jumps up and down with excitement at the sight of the small, sweet fruits. 
  <<say $companionLily>>And down here, absolutely everything is wet.<</say>>
  She casually flicks a drop of water out of your hair, then she steps backwards and does a cartwheel over a large root jutting into the path. Unconcerned that her hands just got covered in mud, she runs them through the vegetation on either side of the narrow path you're following, cleaning them off, mostly. You pause for a second, then ask 
 
-<<if !($ConvoHandicapSmall || $ConvoHandicapLarge)>>\
+<<if $mc.conversationHandicap === 0>>\
 	<<say $mc>>Who maintains this path anyway?<</say>>
 	She laughs at the question for a moment before she answers. 
 
@@ -5613,7 +5613,7 @@ You try to cheer him up a bit, but he just shakes his head.
 :: Cherry Layer 7
 
 <<say $companionCherry>>It's frozen.<</say>>
-<<if !($ConvoHandicapSmall || $ConvoHandicapLarge)>>\
+<<if $mc.conversationHandicap === 0>>\
 	<<say $mc>>What?<</say>>
 <<else>>\
 	You try to make clear you don't understand what she means.
@@ -5762,14 +5762,14 @@ She giggles as you continue to drink your fill, her nourishing milk flowing free
 :: CherryConvoLac Rep
 Cherry is hovering around you again, as if she is anticipating something. The fact she is actually approaching you likely means something, and you suspect you know what it is.
 
-<<if !($ConvoHandicapSmall || $ConvoHandicapLarge)>>\
+<<if $mc.conversationHandicap === 0>>\
 	<<say $mc>>Give me a moment.<</say>>
 <<else>>\
 	You smile gently and nod to her, giving a signal to get closer to you.
 <</if>>\
 You pull out a dish and fill it with your breast milk, then present it to her.
 
-<<if !($ConvoHandicapSmall || $ConvoHandicapLarge)>>\
+<<if $mc.conversationHandicap === 0>>\
 	<<say $mc>>Here, kitty!<</say>>
 <<else>>\
 	You whistle to get her attention and she slowly approaches.

--- a/src/companionSetup.twee
+++ b/src/companionSetup.twee
@@ -435,7 +435,7 @@ One can only imagine what she'll do if she manages to break free.
 <<CarryAdjust>>
 <br>The following companions are a part of your expedition's party and have the associated affection values with you.<br>
 <hr>
-<<if $ConvoHandicapLarge || $ConvoHandicapSmall>>
+<<if $mc.conversationHandicap > 0>>
 	@@.alert2; Because of your handicaps you are unable to have an effective conversation with your companions.@@ <br>
 	<<for _companion range $hiredCompanions>>
 		<<set _name = _companion === $companionTwin ? 'Twin' : _companion === $companionBandit ? 'Bandit' : _companion.name>>
@@ -485,7 +485,7 @@ One can only imagine what she'll do if she manages to break free.
 <br>The following companions are a part of your expedition's party and have the associated affection values with you.
 <br>
 <hr>
-<<if $ConvoHandicapLarge || $ConvoHandicapSmall>>
+<<if $mc.conversationHandicap > 0>>
 	@@.alert2; Because of your handicaps you are unable to have an effective conversation with your companions.@@ 
 	<<for _companion range $hiredCompanions>>
 		<<set $temp = _companion.name>>
@@ -802,7 +802,7 @@ Overall the world would probably see <<if _companion.sex === "male">>him<<else>>
 
 :: Companion Layer Interaction
 <<nobr>>
-<<if !$ConvoHandicapLarge>>
+<<if $mc.conversationHandicap < 2>>
 	<<if $hiredCompanions.length > 0>>
 		<<set _temp1 = random(0,$hiredCompanions.length - 1)>>
 		<<if $hiredCompanions[_temp1].name !== $companionTwin.name && $hiredCompanions[_temp1].name !== $companionGolem.name && $hiredCompanions[_temp1].name !== $companionBandit.name>>

--- a/src/init.twee
+++ b/src/init.twee
@@ -198,9 +198,6 @@ document.documentElement.setAttribute("lang", "en");
 <<set $PulseBloomDate = 9999>>
 <<set $mechaBoarded = false>>
 
-<<set $ConvoHandicapSmall = false>>
-<<set $ConvoHandicapLarge = false>>
-<<set $ConvoHandicapFood = false>>
 <<set $L8T1_counter = 0>>
 
 <<set $dollevent = false>>


### PR DESCRIPTION
Previously, conversation handicaps were handled by multiple boolean variables, complicating checks and maintenance. This update unifies them into a single numerical variable, 'conversationHandicap', making checks simpler and enabling flexibility for potential future enhancements.

Fun fact: an AI generated the above commit description. Surprisingly accurate