### PR TITLE
Implement bordered widget

### DIFF
--- a/src/sandbox.twee
+++ b/src/sandbox.twee
@@ -16,6 +16,12 @@ Or did you just want the honor of being <span class="light">killed</span> by ME,
 <p class="elder-entity.light">Were there not more convenient ways to die elsewhere?</p>
 
 
+<<bordered "images/surface.png" "images/bordershop.png">>\
+This is a test.
+Another line.
+
+<b>bold</b>
+<</bordered>>
 
 
 <<set _test = 0>>

--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -101,7 +101,7 @@ div.cards-grid {
   flex-wrap: wrap;
   justify-content: space-evenly;
   margin: 0 -1rem;
-  padding: 0 0px;
+  padding: 0 0;
 }
 
 div.cards-grid > div {
@@ -147,7 +147,7 @@ div.cards-gridThreat {
   flex-wrap: wrap;
   justify-content: space-evenly;
   margin: 0 -1rem;
-  padding: 0 0px;
+  padding: 0 0;
 }
 
 div.cards-gridThreat > div {
@@ -603,4 +603,20 @@ img.half-size {
 	  animation: flash 3s ease-out alternate infinite;
 	  text-shadow: 1px 2px 4px rgb(188, 188, 188);
 	}
+}
+
+.bordered {
+  border: 8px solid;
+  /* border-image should be overwritten on the element, but we leave it here as a fallback in case it isn't */
+  border-image: url("images/bordershop.png") 82 / 20px / 10px round;
+  box-shadow: 0 0 4px 0 black;
+  text-align: center;
+  display: grid;
+  grid-template-columns: 1fr 3fr;
+  padding: 1px;
+}
+
+.bordered > img {
+  border-radius: 15%;
+  max-width: 100%;
 }

--- a/src/widgets.twee
+++ b/src/widgets.twee
@@ -1199,3 +1199,28 @@
 		});
 	</script>
 <</widget>>
+
+:: bordered widget [widget nobr]
+/* Arguments:
+     0: path of the image to use
+     1: path of the border to use — default 'images/bordershop.png'
+   Note that using a non-square image will result in elliptical borders.
+   When using this widget, be careful with newlines:
+   <<bordered>>
+     sometext
+   <</bordered>
+   will result in an empty line at the start of the content
+ */
+<<widget "bordered" container>>
+<<capture _style>>
+  <<set _args[1] = _args[1] || 'images/bordershop.png'>>
+  <<set _style = `border-image: url('${_args[1]}') 82 / 20px / 10px round`>>
+
+  <div class="bordered" @style="_style">
+    <img @src="_args[0]">
+    <div>
+      _contents
+    </div>
+  </div>
+<</capture>>
+<</widget>>

--- a/t3lt.twee-config.yml
+++ b/t3lt.twee-config.yml
@@ -227,3 +227,7 @@ sugarcube-2:
         - "var |+ ...var"
     printHTML:
       name: printHTML
+    bordered:
+      name: bordered
+      parameters:
+        - "string |+ string"


### PR DESCRIPTION
The \<\<bordered\>\> widget puts a border around its contents and an image in the left quarter of the resulting box.
The first argument is the path to the image. The second, optional argument can be used to change the image used for the border.
There's an example use in the sandbox.