### PR TITLE
conditionally display the mitigated curse description

### DIFF
--- a/src/classes/2curse.js
+++ b/src/classes/2curse.js
@@ -92,7 +92,11 @@ class Curse extends CharEvent {
 	}
 
 	get description() {
-		return this.constructor.description;
+		if (true) { // TODO: check if the mitigation nadir reward is active
+			return this.constructor.description;
+		} else {
+			return this.constructor.descriptionMitigated;
+		}
 	}
 
 	get corr() {


### PR DESCRIPTION
Once the reward acquisition is implemented the condition will have to be replaced (pay no mind to the commit message, I forgot to change it)